### PR TITLE
Enable constrained gridded reading for observations in Colocator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,8 @@ ENV/
 
 # Spyder project settings
 .spyderproject
-
+.spyproject
+ 
 # Rope project settings
 .ropeproject
 

--- a/pyaerocom/colocateddata.py
+++ b/pyaerocom/colocateddata.py
@@ -1361,7 +1361,7 @@ class ColocatedData(object):
     @property
     def unit(self):
         """Unit of data"""
-        const.print_log.warn(DeprecationWarning('Attr. unit is deprecated, '
+        const.print_log.warning(DeprecationWarning('Attr. unit is deprecated, '
                                                 'please use units instead'))
         return self.units
 

--- a/pyaerocom/colocation.py
+++ b/pyaerocom/colocation.py
@@ -207,9 +207,11 @@ def colocate_gridded_gridded(gridded_data, gridded_data_ref, ts_type=None,
             low_ref, high_ref = var_ref_outlier_ranges[var_ref]
 
         if not var_keep_outliers:
-            gridded_data.remove_outliers(low, high)
+            gridded_data.remove_outliers(low, high,
+                                         inplace=True)
         if not var_ref_keep_outliers:
-            gridded_data_ref.remove_outliers(low_ref, high_ref)
+            gridded_data_ref.remove_outliers(low_ref, high_ref,
+                                             inplace=True)
 
     if update_baseyear_gridded is not None:
         # update time dimension in gridded data

--- a/pyaerocom/colocation_auto.py
+++ b/pyaerocom/colocation_auto.py
@@ -379,10 +379,6 @@ class Colocator(ColocationSetup):
         """Get the lowest resolution ts_type of input ts_types"""
         return get_lowest_resolution(ts_type, *ts_types)
 
-    def output_dir(self, task_name):
-        """Output directory for colocated data"""
-        return self._output_dirs[task_name]
-
     def _check_add_model_read_aux(self, model_var, model_reader):
         if not isinstance(self.model_read_aux, dict):
             return False
@@ -403,65 +399,6 @@ class Colocator(ColocationSetup):
             return False
         return True
 
-    def _find_var_matches_OLD(self, obs_vars, model_reader, var_name=None):
-        """Find variable matches in model data for input obs variables"""
-        if isinstance(obs_vars, str):
-            obs_vars = [obs_vars]
-        var_matches = {}
-
-        muv, mav = {}, {}
-        if isinstance(self.model_use_vars, dict):
-            muv = self.model_use_vars
-
-        if isinstance(self.model_add_vars, dict):
-            mav = self.model_add_vars
-
-        for obs_var in obs_vars:
-            if obs_var in muv:
-                model_var = muv[obs_var]
-            else:
-                model_var = obs_var
-
-            self._check_add_model_read_aux(model_var, model_reader)
-
-            if model_reader.has_var(model_var):
-                var_matches[model_var] = obs_var
-
-            if obs_var in mav: #observation variable
-                model_add_var = mav[obs_var]
-                self._check_add_model_read_aux(model_add_var, model_reader)
-                if model_reader.has_var(model_add_var):
-                    var_matches[model_add_var] = obs_var
-
-        for obs_var, obs_var_altname in self.obs_vars_rename.items():
-            if obs_var_altname in var_matches:
-                raise AttributeError('{} match was already found for obs '
-                                     'var to be renamed {}...'
-                                     .format(obs_var_altname, obs_var))
-            if model_reader.has_var(obs_var_altname):
-                var_matches[obs_var_altname] = obs_var
-
-        if var_name is not None:
-            if isinstance(var_name, str):
-                var_name = [var_name]
-            if not isinstance(var_name, list):
-                raise ValueError('Invalid input for var_name. Need str or '
-                                 'list, got {}'.format(var_name))
-            _var_matches = {}
-            for mvar, ovar in var_matches.items():
-                if mvar in var_name or ovar in var_name:
-                    _var_matches[mvar] = ovar
-            var_matches = _var_matches
-
-        if len(var_matches) == 0:
-
-            raise DataCoverageError('No variable matches between '
-                                    '{} and {} for input vars: {}'
-                                    .format(self.model_id,
-                                            self.obs_id,
-                                            self.obs_vars))
-        return var_matches
-
     def _check_model_add_var(self, var_name, model_reader, var_matches):
         if isinstance(self.model_add_vars, dict) and var_name in self.model_add_vars: #observation variable
             add_var = self.model_add_vars[var_name]
@@ -475,8 +412,7 @@ class Colocator(ColocationSetup):
         if isinstance(obs_vars, str):
             obs_vars = [obs_vars]
 
-        # dictionary that will map input variable names (values) with model
-        # variables (keys)
+        # dictionary that will map model variables (keys) with observation variables (values)
         var_matches = {}
 
         muv = self.model_use_vars if isinstance(self.model_use_vars, dict) else {}
@@ -552,7 +488,7 @@ class Colocator(ColocationSetup):
             if var in obs_reader.get_reader(self.obs_id).PROVIDES_VARIABLES:
                 obs_vars.append(var)
             else:
-                const.print_log.warn('Variable {} is not supported by {} '
+                const.print_log.warning('Variable {} is not supported by {} '
                                      'and will be skipped'
                                      .format(var, self.obs_id))
         if len(obs_vars) == 0:

--- a/pyaerocom/colocation_auto.py
+++ b/pyaerocom/colocation_auto.py
@@ -894,6 +894,8 @@ class Colocator(ColocationSetup):
 
         if 'obs_filters' in self:
             obs_filters = self._eval_obs_filters()
+        else:
+            obs_filters = {}
 
         obs_vars = self.obs_vars
 

--- a/pyaerocom/conftest.py
+++ b/pyaerocom/conftest.py
@@ -35,6 +35,7 @@ AMES_FILE = 'CH0001G.20180101000000.20190520124723.nephelometer..aerosol.1y.1h.C
 ADD_PATHS = {
 
     'MODELS'                : 'modeldata',
+    'OBSERVATIONS'          : 'obsdata',
     'AeronetSunV3L2Subset.daily'  : 'obsdata/AeronetSunV3Lev2.daily/renamed',
     'AeronetSDAV3L2Subset.daily'  : 'obsdata/AeronetSDAV3Lev2.daily/renamed',
     'AeronetInvV3L2Subset.daily'  : 'obsdata/AeronetInvV3Lev2.daily/renamed',

--- a/pyaerocom/griddeddata.py
+++ b/pyaerocom/griddeddata.py
@@ -700,7 +700,7 @@ class GriddedData(object):
             try:
                 self.var_name = var_name
             except ValueError:
-                const.print_log.warn('Could not update var_name, invalid input '
+                const.print_log.warning('Could not update var_name, invalid input '
                                      '{} (need str)'.format(var_name))
 
     def _get_info_from_filenames(self):
@@ -2474,7 +2474,7 @@ class GriddedData(object):
         """Update metadata dictionary"""
         for key, val in kwargs.items():
             if key == 'var_name' and not isinstance(val, str):
-                const.print_log.warn('Skipping assignment of var_name from '
+                const.print_log.warning('Skipping assignment of var_name from '
                                      'metadata in GriddedData, since attr. '
                                      'needs to be str and is {}'.format(val))
                 continue
@@ -2651,13 +2651,13 @@ class GriddedData(object):
     @property
     def unit(self):
         """Unit of data"""
-        const.print_log.warn(DeprecationWarning('Attr. unit is deprecated, '
+        const.print_log.warning(DeprecationWarning('Attr. unit is deprecated, '
                                                 'please use units instead'))
         return self.grid.units
 
     @unit.setter
     def unit(self, val):
-        const.print_log.warn(DeprecationWarning('Attr. unit is deprecated, '
+        const.print_log.warning(DeprecationWarning('Attr. unit is deprecated, '
                                                 'please use units instead'))
         self.grid.units = val
 

--- a/pyaerocom/helpers.py
+++ b/pyaerocom/helpers.py
@@ -51,7 +51,7 @@ def varlist_aerocom(varlist):
             if not _var in output:
                 output.append(_var)
         except VariableDefinitionError as e:
-            const.print_log.warn(repr(e))
+            const.print_log.warning(repr(e))
     if len(output) == 0:
         raise ValueError('None of the input variables appears to be valid')
     return output
@@ -466,7 +466,7 @@ def get_standard_unit(var_name):
         corresponding standard unit
     """
     from pyaerocom import const
-    return const.VARS[var_name].unit
+    return const.VARS[var_name].units
 
 def get_lowest_resolution(ts_type, *ts_types):
     """Get the lowest resolution from several ts_type codes

--- a/pyaerocom/io/read_ebas.py
+++ b/pyaerocom/io/read_ebas.py
@@ -819,7 +819,7 @@ class ReadEbas(ReadUngriddedBase):
         for colnum in col_matches:
             colinfo = file.var_defs[colnum]
             if not 'wavelength' in colinfo:
-                const.logger.warn('Ignoring column {}\n{}\nVar {}: column '
+                const.logger.warning('Ignoring column {}\n{}\nVar {}: column '
                                   'misses wavelength specification!'
                                   .format(colnum, colinfo,
                                           var_info.var_name))
@@ -852,7 +852,7 @@ class ReadEbas(ReadUngriddedBase):
         for colnum in col_matches:
             colinfo = file.var_defs[colnum]
             if not 'wavelength' in colinfo:
-                const.logger.warn('Ignoring column {} ({}) in EBAS file for '
+                const.logger.warning('Ignoring column {} ({}) in EBAS file for '
                                   'reading var {}: column misses wavelength '
                                   'specification'
                                   .format(colnum, colinfo, var_info))

--- a/pyaerocom/io/readgridded.py
+++ b/pyaerocom/io/readgridded.py
@@ -567,7 +567,7 @@ class ReadGridded(object):
         try:
             var = const.VARS[var_name]
         except VariableDefinitionError as e:
-            const.print_log.warn(repr(e))
+            const.print_log.warning(repr(e))
             return False
 
         if self.check_compute_var(var_name):

--- a/pyaerocom/test/test_colocation_auto.py
+++ b/pyaerocom/test/test_colocation_auto.py
@@ -1,0 +1,157 @@
+import os
+import pytest
+
+from pyaerocom.conftest import TESTDATADIR
+from pyaerocom.conftest import does_not_raise_exception
+from pyaerocom.conftest import testdata_unavail
+
+from pyaerocom import Colocator, ColocatedData, GriddedData, UngriddedData
+from pyaerocom.io import ReadGridded
+from pyaerocom.exceptions import DataCoverageError
+from pyaerocom.io.aux_read_cubes import add_cubes
+
+@pytest.fixture(scope='function')
+def col_tm5_aero(model_id='TM5-met2010_CTRL-TEST', obs_id='AeronetSunV3L2Subset.daily',
+                 obs_vars='od550aer'):
+    coloc = Colocator(model_id=model_id, obs_id=obs_id, obs_vars=obs_vars)
+    coloc.raise_exceptions = True
+    coloc.reanalyse_existing = True
+    coloc.start = 2010
+    return coloc
+
+@pytest.fixture(scope='function')
+def col():
+    return Colocator(raise_exceptions=True, reanalyze_existing=True)
+
+
+def test_colocator(col):
+    assert isinstance(col, Colocator)
+    col.obs_vars = 'var'
+    assert isinstance(col.obs_vars, str)
+
+def test_colocator_init_basedir_coldata(tmpdir):
+    basedir = os.path.join(tmpdir, 'basedir')
+    col = Colocator(raise_exceptions=True, basedir_coldata=basedir)
+    assert os.path.isdir(basedir)
+
+def test_colocator__check_add_model_read_aux():
+    coloc = Colocator(raise_exceptions=True)
+    r = ReadGridded('TM5-met2010_CTRL-TEST')
+
+    assert not coloc._check_add_model_read_aux('od550aer', r)
+
+    coloc.model_read_aux = {
+        'od550aer' : dict(
+            vars_required=['od550aer', 'od550aer'],
+            fun=add_cubes)}
+    assert coloc._check_add_model_read_aux('od550aer', r)
+
+@testdata_unavail
+def test_colocator__coldata_savename(data_tm5):
+    col = Colocator(raise_exceptions=True)
+    col.obs_name = 'obs'
+    col.model_name = 'model'
+    col.ts_type = 'monthly'
+    col.filter_name = 'WORLD'
+    savename = col._coldata_savename(data_tm5)
+    assert isinstance(savename, str)
+    assert savename == 'od550aer_REF-obs_MOD-model_20100101_20101231_monthly_WORLD.nc'
+
+def test_colocator_update(tmpdir):
+    col = Colocator(raise_exceptions=True)
+    col.update(test="test")
+    assert col.test == 'test'
+
+    obs_id = 'test'
+    col.update(obs_id=obs_id)
+    assert col.obs_id == obs_id
+
+    basedir = os.path.join(tmpdir, 'basedir')
+    assert not os.path.isdir(basedir)
+    col.update(basedir_coldata=basedir)
+    assert os.path.isdir(basedir)
+
+@pytest.mark.parametrize('gridded_gridded',[False, True])
+def test_colocator_run(col_tm5_aero, gridded_gridded):
+    if gridded_gridded:
+        col_tm5_aero.obs_id = col_tm5_aero.model_id
+    col_tm5_aero.run()
+    coldata = col_tm5_aero.data[col_tm5_aero.model_id][col_tm5_aero.obs_vars[0]]
+    assert isinstance(coldata, ColocatedData)
+
+def test__run_gridded_ungridded(col_tm5_aero):
+    obs_vars = col_tm5_aero.obs_vars[0]
+    colocated_dict = col_tm5_aero._run_gridded_ungridded()
+    assert isinstance(colocated_dict[obs_vars], ColocatedData)
+
+def test__run_gridded_gridded(col_tm5_aero):
+    obs_vars = col_tm5_aero.obs_vars[0]
+    col_tm5_aero.obs_id = col_tm5_aero.model_id
+    colocated = col_tm5_aero._run_gridded_gridded(obs_vars)
+    assert isinstance(colocated[obs_vars], ColocatedData)
+    assert isinstance(col_tm5_aero.data, dict)
+    assert col_tm5_aero.data == {}
+
+def test_colocator_filter_name():
+    with does_not_raise_exception():
+        col = Colocator(filter_name='WORLD')
+    with pytest.raises(Exception):
+        col = Colocator(filter_name='invalid')
+
+def test_colocator_basedir_coldata(tmpdir):
+    basedir = os.path.join(tmpdir, 'test')
+    col = Colocator(raise_exceptions=True)
+    col.basedir_coldata = basedir
+    assert not os.path.isdir(basedir)
+
+def test_colocator__find_var_matches(col):
+    r = ReadGridded('TM5-met2010_CTRL-TEST')
+    with pytest.raises(DataCoverageError):
+        col._find_var_matches('invalid', r)
+    var_matches = col._find_var_matches('od550aer', r)
+    assert var_matches == {'od550aer': 'od550aer'}
+
+    obs_vars = 'conco3'
+    col.obs_vars = [obs_vars]
+    col.model_use_vars = {obs_vars : 'od550aer'}
+    var_matches = col._find_var_matches('conco3', r)
+    assert var_matches == {'od550aer' : 'conco3'}
+
+def test_colocator_read_ungridded():
+    col = Colocator(raise_exceptions=True)
+    obs_id = 'AeronetSunV3L2Subset.daily'
+    obs_var = 'od550aer'
+    col.obs_filters = {'longitude' : [-30, 30]}
+    col.obs_id = obs_id
+    col.read_opts_ungridded = {'last_file' : 10}
+    with pytest.raises(DataCoverageError):
+        data = col.read_ungridded(obs_var) # Why is this raised?
+        # read_ungridded expects a list of one or more variables!
+        # Should check for str and convert to list?
+        # Should read_ungridded and read_model_data have same arguments?
+    data = col.read_ungridded([obs_var])
+    assert isinstance(data, UngriddedData)
+
+    col.read_opts_ungridded = None
+    col.obs_vars = ['od550aer']
+    with does_not_raise_exception():
+        data = col.read_ungridded()
+    col.obs_vars = ['invalid']
+    with pytest.raises(DataCoverageError):
+        data = col.read_ungridded()
+
+def test_colocator_read_model_data():
+    col = Colocator(raise_exceptions=True)
+    model_id = 'TM5-met2010_CTRL-TEST'
+    col.model_id = model_id
+    data = col.read_model_data('od550aer')
+    assert isinstance(data, GriddedData)
+
+def test_colocator_call():
+    col = Colocator(raise_exceptions=True)
+    with pytest.raises(NotImplementedError):
+        col()
+
+if __name__ == '__main__':
+    import sys
+    pytest.main(sys.argv)

--- a/pyaerocom/time_resampler.py
+++ b/pyaerocom/time_resampler.py
@@ -65,7 +65,7 @@ class TimeResampler(object):
         valid = self.valid_base_ts_types
         from_mul = from_ts_type.mulfac
         if from_mul != 1:
-            const.print_log.warn('Ignoring multiplication factor {} in '
+            const.print_log.warning('Ignoring multiplication factor {} in '
                                  'data with resolution {} in resampling method'
                                  .format(from_mul, from_ts_type))
         start = valid.index(from_ts_type.base)

--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -850,7 +850,7 @@ class UngriddedData(object):
 
             vals = subset[:, self._DATAINDEX]
             if np.all(np.isnan(vals)):
-                logger.warn('Ignoring station {}, var {} ({}):'
+                logger.warning('Ignoring station {}, var {} ({}):'
                             'All values are NaN'
                             .format(sd['station_name'], var, sd['data_id']))
                 continue
@@ -1342,7 +1342,7 @@ class UngriddedData(object):
                     try:
                         totnum += len(self.meta_idx[meta_idx][var])
                     except KeyError:
-                        const.print_log.warn('Ignoring variable {} in '
+                        const.print_log.warning('Ignoring variable {} in '
                                              'meta block {} since no data '
                                              'could be found'.format(
                                               var, meta_idx))

--- a/pyaerocom/variable.py
+++ b/pyaerocom/variable.py
@@ -433,7 +433,7 @@ class Variable(object):
     @property
     def has_unit(self):
         """Boolean specifying whether variable has unit"""
-        return True if not self.unit in (1, None) else False
+        return True if not self.units in (1, None) else False
 
     @property
     def lower_limit(self):
@@ -450,10 +450,10 @@ class Variable(object):
     @property
     def unit_str(self):
         """string representation of unit"""
-        if self.unit is None:
+        if self.units is None:
             return ''
         else:
-            return '[{}]'.format(self.unit)
+            return '[{}]'.format(self.units)
 
     @staticmethod
     def read_config():
@@ -498,7 +498,7 @@ class Variable(object):
         try:
             return VarNameInfo(self.var_name_aerocom).get_default_vert_code()
         except ValueError:
-            print_log.warn('default_vert_code not set for {} and '
+            print_log.warning('default_vert_code not set for {} and '
                            'could also not be inferred'
                            .format(self.var_name_aerocom))
             return None
@@ -583,7 +583,7 @@ class Variable(object):
     def __repr__(self):
        return ("{}\nstandard_name: {}; Unit: {}"
                .format(self.var_name, self.standard_name,
-                       self.unit))
+                       self.units))
 
     def __eq__(self, other):
         if isinstance(other, str):

--- a/pyaerocom/web/aerocom_evaluation.py
+++ b/pyaerocom/web/aerocom_evaluation.py
@@ -215,7 +215,7 @@ class AerocomEvaluation(object):
         if len(settings)==0 and try_load_json and proj_id is not None:
             try:
                 self.load_config(self.proj_id, self.exp_id, config_dir)
-                const.print_log.warn('Found and imported config file for {} / {}'
+                const.print_log.warning('Found and imported config file for {} / {}'
                                      .format(self.proj_id, self.exp_id))
             except Exception:
                 pass
@@ -381,12 +381,12 @@ class AerocomEvaluation(object):
         elif isinstance(key, str) and isinstance(val, dict):
             if 'obs_id' in val:
                 if key in self.obs_config:
-                    self._log.warn('Obs config for key {}  already exists and '
+                    self._log.warning('Obs config for key {}  already exists and '
                                    'will be overwritten {}'.format(key))
                 self.obs_config[key] = ObsConfigEval(**val)
             elif 'model_id' in val:
                 if key in self.model_config:
-                    self._log.warn('Model config for key {}  already exists and '
+                    self._log.warning('Model config for key {}  already exists and '
                                    'will be overwritten {}'.format(key))
                 self.model_config[key] = ModelConfigEval(**val)
             else:

--- a/pyaerocom/web/trends_evaluation.py
+++ b/pyaerocom/web/trends_evaluation.py
@@ -205,7 +205,7 @@ class TrendsEvaluation(object):
         elif isinstance(key, str) and isinstance(val, dict):
             if 'obs_id' in val:
                 if key in self.obs_config:
-                    self._log.warn('Obs config for key {}  already exists and '
+                    self._log.warning('Obs config for key {}  already exists and '
                                    'will be overwritten {}'.format(key))
                 self.obs_config[key] = ObsConfigEval(**val)
             elif 'model_id' in val:
@@ -213,7 +213,7 @@ class TrendsEvaluation(object):
                     raise KeyError('Need key "mtype" in specfication of model {}'
                                    .format(key))
                 if key in self.model_config:
-                    self._log.warn('Model config for key {}  already exists and '
+                    self._log.warning('Model config for key {}  already exists and '
                                    'will be overwritten {}'.format(key))
                 self.model_config[key] = ModelConfigEval(**val)
             else:

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -13,7 +13,6 @@ dependencies:
   - seaborn >= 0.8.0
   - netcdf4
   - geonum
-  - cf_units
   - numpy
   - simplejson
   - pytest


### PR DESCRIPTION
This is just a quick fix to make a first version work. In principle, this should also be possible to be applied to the model data, both in gridded/gridded and gridded/ungridded colocation. Can thus, only be  considered a limited fix of #152.
Includes also some cleanup for #154.