### PR TITLE
added checking for the presence of model_add_vars

### DIFF
--- a/pyaerocom/data/aliases.ini
+++ b/pyaerocom/data/aliases.ini
@@ -44,6 +44,7 @@ emioa = emipoa
 abs550oa = abs550oc
 mmrpm25 = mmrpm2p5
 wetoxs = wetsox
+drysox = dryoxs
 
 [alias_families]
 # so far only works with beginning of name

--- a/pyaerocom/data/variables.ini
+++ b/pyaerocom/data/variables.ini
@@ -1922,7 +1922,7 @@ dimensions = time,lat,lon
 comments_and_purpose = Verification of nitrogen budget
 
 [wetoxn]
-description=Wet deposition of total nitrogen mass
+description=Wet deposition of oxidized nitrogen mass
 unit = mg N m-2 d-1
 minimum=0
 
@@ -1934,6 +1934,16 @@ minimum=0
 [wetoxs]
 description=Wet deposition of total sulphur mass
 unit = mg S m-2 d-1
+minimum=0
+
+[dryoxn]
+description=dry deposition of oxidized nitrogen mass
+unit = mg N m-2 d-1
+minimum=0
+
+[dryrdn]
+description=Dry deposition of reduced Nitrogen mass
+unit = mg N m-2 d-1
 minimum=0
 
 [drysox]

--- a/pyaerocom/web/aerocom_evaluation.py
+++ b/pyaerocom/web/aerocom_evaluation.py
@@ -748,7 +748,7 @@ class AerocomEvaluation(object):
                         try:
                             add_var_name = self.model_config[model_name]['model_add_vars'][var_name]
                         except:
-                            pass
+                            add_var_name = None
                         if not m['var_name'] == var_name:
                             if not m['var_name'] == add_var_name:
                                 match = False

--- a/pyaerocom/web/aerocom_evaluation.py
+++ b/pyaerocom/web/aerocom_evaluation.py
@@ -745,8 +745,13 @@ class AerocomEvaluation(object):
                             var_name = self.model_config[model_name]['model_use_vars'][var_name]
                         except:
                             pass
+                        try:
+                            add_var_name = self.model_config[model_name]['model_add_vars'][var_name]
+                        except:
+                            pass
                         if not m['var_name'] == var_name:
-                            match = False
+                            if not m['var_name'] == add_var_name:
+                                match = False
                     if match:
                         files.append(os.path.join(coldata_dir, fname))
                 except Exception:


### PR DESCRIPTION
The functionality supposed to be supported through the `model_add_vars` option to model config in web evaluation was broken. This should fix it.