### PR TITLE
Provide logic for automatic EBAS file column selection based on variable unit

### DIFF
--- a/pyaerocom/data/ebas_config.ini
+++ b/pyaerocom/data/ebas_config.ini
@@ -226,6 +226,10 @@ component=carbon_monoxide
 matrix=air
 scale_factor=1.
 
+[vmro3]
+component=ozone
+matrix=air
+
 # 2.3. Precipitation concentrations
 [concprcpso4]
 old_name=CONCPRCP_SO4

--- a/pyaerocom/io/read_ebas.py
+++ b/pyaerocom/io/read_ebas.py
@@ -908,7 +908,9 @@ class ReadEbas(ReadUngriddedBase):
             of the input variables.
         """
         file = loaded_nasa_ames
-        var_cols = {}
+
+        # dict containing variable column matches
+        _vc = {}
         # Loop over all variables that are supposed to be read
         for var in vars_to_read:
             # get corresponding EBAS variable info ...
@@ -947,19 +949,21 @@ class ReadEbas(ReadUngriddedBase):
                                                           file, var_info)
 
             if bool(col_matches):
-                var_cols[var] = col_matches
+                _vc[var] = col_matches
 
-        if not len(var_cols) > 0:
+        if not len(_vc) > 0:
             raise NotInFileError('None of the specified variables {} could be '
                                  'found in file {}'.format(vars_to_read,
                                                 os.path.basename(file.file)))
-
-        for var, cols in var_cols.items():
-            if len(cols) > 1:
+        var_cols = {}
+        for var, cols in _vc.items():
+            if len(cols) == 1:
+                col = cols[0]
+            else:
                 col = self._find_best_data_column(cols,
                                                   self.get_ebas_var(var),
                                                   file)
-                var_cols[var] = col
+            var_cols[var] = col
         return var_cols
 
     def get_ebas_var(self, var_name):

--- a/pyaerocom/io/read_ebas.py
+++ b/pyaerocom/io/read_ebas.py
@@ -23,6 +23,7 @@ import fnmatch
 import numpy as np
 from collections import OrderedDict as od
 from pyaerocom import const
+from pyaerocom.units_helpers import unit_conversion_fac
 from pyaerocom.mathutils import (compute_sc550dryaer,
                                  compute_sc440dryaer,
                                  compute_sc700dryaer,
@@ -35,7 +36,8 @@ from pyaerocom.ungriddeddata import UngriddedData
 from pyaerocom.io.ebas_varinfo import EbasVarInfo
 from pyaerocom.io.ebas_file_index import EbasFileIndex, EbasSQLRequest
 from pyaerocom.io.ebas_nasa_ames import EbasNasaAmesFile
-from pyaerocom.exceptions import NotInFileError, EbasFileError
+from pyaerocom.exceptions import (NotInFileError, EbasFileError,
+                                  UnitConversionError)
 from pyaerocom._lowlevel_helpers import BrowseDict
 from tqdm import tqdm
 
@@ -635,7 +637,8 @@ class ReadEbas(ReadUngriddedBase):
                                  "file".format(ebas_var_info.var_name))
         return col_matches
 
-    def _find_best_data_column(self, cols, ebas_var_info, file):
+    def _find_best_data_column(self, cols, ebas_var_info, file,
+                               check_units_on_multimatch=True):
         """Find best match of data column for variable in multiple columns
 
         This method is supposed to be used in case no unique match can be
@@ -710,19 +713,28 @@ class ReadEbas(ReadUngriddedBase):
             if num_matches == 0:
                 raise ValueError('Note for developers: this should not happen, '
                                  'please debug')
-            # multiple column matches were found, use the one that contains
-            # less NaNs
-            num_invalid = []
-            for colnum in result_col:
-                num_invalid.append(np.isnan(file.data[:, colnum]).sum())
-            result_col = [result_col[np.argmin(num_invalid)]]
-# =============================================================================
-#             raise EbasFileError('Could not identify unique column for var {}. '
-#                                 'Detected multiple matches: {}'.format(
-#                                         ebas_var_info.var_name,
-#                                         result_col))
-# =============================================================================
-        return result_col
+            to_unit =  str(self.var_info(ebas_var_info['var_name']).units)
+            if check_units_on_multimatch and not to_unit in ('', '1'):
+                _cols = []
+                for colnum in result_col:
+                    try:
+                        from_unit = file.var_defs[colnum].units
+                        unit_conversion_fac(from_unit, to_unit)
+                        _cols.append(colnum)
+                    except UnitConversionError:
+                        continue
+                if len(_cols) > 0:
+                    result_col = _cols
+
+            if len(result_col) > 1:
+                # multiple column matches were found, use the one that contains
+                # less NaNs
+                num_invalid = []
+                for colnum in result_col:
+                    num_invalid.append(np.isnan(file.data[:, colnum]).sum())
+                result_col = [result_col[np.argmin(num_invalid)]]
+
+        return result_col[0]
 
     def _add_meta(self, data_out, file):
         meta = file.meta
@@ -995,11 +1007,9 @@ class ReadEbas(ReadUngriddedBase):
         #data_out['ebas_meta'] = meta
         data_out['var_info'] = {}
         #totnum = file.data.shape[0]
-        for var, colnums  in var_cols.items():
+        for var, colnum  in var_cols.items():
             data_out['var_info'][var] = {}
-            if len(colnums) != 1:
-                raise Exception('Something went wrong...please debug')
-            colnum = colnums[0]
+
             _col = file.var_defs[colnum]
             data = file.data[:, colnum]
 
@@ -1366,4 +1376,6 @@ if __name__=="__main__":
     db = r.sqlite_database_file
     #$files = r.get_file_list(['vmro3'])
 
-    r.read('vmro3')
+    data = r.read('vmro3', station_names='Eureka')
+
+    data.plot_station_timeseries('Eureka', 'vmro3')

--- a/pyaerocom/io/read_ebas.py
+++ b/pyaerocom/io/read_ebas.py
@@ -1364,6 +1364,6 @@ if __name__=="__main__":
     r = ReadEbas()
 
     db = r.sqlite_database_file
-    files = r.get_file_list(['sc550dryaer'])
+    #$files = r.get_file_list(['vmro3'])
 
-    r.read('sc550dryaer')
+    r.read('vmro3')

--- a/pyaerocom/io/test/test_read_ebas.py
+++ b/pyaerocom/io/test/test_read_ebas.py
@@ -313,8 +313,8 @@ class TestReadEBAS(object):
 
     def test_find_var_cols(self, reader, loaded_nasa_ames_example):
         var = ['sc550aer', 'scrh']
-        desired = {'sc550aer' : [17],
-                   'scrh'     : [3]}
+        desired = {'sc550aer' : 17,
+                   'scrh'     : 3}
 
         cols = reader.find_var_cols(var, loaded_nasa_ames_example)
         for k, v in desired.items():

--- a/pyaerocom/io/test/test_read_ebas.py
+++ b/pyaerocom/io/test/test_read_ebas.py
@@ -78,6 +78,7 @@ class TestReadEBAS(object):
                          'concno2',
                          'conco3',
                          'concco',
+                         'vmro3',
                          'concprcpso4',
                          'concprcpso4t',
                          'concprcpso4c',


### PR DESCRIPTION
Needed to read, e.g. vmro3 from a NASA Ames file that contains both vmro3 and conco3, stored in different columns. 

Added `vmror` to ebas_config.ini. More variables for other gas mixing ratios (e.g. NO2, SO2) need to be added as needed.