### PR TITLE
Add option to apply constrained reading in ReadGridded

### DIFF
--- a/pyaerocom/io/readgridded.py
+++ b/pyaerocom/io/readgridded.py
@@ -1389,11 +1389,69 @@ class ReadGridded(object):
                 ts_type = None
         return vert_which, ts_type
 
+    def apply_var_filter(self, data, filter_var, perator,
+                         filter_val,
+                         new_val=None,
+                         **kwargs):
+        """
+        Filter a `GriddeData` object by value in another variable
+
+        Note
+        ----
+        BETA version, that was hacked down in a rush to be able to apply
+        AOD>0.1 threshold when reading AE.
+
+
+        Parameters
+        ----------
+        data : TYPE
+            DESCRIPTION.
+        filter_var : TYPE
+            DESCRIPTION.
+        operator : str
+            operator used to filter other variable field to retrieve filter
+            mask
+        filter_val : float
+            value in filter_var for which mask will be retrieved
+        new_val : TYPE, optional
+            DESCRIPTION. The default is None.
+        **kwargs : TYPE
+            DESCRIPTION.
+
+        Raises
+        ------
+        ValueError
+            DESCRIPTION.
+
+        Returns
+        -------
+        None.
+
+        """
+        if new_val is None:
+            new_val = np.nan
+
+        other_data = self.read_var(filter_var, **kwargs)
+        if not other_data.shape == data.shape:
+            raise ValueError('Failed to apply filter. Shape mismatch')
+        if operator == '==':
+            mask = other_data.cube.data == filter_val
+        elif operator == '>':
+            mask = other_data.cube.data > filter_val
+        elif operator == '<':
+            mask = other_data.cube.data < filter_val
+        else:
+            raise NotImplementedError('Can only handle the following operators '
+                                      'so far: ==, <, >')
+        data.cube.data[mask] = new_val
+        return data
+
     # TODO: add from_vars input arg for computation and corresponding method
     def read_var(self, var_name, start=None, stop=None,
                  ts_type=None, experiment=None, vert_which=None,
                  flex_ts_type=True, prefer_longer=False,
                  aux_vars=None, aux_fun=None,
+                 apply_var_filter=None,
                  **kwargs):
         """Read model data for a specific variable
 

--- a/pyaerocom/io/readgridded.py
+++ b/pyaerocom/io/readgridded.py
@@ -1579,7 +1579,7 @@ class ReadGridded(object):
             to be computed: custom method for computation (cf.
             :func:`add_aux_compute` for details)
         constraints : list, optional
-            list of reading cons
+            list of reading constraints
         **kwargs
             additional keyword args parsed to :func:`_load_var`
 

--- a/pyaerocom/io/test/test_readgridded.py
+++ b/pyaerocom/io/test/test_readgridded.py
@@ -7,8 +7,8 @@ Created on Mon Jul  9 14:14:29 2018
 # TODO: Docstrings
 import pytest
 import numpy.testing as npt
-from pandas import Timestamp, DataFrame
-from pyaerocom.conftest import TEST_RTOL, lustre_unavail
+from pandas import DataFrame
+from pyaerocom.conftest import TEST_RTOL, lustre_unavail, testdata_unavail
 from pyaerocom.io.readgridded import ReadGridded
 
 START = "1-1-2003"
@@ -17,10 +17,39 @@ STOP = "31-12-2007"
 def init_reader():
     return ReadGridded(data_id="ECMWF_CAMS_REAN")
 
-@lustre_unavail
 @pytest.fixture(scope='session')
 def reader_reanalysis():
     return init_reader()
+
+@pytest.fixture(scope='module')
+def reader_tm5():
+    return ReadGridded('TM5-met2010_CTRL-TEST')
+
+
+@pytest.mark.parametrize('input_args,mean_val', [
+    (dict(var_name='od550aer'), 0.1186),
+    (dict(var_name='od550aer', constraints={
+                                  'var_name'   : 'od550aer',
+                                  'operator'   : '>',
+                                  'filter_val' : 1000
+                                  }), 0.1186),
+    (dict(var_name='od550aer', constraints={
+                                  'var_name'   : 'od550aer',
+                                  'operator'   : '<',
+                                  'filter_val' : 0.1
+                                  }), 0.2062),
+    (dict(var_name='od550aer', constraints=[
+        {'var_name'   : 'od550aer',
+         'operator'   : '<',
+         'filter_val' : 0.1},
+        {'var_name'   : 'od550aer',
+         'operator'   : '>',
+         'filter_val' : 0.11}
+        ]), 0.1047)
+    ])
+def test_read_var(reader_tm5, input_args, mean_val):
+    data = reader_tm5.read_var(**input_args)
+    npt.assert_allclose(data.mean(), mean_val, rtol=1e-3)
 
 def test_ReadGridded_class_empty():
     r = ReadGridded()
@@ -52,7 +81,7 @@ def test_data_dir(reader_reanalysis):
     assert reader_reanalysis.data_dir.endswith('aerocom/aerocom-users-database/ECMWF/ECMWF_CAMS_REAN/renamed')
 
 @lustre_unavail
-def test_read_var(reader_reanalysis):
+def test_read_var_lustre(reader_reanalysis):
     from numpy import datetime64
     d = reader_reanalysis.read_var(var_name="od550aer", ts_type="daily",
                          start=START, stop=STOP)
@@ -90,4 +119,5 @@ def test_read_vars(reader_reanalysis):
     npt.assert_array_equal(vals, nominal)
 
 if __name__=="__main__":
-    pytest.main(['./test_readgridded.py'])
+    import sys
+    pytest.main(sys.argv)


### PR DESCRIPTION
One usage example is:

Read Angstrom Exponent from a satellite and invalidate all grid points where the AOD is smaller than a certain threshold (e.g. 0.1).

Should be implemented in `ReadGridded.read_var`, e.g. via:

```python
import pyaerocom as pya
reader = pya.io.ReadGridded('AATSR_SU_v4.3')
read_constraint = dict(
   var_name = 'od550aer',
   operator='>',
   filter_val=0.1
)
ae = reader.read_var('ang4487aer', constraints=[read_constraint])
```