### PR TITLE
Implement unit conversion method in UngriddedData

### DIFF
--- a/pyaerocom/colocation.py
+++ b/pyaerocom/colocation.py
@@ -918,35 +918,12 @@ if __name__=='__main__':
     import matplotlib.pyplot as plt
     plt.close('all')
 
-    #obsdata = pya.io.ReadGhost('GHOST.hourly').read('concpm25')
-    obsdata = pya.io.ReadUngridded().read('GHOST.hourly', 'conco3',
-                                          only_cached=True)
+    obsdata = pya.io.ReadUngridded().read('EBASMC', 'ac550aer')
 
-    obsdata.check_set_country()
+    # update unit to wrong unit
+    obsdata.check_convert_var_units('ac550aer', 'm-1', inplace=True)
 
-    obsdata = obsdata.filter_region('Norway', check_country_meta=True)
-    model_id='ENSEMBLE.cams61.day1'
+    obsdata.remove_outliers('ac550aer', inplace=True)
 
-    mr = pya.io.ReadGridded(model_id)
-    modeldata = mr.read_var('conco3', start=2018, vert_which='Surface')
-
-    #modeldata.resample_time('yearly').quickplot_map()
-
-    #obsdata = pya.io.ReadUngridded().read(obs_id, 'concso4').set_flags_nan()
-
-    rsh = {'daily': {'hourly': 'max'}}
-
-    coldata_max = pya.colocation.colocate_gridded_ungridded(modeldata, obsdata,
-                                                         ts_type='monthly',
-                                                         var_ref='conco3',
-                                                         resample_how=rsh)
-
-    coldata_mean = pya.colocation.colocate_gridded_ungridded(modeldata, obsdata,
-                                                         ts_type='monthly',
-                                                         var_ref='conco3')
-
-    pya.plot.mapping.plot_nmb_map_colocateddata(coldata_max)
-    pya.plot.mapping.plot_nmb_map_colocateddata(coldata_mean)
-    #scoldata2.plot_scatter()
 
 

--- a/pyaerocom/colocation.py
+++ b/pyaerocom/colocation.py
@@ -591,10 +591,6 @@ def colocate_gridded_ungridded(gridded_data, ungridded_data, ts_type=None,
         gridded_data = _regrid_gridded(gridded_data, regrid_scheme,
                                        regrid_res_deg)
 
-<<<<<<< Updated upstream
-=======
-    #called twice if used via Colocator, this should go out here
->>>>>>> Stashed changes
     if remove_outliers and not var_ref_keep_outliers:
         ungridded_data.remove_outliers(var_ref, inplace=True,
                                        low=low_ref,

--- a/pyaerocom/colocation.py
+++ b/pyaerocom/colocation.py
@@ -591,6 +591,10 @@ def colocate_gridded_ungridded(gridded_data, ungridded_data, ts_type=None,
         gridded_data = _regrid_gridded(gridded_data, regrid_scheme,
                                        regrid_res_deg)
 
+<<<<<<< Updated upstream
+=======
+    #called twice if used via Colocator, this should go out here
+>>>>>>> Stashed changes
     if remove_outliers and not var_ref_keep_outliers:
         ungridded_data.remove_outliers(var_ref, inplace=True,
                                        low=low_ref,

--- a/pyaerocom/conftest.py
+++ b/pyaerocom/conftest.py
@@ -147,7 +147,7 @@ def aeronetsunv3lev2_subset():
 @pytest.fixture(scope='session')
 def data_scat_jungfraujoch():
     r = ReadEbas()
-    return r.read('scatc550aer', station_names='Jungfrau*')
+    return r.read('sc550aer', station_names='Jungfrau*')
 
 @pytest.fixture(scope='session')
 def loaded_nasa_ames_example():

--- a/pyaerocom/conftest.py
+++ b/pyaerocom/conftest.py
@@ -146,7 +146,7 @@ def aeronetsunv3lev2_subset():
 
 @pytest.fixture(scope='session')
 def data_scat_jungfraujoch():
-    r = ReadEbas()
+    r = ReadEbas('EBASSubset')
     return r.read('sc550aer', station_names='Jungfrau*')
 
 @pytest.fixture(scope='session')

--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -1264,12 +1264,8 @@ class UngriddedData(object):
             new = self
         else:
             new = self.copy()
-        try:
-            self.check_unit(var_name, unit=unit_ref)
-        except MetaDataError as e:
-            raise MetaDataError('Cannot remove outliers for variable {}. Found '
-                                'invalid units. Error: {}'
-                                .format(var_name, repr(e)))
+
+        new.check_convert_var_units(var_name, to_unit=unit_ref)
 
         if low is None:
             low = const.VARS[var_name].minimum
@@ -1278,9 +1274,9 @@ class UngriddedData(object):
             high = const.VARS[var_name].maximum
             logger.info('Setting {} outlier upper lim: {:.2f}'.format(var_name, high))
         var_idx = new.var_idx[var_name]
-        var_mask = self._data[:, new._VARINDEX] == var_idx
+        var_mask = new._data[:, new._VARINDEX] == var_idx
 
-        all_data =  self._data[:, self._DATAINDEX]
+        all_data =  new._data[:, new._DATAINDEX]
         invalid_mask = np.logical_or(all_data<low, all_data>high)
 
         mask = invalid_mask * var_mask

--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -1109,6 +1109,33 @@ class UngriddedData(object):
                                          .format(list(val), key, repr(e)))
         return (str_f, list_f, range_f, val_f)
 
+    def check_convert_var_units(self, var_name, to_unit=None,
+                                    inplace=True):
+        obj = self if inplace else self.copy()
+        from pyaerocom.units_helpers import unit_conversion_fac
+
+        # get the unit
+        if to_unit is None:
+            to_unit = const.VARS[var_name]['units']
+
+        for i, meta in obj.metadata.items():
+            if var_name in meta['var_info']:
+                try:
+                    unit = meta['var_info'][var_name]['units']
+                except KeyError:
+                    add_str = ''
+                    if 'unit' in meta['var_info'][var_name]:
+                        add_str = ('Corresponding var_info dict contains '
+                                   'attr. "unit", which is deprecated, please '
+                                   'check corresponding reading routine. ')
+                    raise MetaDataError('Failed to access unit information for '
+                                        'variable {} in metadata block {}. {}'
+                                        .format(var_name, i, add_str))
+                fac = unit_conversion_fac(unit, to_unit)
+                if fac != 1:
+                    raise NotImplementedError
+        return obj
+
     def check_unit(self, var_name, unit=None):
         """Check if variable unit corresponds to AeroCom unit
 

--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -1133,7 +1133,12 @@ class UngriddedData(object):
                                         .format(var_name, i, add_str))
                 fac = unit_conversion_fac(unit, to_unit)
                 if fac != 1:
-                    raise NotImplementedError
+                    meta_idx = obj.meta_idx[i][var_name]
+                    current = obj._data[meta_idx, obj._DATAINDEX]
+                    new = current * fac
+                    obj._data[meta_idx, obj._DATAINDEX] = new
+                    obj.metadata[i]['var_info'][var_name]['units'] = to_unit
+
         return obj
 
     def check_unit(self, var_name, unit=None):
@@ -2731,11 +2736,11 @@ def reduce_array_closest(arr_nominal, arr_to_be_reduced):
 if __name__ == "__main__":
     import pyaerocom as pya
     import matplotlib.pyplot as plt
-    data = pya.io.ReadUngridded().read('AeronetSunV3Lev2.daily', 'od550aer')
+    plt.close('all')
+    data = pya.io.ReadUngridded().read('EBASMC', 'ac550aer')
 
-    data.check_set_country()
+    data1 = data.check_convert_var_units('ac550aer', 'm-1', inplace=False)
 
-    sub = data.filter_region('United States', check_country_meta=True)
+    data.plot_station_timeseries(10, 'ac550aer')
 
-    sub.plot_station_coordinates()
-    plt.show()
+    data1.plot_station_timeseries(10, 'ac550aer')


### PR DESCRIPTION
This useful functionality is needed for colocation routine in case outlier removal is activated and obsdata units deviate from AeroCom default (cf. #181)