### PR TITLE
Enable adding variables in VarCollection and automatic behaviour in colocation

### DIFF
--- a/pyaerocom/griddeddata.py
+++ b/pyaerocom/griddeddata.py
@@ -141,7 +141,7 @@ class GriddedData(object):
     def var_name_aerocom(self):
         """AeroCom variable name"""
         try:
-            return const.VARS[self.var_name].var_name
+            return const.VARS[self.var_name].var_name_aerocom
         except Exception:
             return None
 

--- a/pyaerocom/test/test_colocation.py
+++ b/pyaerocom/test/test_colocation.py
@@ -44,6 +44,13 @@ def test__colocate_site_data_helper(aeronetsunv3lev2_subset):
                  0.07752743643132792]
     npt.assert_allclose(means, should_be, rtol=1e-5)
 
+def test_colocate_gridded_ungridded_new_var(data_tm5, aeronetsunv3lev2_subset):
+    data = data_tm5.copy()
+    data.var_name='Blaaa'
+    coldata = colocate_gridded_ungridded(data, aeronetsunv3lev2_subset,
+                                         var_ref='od550aer')
+
+    assert coldata.meta['var_name'] == ['od550aer', 'Blaaa']
 
 @testdata_unavail
 @pytest.mark.parametrize('addargs,ts_type,shape,obsmean,modmean',[
@@ -80,6 +87,8 @@ def test_colocate_gridded_ungridded(data_tm5, aeronetsunv3lev2_subset,
 
     npt.assert_allclose(means, [obsmean, modmean], rtol=TEST_RTOL)
 
+
+
 @testdata_unavail
 def test_colocate_gridded_ungridded_nonglobal(aeronetsunv3lev2_subset):
     times = [1,2]
@@ -100,6 +109,15 @@ def test_colocate_gridded_ungridded_nonglobal(aeronetsunv3lev2_subset):
     coldata = colocate_gridded_ungridded(gridded, aeronetsunv3lev2_subset, colocate_time=False)
     coords = coldata.coords
     assert len(coords['station_name']) == 1
+
+
+@testdata_unavail
+def test_colocate_gridded_gridded_same_new_var(data_tm5):
+    data = data_tm5.copy()
+    data.var_name = 'Blaaa'
+    coldata = colocate_gridded_gridded(data, data_tm5)
+
+    assert coldata.meta['var_name'] == ['od550aer', 'Blaaa']
 
 @testdata_unavail
 def test_colocate_gridded_gridded_same(data_tm5):

--- a/pyaerocom/test/test_variable.py
+++ b/pyaerocom/test/test_variable.py
@@ -7,6 +7,7 @@ Created on Fri Feb 14 16:31:13 2020
 """
 
 import pytest
+from pyaerocom import const
 from pyaerocom.variable import Variable
 from pyaerocom.variable import get_emep_variables
 
@@ -36,6 +37,20 @@ def test_get_emep_variables():
     variables = get_emep_variables()
     assert isinstance(variables, dict)
     assert variables['conco3'] == 'SURF_ug_O3'
+
+def test_VarCollection_add_var():
+    var = Variable(var_name='concpmgt25',
+                   units='ug m-3',
+                   long_name='PM mass greater than 2.5 um')
+
+    const.VARS.add_var(var)
+    assert 'concpmgt25' in const.VARS
+    var1 = const.VARS['concpmgt25']
+    assert var1.var_name == var.var_name
+    assert var1.var_name_aerocom == var.var_name_aerocom
+    assert var1.units == var.units
+    assert var1.long_name == var.long_name
+
 
 
 if __name__=='__main__':

--- a/pyaerocom/variable.py
+++ b/pyaerocom/variable.py
@@ -803,7 +803,7 @@ class VarCollection(object):
         if not isinstance(var, Variable):
             raise ValueError('Can only add instances of Variable class...')
         if not isinstance(var.units, str):
-            if isinstance(var.units, Unit):
+            if not isinstance(var.units, Unit):
                 raise ValueError('Please assign a unit to the new input '
                                  'variable')
             var.units = str(var.units)

--- a/pyaerocom/variable.py
+++ b/pyaerocom/variable.py
@@ -3,6 +3,7 @@
 import os
 from ast import literal_eval
 import re, fnmatch
+from cf_units import Unit
 from configparser import ConfigParser
 from pyaerocom import logger, print_log
 from pyaerocom.obs_io import OBS_WAVELENGTH_TOL_NM
@@ -672,6 +673,8 @@ class VarCollection(object):
 
         self.var_ini = var_ini
 
+        self._vars_added = {}
+
         self._cfg_parser = parse_variables_ini(var_ini)
         self._alias_parser = parse_aliases_ini()
         self._idx = -1
@@ -690,6 +693,7 @@ class VarCollection(object):
         """
         if self._all_vars is None:
             all_vars = [k.lower() for k in self._cfg_parser.keys()]
+            all_vars.extend(self._vars_added.keys())
             #all_vars.extend(list(_read_alias_ini()))
             self._all_vars = all_vars
         return self._all_vars
@@ -770,12 +774,73 @@ class VarCollection(object):
             return self.__dict__[attr]
         return self[attr]
 
-    def __getitem__(self, var_name):
+    def add_var(self, var):
+        """Add a new variable to this collection
+
+        Minimum requirement for new variables are attributes var_name and
+        units.
+
+        Parameters
+        ----------
+        var : Variable
+            new variable definition
+
+        Raises
+        ------
+        VariableDefinitionError
+            if a variable is already defined under that name
+
+        Returns
+        -------
+        None
+        """
+        if not isinstance(var.var_name, str):
+            raise ValueError('Attr. var_name needs to be assigned to input '
+                             'variable')
+        if var.var_name in self.all_vars:
+            raise VariableDefinitionError(f'variable with name {var.var_name} '
+                                          f'is already defined')
+        if not isinstance(var, Variable):
+            raise ValueError('Can only add instances of Variable class...')
+        if not isinstance(var.units, str):
+            if isinstance(var.units, Unit):
+                raise ValueError('Please assign a unit to the new input '
+                                 'variable')
+            var.units = str(var.units)
+        self._all_vars.append(var.var_name)
+        self._vars_added[var.var_name] = var
+
+    def get_var(self, var_name):
+        """
+        Get variable based on variable name
+
+        Parameters
+        ----------
+        var_name : str
+            name of variable
+
+        Raises
+        ------
+        VariableDefinitionError
+            if no variable under input var_name is registered.
+
+        Returns
+        -------
+        Variable
+            Variable instance
+
+        """
+        if var_name in self._vars_added:
+            return self._vars_added[var_name]
         var = Variable(var_name, cfg=self._cfg_parser)
         if not var.var_name_aerocom in self:
-            raise VariableDefinitionError('Error (VarCollection): input variable '
-                                          '{} is not supported'.format(var_name))
+            raise VariableDefinitionError(
+                'Error (VarCollection): input variable '
+                '{} is not supported'.format(var_name))
         return var
+
+    def __getitem__(self, var_name):
+        return self.get_var(var_name)
 
     def __repr__(self):
         head = "Pyaerocom {}".format(type(self).__name__)


### PR DESCRIPTION
Requires 2 steps:

- [x] Provide functionality to register new variables in `pyaerocom.variable.VarCollection`
- [x] Add logic to automatically do that (i.e. adding variables) in colocation routine. This will be done based on attrs. `var_name` and `units` in the associated `GriddedData` object that is supposed to be colocated. 