### PR TITLE
implicit_to_explicit_rate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,9 @@ ENV/
 # Spyder project settings
 .spyderproject
 .spyproject
+
+# Visual studio code project
+.vscode
  
 # Rope project settings
 .ropeproject

--- a/pyaerocom/helpers.py
+++ b/pyaerocom/helpers.py
@@ -411,7 +411,7 @@ def seconds_in_periods(timestamps, ts_type):
         timestamps = [to_pandas_timestamp(timestamp) for timestamp in timestamps]
     # From here on timestamps should be a numpy array containing pandas Timestamps
 
-    seconds_in_day = 24*60*60
+    seconds_in_day = 86400
     if ts_type >= TsType('monthly'):
         if ts_type == TsType('monthly'):
             days_in_months = np.array([ timestamp.days_in_month for timestamp in timestamps])

--- a/pyaerocom/test/test_helpers.py
+++ b/pyaerocom/test/test_helpers.py
@@ -139,6 +139,18 @@ def test_extract_latlon_dataarray_no_matches(lat, lon, expectation):
     with expectation:
         helpers.extract_latlon_dataarray(data, lat, lon, check_domain=True)
 
+@pytest.mark.parametrize("date,ts_type,expected", [
+    ("2000-02-18","monthly",29),  # February leap year
+    ("2000-02-18","yearly",366),  # Leap year
+    ("2001-02-18","monthly",28),  # February non leap year
+    ("2001-02-18","daily",1),     # Daily
+    ("2001-02-18","yearly",365)]) # Non leap year
+def test_seconds_in_periods(date, ts_type, expected):
+    seconds_in_day = 24*60*60
+    ts = np.datetime64(date)
+    seconds = helpers.seconds_in_periods(ts, ts_type)
+    assert seconds == expected*seconds_in_day
+
 if __name__=="__main__":
 
     import pandas as pd

--- a/pyaerocom/test/test_helpers.py
+++ b/pyaerocom/test/test_helpers.py
@@ -8,9 +8,10 @@ Created on Thu Apr 12 14:45:43 2018
 import numpy as np
 import pytest
 import xarray as xr
-from pyaerocom.conftest import DATA_ACCESS, does_not_raise_exception
-#import numpy.testing as npt
+from pandas import Series, date_range, Timestamp
+
 from pyaerocom import helpers
+from pyaerocom.conftest import does_not_raise_exception
 from pyaerocom.exceptions import DataCoverageError
 
 def test_get_standarad_name():
@@ -28,7 +29,7 @@ def test_get_lowest_resolution():
 def test_isnumeric():
     assert helpers.isnumeric(3)
     assert helpers.isnumeric(3.3455)
-    assert helpers.isnumeric(np.complex(1,2))
+    assert helpers.isnumeric(np.complex(1, 2))
 
 def test_isrange():
     assert helpers.isrange((0, 1))
@@ -42,10 +43,8 @@ def test__get_pandas_freq_and_loffset():
     assert val == ('MS', '14D')
 
 def _make_timeseries_synthetic():
-    from pandas import Series, date_range
-    idx = date_range(start="2000",periods=90, freq='D')
+    idx = date_range(start="2000", periods=90, freq='D')
     vals = np.arange(len(idx))
-
     return  Series(vals, idx)
 
 @pytest.fixture(scope='module')
@@ -62,18 +61,18 @@ def test_resample_timeseries(timeseries_synthetic):
         assert time.day == 15, time.day
 
 def test_same_meta_dict():
-    d1 =  dict(station_name = 'bla',
-               station_id = 'blub',
-               latitude = 33,
-               longitude = 15,
-               altitude = 400,
-               PI='pi1')
-    d2 =  dict(station_name = 'bla',
-               station_id = 'blub1',
-               latitude = 33,
-               longitude = 15,
-               altitude = 401,
-               PI='pi2')
+    d1 = dict(station_name='bla',
+              station_id='blub',
+              latitude=33,
+              longitude=15,
+              altitude=400,
+              PI='pi1')
+    d2 = dict(station_name='bla',
+              station_id='blub1',
+              latitude=33,
+              longitude=15,
+              altitude=401,
+              PI='pi2')
 
     assert helpers.same_meta_dict(d1, d2) == False
 
@@ -96,7 +95,6 @@ def test_start_stop_str():
 
 def test_start_stop_from_year():
     start, stop = helpers.start_stop_from_year(2000)
-    from pandas import Timestamp
     assert start == Timestamp('2000')
     assert stop == Timestamp('2000-12-31 23:59:59')
 
@@ -119,11 +117,11 @@ def test_get_time_rng_constraint():
     pass
 
 def test_extract_latlon_dataarray():
-    cube = helpers.make_dummy_cube_latlon(lat_res_deg=1, lon_res_deg=1, lat_range=[10,20], lon_range=[10,20])
+    cube = helpers.make_dummy_cube_latlon(lat_res_deg=1, lon_res_deg=1, lat_range=[10, 20], lon_range=[10, 20])
     data = xr.DataArray.from_iris(cube)
     # First coordinate does not exist in the dataarray.
-    lat = [15,15, 18]
-    lon = [1,15, 18]
+    lat = [15, 15, 18]
+    lon = [1, 15, 18]
     subset = helpers.extract_latlon_dataarray(data, lat, lon, check_domain=True)
     assert isinstance(subset, xr.DataArray)
     assert len(subset.lat) == len(lat) - 1 and len(subset.lon) == len(lon) -1
@@ -134,36 +132,23 @@ def test_extract_latlon_dataarray():
     ([15], [15], does_not_raise_exception())
     ])
 def test_extract_latlon_dataarray_no_matches(lat, lon, expectation):
-    cube = helpers.make_dummy_cube_latlon(lat_res_deg=1, lon_res_deg=1, lat_range=[10,20], lon_range=[10,20])
+    cube = helpers.make_dummy_cube_latlon(lat_res_deg=1, lon_res_deg=1, lat_range=[10, 20], lon_range=[10, 20])
     data = xr.DataArray.from_iris(cube)
     with expectation:
         helpers.extract_latlon_dataarray(data, lat, lon, check_domain=True)
 
 @pytest.mark.parametrize("date,ts_type,expected", [
-    ("2000-02-18","monthly",29),  # February leap year
-    ("2000-02-18","yearly",366),  # Leap year
-    ("2001-02-18","monthly",28),  # February non leap year
-    ("2001-02-18","daily",1),     # Daily
-    ("2001-02-18","yearly",365)]) # Non leap year
+    ("2000-02-18", "monthly", 29),  # February leap year
+    ("2000-02-18", "yearly", 366),  # Leap year
+    ("2001-02-18", "monthly", 28),  # February non leap year
+    ("2001-02-18", "daily", 1),     # Daily
+    ("2001-02-18", "yearly", 365)]) # Non leap year
 def test_seconds_in_periods(date, ts_type, expected):
     seconds_in_day = 24*60*60
     ts = np.datetime64(date)
     seconds = helpers.seconds_in_periods(ts, ts_type)
     assert seconds == expected*seconds_in_day
 
-if __name__=="__main__":
-
-    import pandas as pd
-
-    test_get_standarad_name()
-    test_get_standard_unit()
-    test_start_stop_from_year()
-    test__get_pandas_freq_and_loffset()
-    test_resample_timeseries(_make_timeseries_synthetic())
-    test_same_meta_dict()
-
-    stat1 = DATA_ACCESS['station_data1']
-    stat2 = DATA_ACCESS['station_data2']
-
-    merged_ec = helpers.merge_station_data([stat1, stat2],
-                                           var_name='ec550aer')
+if __name__ == "__main__":
+    import sys
+    pytest.main(sys.argv)

--- a/pyaerocom/test/test_units_helpers.py
+++ b/pyaerocom/test/test_units_helpers.py
@@ -8,8 +8,8 @@ Created on Thu Apr 12 14:45:43 2018
 import pytest
 import numpy.testing as npt
 from pyaerocom import units_helpers as uh
-from pyaerocom.conftest import lustre_unavail, testdata_unavail
-
+from pyaerocom.conftest import testdata_unavail
+from pyaerocom import GriddedData
 
 @pytest.mark.parametrize('from_unit,to_unit,val', [
     ('m-1', '1/Mm', 1e6),
@@ -18,15 +18,13 @@ from pyaerocom.conftest import lustre_unavail, testdata_unavail
 def test_unit_conversion_fac(from_unit, to_unit, val):
     assert uh.unit_conversion_fac(from_unit, to_unit) == val
 
-
-
 @pytest.mark.parametrize('var_name,from_unit,to_unit,val', [
-    ('concso2', 'ug S/m3','ug m-3', 1.9979),
-    ('concso4', 'ug S/m3','ug m-3', 2.9958),
-    ('concbc', 'ug C/m3','ug m-3', 1),
-    ('concoa', 'ug C/m3','ug m-3', 1),
-    ('concoc', 'ug C/m3','ug m-3', 1),
-    ('wetso4', 'kg S/ha','kg m-2', 0.0003),
+    ('concso2', 'ug S/m3', 'ug m-3', 1.9979),
+    ('concso4', 'ug S/m3', 'ug m-3', 2.9958),
+    ('concbc', 'ug C/m3', 'ug m-3', 1),
+    ('concoa', 'ug C/m3', 'ug m-3', 1),
+    ('concoc', 'ug C/m3', 'ug m-3', 1),
+    ('wetso4', 'kg S/ha', 'kg m-2', 0.0003),
     ('concso4pr', 'mg S/L', 'g m-3', 2.995821)
     ])
 def test_unit_conversion_fac_custom(var_name, from_unit, to_unit, val):
@@ -36,13 +34,13 @@ def test_unit_conversion_fac_custom(var_name, from_unit, to_unit, val):
                         val, rtol=1e-2)
 
 @pytest.mark.parametrize('from_unit,to_unit,var_name,val', [
-    ('ug m-3','ug/m3',None,1),
-    ('ug m-3','ug/m3','concso2',1),
+    ('ug m-3', 'ug/m3', None, 1),
+    ('ug m-3', 'ug/m3', 'concso2', 1),
     ('mg m-3', 'ug m-3', 'concso2', 1e3),
     ('ug S/m3', 'mg m-3', 'concso2', 1.9979e-3)
     ])
 def test_convert_unit(from_unit, to_unit, var_name, val):
-    result = uh.convert_unit(1,from_unit, to_unit, var_name)
+    result = uh.convert_unit(1, from_unit, to_unit, var_name)
     npt.assert_allclose(result,
                         val, rtol=1e-2)
 

--- a/pyaerocom/test/test_units_helpers.py
+++ b/pyaerocom/test/test_units_helpers.py
@@ -7,16 +7,20 @@ Created on Thu Apr 12 14:45:43 2018
 """
 import pytest
 import numpy.testing as npt
+
+from pytest import approx
 from pyaerocom import units_helpers as uh
 from pyaerocom.conftest import testdata_unavail
 from pyaerocom import GriddedData
 
+
 @pytest.mark.parametrize('from_unit,to_unit,val', [
     ('m-1', '1/Mm', 1e6),
     ('ug m-3', 'ug/m3', 1)
-    ])
+])
 def test_unit_conversion_fac(from_unit, to_unit, val):
     assert uh.unit_conversion_fac(from_unit, to_unit) == val
+
 
 @pytest.mark.parametrize('var_name,from_unit,to_unit,val', [
     ('concso2', 'ug S/m3', 'ug m-3', 1.9979),
@@ -26,28 +30,30 @@ def test_unit_conversion_fac(from_unit, to_unit, val):
     ('concoc', 'ug C/m3', 'ug m-3', 1),
     ('wetso4', 'kg S/ha', 'kg m-2', 0.0003),
     ('concso4pr', 'mg S/L', 'g m-3', 2.995821)
-    ])
+])
 def test_unit_conversion_fac_custom(var_name, from_unit, to_unit, val):
     to, num = uh.unit_conversion_fac_custom(var_name, from_unit)
     assert to == to_unit
     npt.assert_allclose(num,
                         val, rtol=1e-2)
 
+
 @pytest.mark.parametrize('from_unit,to_unit,var_name,val', [
     ('ug m-3', 'ug/m3', None, 1),
     ('ug m-3', 'ug/m3', 'concso2', 1),
     ('mg m-3', 'ug m-3', 'concso2', 1e3),
     ('ug S/m3', 'mg m-3', 'concso2', 1.9979e-3)
-    ])
+])
 def test_convert_unit(from_unit, to_unit, var_name, val):
     result = uh.convert_unit(1, from_unit, to_unit, var_name)
     npt.assert_allclose(result,
                         val, rtol=1e-2)
 
+
 @testdata_unavail
 @pytest.mark.parametrize('units', [
     's-1', '1/s'
-    ])
+])
 def test_implicit_to_explicit_rates_already_rate(data_tm5, units):
     # Function should not convert data that is already a rate
     data = data_tm5
@@ -57,9 +63,9 @@ def test_implicit_to_explicit_rates_already_rate(data_tm5, units):
     data_values = data.to_xarray().values
     assert (new_data_values == data_values).all()
 
+
 @testdata_unavail
 def test_implicit_to_explicit_rates_convert_data(data_tm5):
-    # seconds_in_months = ['']
     data = data_tm5
     data.units = 'kg m-2'
     new_data = uh.implicit_to_explicit_rates(data, 'monthly')
@@ -68,6 +74,11 @@ def test_implicit_to_explicit_rates_convert_data(data_tm5):
     new_data_values = new_data.to_xarray().values
     data_values = data.to_xarray().values
     assert (new_data_values != data_values).all()
+    factors = uh.seconds_in_periods(data.time_stamps(), 'monthly')
+    ratio = data_values / new_data_values
+    for i, factor in enumerate(factors):
+        assert (ratio)[i].mean() == factor
+
 
 if __name__ == '__main__':
     import sys

--- a/pyaerocom/test/test_units_helpers.py
+++ b/pyaerocom/test/test_units_helpers.py
@@ -46,6 +46,31 @@ def test_convert_unit(from_unit, to_unit, var_name, val):
     npt.assert_allclose(result,
                         val, rtol=1e-2)
 
-if __name__=='__main__':
+@testdata_unavail
+@pytest.mark.parametrize('units', [
+    's-1', '1/s'
+    ])
+def test_implicit_to_explicit_rates_already_rate(data_tm5, units):
+    # Function should not convert data that is already a rate
+    data = data_tm5
+    data.units = units
+    new_data = uh.implicit_to_explicit_rates(data, 'monthly')
+    new_data_values = new_data.to_xarray().values
+    data_values = data.to_xarray().values
+    assert (new_data_values == data_values).all()
+
+@testdata_unavail
+def test_implicit_to_explicit_rates_convert_data(data_tm5):
+    # seconds_in_months = ['']
+    data = data_tm5
+    data.units = 'kg m-2'
+    new_data = uh.implicit_to_explicit_rates(data, 'monthly')
+    assert isinstance(new_data, GriddedData)
+    assert new_data.units == 'kg m-2 s-1'
+    new_data_values = new_data.to_xarray().values
+    data_values = data.to_xarray().values
+    assert (new_data_values != data_values).all()
+
+if __name__ == '__main__':
     import sys
     pytest.main(sys.argv)

--- a/pyaerocom/units_helpers.py
+++ b/pyaerocom/units_helpers.py
@@ -11,7 +11,6 @@ import numpy as np
 
 from cf_units import Unit
 from pyaerocom import const
-from pyaerocom import GriddedData
 from pyaerocom.exceptions import UnitConversionError
 from pyaerocom.helpers import seconds_in_periods
 
@@ -40,16 +39,16 @@ HA_TO_SQM = 10000   # hectar to square metre.
 # logic of hierarchy is: variable -> from unit -> to_unit -> conversion factor
 UCONV_MUL_FACS = pd.DataFrame([
 
-  ['concso4', 'ug S/m3', VARS.concso4.units,  UCONV_FAC_S_SO4],
-  ['concso2', 'ug S/m3', VARS.concso2.units,  UCONV_FAC_S_SO2],
+    ['concso4', 'ug S/m3', VARS.concso4.units, UCONV_FAC_S_SO4],
+    ['concso2', 'ug S/m3', VARS.concso2.units, UCONV_FAC_S_SO2],
 
-  ['concbc', 'ug C/m3', VARS.concbc.units, 1.0],
-  ['concoa', 'ug C/m3', VARS.concoa.units, 1.0],
-  ['concoc', 'ug C/m3', VARS.concoc.units, 1.0],
-  ['conctc', 'ug C/m3', VARS.conctc.units, 1.0],
+    ['concbc', 'ug C/m3', VARS.concbc.units, 1.0],
+    ['concoa', 'ug C/m3', VARS.concoa.units, 1.0],
+    ['concoc', 'ug C/m3', VARS.concoc.units, 1.0],
+    ['conctc', 'ug C/m3', VARS.conctc.units, 1.0],
 
-  ['wetso4', 'kg S/ha', 'kg m-2',  UCONV_FAC_S_SO4 / HA_TO_SQM],
-  ['concso4pr', 'mg S/L', 'g m-3',  UCONV_FAC_S_SO4] # 1mg/L = 1g/m3
+    ['wetso4', 'kg S/ha', 'kg m-2', UCONV_FAC_S_SO4 / HA_TO_SQM],
+    ['concso4pr', 'mg S/L', 'g m-3', UCONV_FAC_S_SO4] # 1mg/L = 1g/m3
 
 ], columns=['var_name', 'from', 'to', 'fac']).set_index(['var_name', 'from'])
 
@@ -202,8 +201,8 @@ def implicit_to_explicit_rates(gridded, ts_type):
     GriddedData
         Modified data, if not already a rate.
     """
-
     from pyaerocom import GriddedData
+
     unit = gridded.units
     unit_string = str(unit)
     is_rate = ('/s' in unit_string) or ('s-1' in unit_string)

--- a/pyaerocom/units_helpers.py
+++ b/pyaerocom/units_helpers.py
@@ -214,7 +214,7 @@ def implicit_to_explicit_rates(gridded, ts_type):
         mult_fac = np.ones_like(data)
         for i in range(len(seconds_factor)):
             mult_fac[i] *= seconds_factor[i]
-        result = data*mult_fac
+        result = data / mult_fac
         cube = result.to_iris()
         new_gridded = GriddedData()
         new_gridded.grid = cube


### PR DESCRIPTION
Add functionality for dealing with variables that should be defined as rates but does not have a frequency as part of its units (f.e. deposition rates in EMEP model data).