### PR TITLE
Second attempt to fix issue 263

### DIFF
--- a/pyaerocom/test/test_time_resampler.py
+++ b/pyaerocom/test/test_time_resampler.py
@@ -77,33 +77,39 @@ def test_TimeResampler__gen_index(from_ts_type, to_ts_type, min_num_obs,
     val = TimeResampler()._gen_idx(from_ts_type, to_ts_type, min_num_obs, how)
     assert val == expected
 
-@pytest.mark.parametrize('args,output_len,output_numnotnan', [
+@pytest.mark.parametrize('args,output_len,output_numnotnan,lsp', [
+    (dict(to_ts_type='monthly',from_ts_type='hourly',
+          how=dict(daily=dict(hourly='sum')),
+          apply_constraints=True,
+          min_num_obs=min_num_obs_custom), 1, 0, False),
     (dict(to_ts_type='monthly',from_ts_type='hourly',how='median',
-          apply_constraints=False), 1, 1),
+          apply_constraints=False), 1, 1, True),
     (dict(to_ts_type='daily',from_ts_type='hourly',how='median',
-          apply_constraints=False), 13, 13),
+          apply_constraints=False), 13, 13, True),
     (dict(to_ts_type='daily',from_ts_type='hourly',how='median',
-          apply_constraints=False), 13, 13),
-    (dict(to_ts_type='daily',from_ts_type='hourly',how='median',
-          apply_constraints=True,
-          min_num_obs=min_num_obs_default), 13, 13),
+          apply_constraints=False), 13, 13, True),
     (dict(to_ts_type='daily',from_ts_type='hourly',how='median',
           apply_constraints=True,
-          min_num_obs=min_num_obs_custom), 13, 12),
+          min_num_obs=min_num_obs_default), 13, 13, True),
+    (dict(to_ts_type='daily',from_ts_type='hourly',how='median',
+          apply_constraints=True,
+          min_num_obs=min_num_obs_custom), 13, 12, True),
     (dict(to_ts_type='monthly',from_ts_type='hourly',how='median',
           apply_constraints=True,
-          min_num_obs=min_num_obs_default), 1, 1),
+          min_num_obs=min_num_obs_default), 1, 1, True),
     (dict(to_ts_type='monthly',from_ts_type='hourly',how='median',
           apply_constraints=True,
-          min_num_obs=min_num_obs_custom), 1, 0)
+          min_num_obs=min_num_obs_custom), 1, 0, True),
+
     ])
 def test_TimeResampler_resample(fakedata_hourly, args, output_len,
-                                output_numnotnan):
+                                output_numnotnan, lsp):
     tr = TimeResampler(input_data=fakedata_hourly)
     ts = tr.resample(**args)
     assert len(ts) == output_len
     notnan = ~np.isnan(ts)
     assert notnan.sum() == output_numnotnan
+    assert tr.last_units_preserved == lsp
 
 if __name__ == '__main__':
     import sys

--- a/pyaerocom/test/test_time_resampler.py
+++ b/pyaerocom/test/test_time_resampler.py
@@ -77,7 +77,7 @@ def test_TimeResampler__gen_index(from_ts_type, to_ts_type, min_num_obs,
     val = TimeResampler()._gen_idx(from_ts_type, to_ts_type, min_num_obs, how)
     assert val == expected
 
-@pytest.mark.parametrize('args,output_len,output_numnotnan,lsp', [
+@pytest.mark.parametrize('args,output_len,output_numnotnan,lup', [
     (dict(to_ts_type='monthly',from_ts_type='hourly',
           how=dict(daily=dict(hourly='sum')),
           apply_constraints=True,
@@ -103,13 +103,13 @@ def test_TimeResampler__gen_index(from_ts_type, to_ts_type, min_num_obs,
 
     ])
 def test_TimeResampler_resample(fakedata_hourly, args, output_len,
-                                output_numnotnan, lsp):
+                                output_numnotnan, lup):
     tr = TimeResampler(input_data=fakedata_hourly)
     ts = tr.resample(**args)
     assert len(ts) == output_len
     notnan = ~np.isnan(ts)
     assert notnan.sum() == output_numnotnan
-    assert tr.last_units_preserved == lsp
+    assert tr.last_units_preserved == lup
 
 if __name__ == '__main__':
     import sys

--- a/pyaerocom/time_resampler.py
+++ b/pyaerocom/time_resampler.py
@@ -24,15 +24,29 @@ class TimeResampler(object):
     specified to first required minimum number of hours per day, and minimum
     days per month, to create the output data.
     """
-    SAMPLING_CONSTRAINTS = const.OBS_MIN_NUM_RESAMPLE
+    DEFAULT_SAMPLING_CONSTRAINTS = const.OBS_MIN_NUM_RESAMPLE
     APPLY_CONSTRAINTS = const.OBS_APPLY_TIME_RESAMPLE_CONSTRAINTS
     FREQS_SUPPORTED = TS_TYPE_TO_PANDAS_FREQ
+    AGGRS_UNIT_PRESERVE = ('mean', 'median', 'std', 'max', 'min')
+
     def __init__(self, input_data=None):
         self.last_setup = None
+        # the following attribute is updated whenever a resampling operation is
+        # performed and it will check if any of the specified resampling
+        # aggregators invalidates unit preservation (e.g. using how=add for
+        # for accumulating precipitation...). See also attr. AGGRS_UNIT_PRESERVE
+        self._last_units_preserved = None
         self._input_data = None
 
         if input_data is not None:
             self.input_data = input_data
+
+    @property
+    def last_units_preserved(self):
+        """Boolean indicating if last resampling operation preserves units"""
+        if self._last_units_preserved is None:
+            raise AttributeError('Please call resample first...')
+        return self._last_units_preserved
 
     @property
     def input_data(self):
@@ -88,6 +102,7 @@ class TimeResampler(object):
 
         last_from = valid[start]
         idx = []
+
         for i in range(start+1, stop+1):
             to = valid[i]
             if to in min_num_obs and last_from in min_num_obs[to]:
@@ -162,16 +177,26 @@ class TimeResampler(object):
         if apply_constraints is None:
             apply_constraints = self.APPLY_CONSTRAINTS
 
-        self.last_setup = dict(apply_constraints=False,
-                               min_num_obs=None,
+        if min_num_obs is None:
+            min_num_obs = self.DEFAULT_SAMPLING_CONSTRAINTS
+
+        self.last_setup = dict(apply_constraints=apply_constraints,
+                               min_num_obs=min_num_obs,
                                how=how)
 
-        if not apply_constraints or from_ts_type is None:
+        if from_ts_type is None:
+            apply_constraints = False
+
+        if not apply_constraints:
             freq = to_ts_type.to_pandas_freq()
             if not isinstance(how, str):
                 raise ValueError('Temporal resampling without constraints can '
                                  'only use string type argument how (e.g. '
                                  'how=mean). Got {}'.format(how))
+            if how in self.AGGRS_UNIT_PRESERVE:
+                self._last_units_preserved = True
+            else:
+                self._last_units_preserved = False
             return self.fun(self.input_data, freq=freq,
                             how=how, **kwargs)
 
@@ -196,19 +221,25 @@ class TimeResampler(object):
                               'time stamps'.format(to_ts_type.val))
 
             freq = to_ts_type.to_pandas_freq()
+            self._last_units_preserved = True
             return self.fun(self.input_data, freq=freq, how='mean',
                             **kwargs)
 
-        if min_num_obs is None:
-            min_num_obs = self.SAMPLING_CONSTRAINTS
-
         _idx = self._gen_idx(from_ts_type, to_ts_type, min_num_obs, how)
         data = self.input_data
+        aggrs = []
         for to_ts_type, mno, rshow in _idx:
             const.logger.info('TO: {} ({}, {})'.format(to_ts_type, mno, rshow))
             freq = TsType(to_ts_type).to_pandas_freq()
             data = self.fun(data, freq=freq, how=rshow,
                             min_num_obs=mno)
+            aggrs.append(rshow)
+
+        if all([x in self.AGGRS_UNIT_PRESERVE for x in aggrs]):
+            self._last_units_preserved = True
+        else:
+            self._last_units_preserved = False
+
         self.last_setup = dict(apply_constraints=True,
                                min_num_obs=min_num_obs,
                                how=how)


### PR DESCRIPTION
Some temporal resampling aggregators do not preserve the unit of the data. E.g. if hourly precip data in units of mm hr-1 is resampled to daily using `sum` as an aggregator, the units will need to be changed to mm d-1. While this can be certainly automated (and should be at some point), for now, this PR introduces a list of "safe" aggregators in `TimeResampler` that preserve the units of the input data and checks if this criterion is fulfilled whenever `TimeResampler.resample` is called.

This has been implemented in `GriddedData.resample_time` in order to check if units in output data object are preserved. This should fix #263, but needs further looking into at some point.