### PR TITLE
Fixed the ghost meta key Joly_Peuch_classification_code

### DIFF
--- a/pyaerocom/io/ghost_meta_keys.py
+++ b/pyaerocom/io/ghost_meta_keys.py
@@ -34,7 +34,7 @@ GHOST_META_KEYS = [
     'GPW_max_population_density_5km',
     'GPW_population_density',
     'GSFC_coastline_proximity',
-    'Joly-Peuch_classification_code',
+    'Joly_Peuch_classification_code',
     'Koppen-Geiger_classification',
     'Koppen-Geiger_modal_classification_25km',
     'Koppen-Geiger_modal_classification_5km',

--- a/pyaerocom/io/test/test_ghost_meta_keys.py
+++ b/pyaerocom/io/test/test_ghost_meta_keys.py
@@ -34,7 +34,7 @@ desired_keys = [
     'GPW_max_population_density_5km',
     'GPW_population_density',
     'GSFC_coastline_proximity',
-    'Joly-Peuch_classification_code',
+    'Joly_Peuch_classification_code',
     'Koppen-Geiger_classification',
     'Koppen-Geiger_modal_classification_25km',
     'Koppen-Geiger_modal_classification_5km',


### PR DESCRIPTION
I had to change the name of the Joly-Peuch_classification_code to Joly_Peuch_classification_code in the GHOST.EEA netcdf files to be able to use it for filtering since the "-" breaks the UngriddedData.filter_by_meta() method.

Fixes issue #117 