### PR TITLE
Harmonisation of ungridded reading API

### DIFF
--- a/pyaerocom/colocation_auto.py
+++ b/pyaerocom/colocation_auto.py
@@ -907,7 +907,7 @@ class Colocator(ColocationSetup):
         obs_reader = ReadUngridded(self.obs_id, data_dirs=self.obs_data_dir)
         try:
             obs_vars = obs_reader.get_vars_supported(self.obs_id,
-                                                 vars_to_read)
+                                                     vars_to_read)
         except ValueError:
             raise DataCoverageError('No observation variable matches found for '
                                     '{}'.format(self.obs_id))

--- a/pyaerocom/colocation_auto.py
+++ b/pyaerocom/colocation_auto.py
@@ -844,7 +844,7 @@ class Colocator(ColocationSetup):
 
         vars_to_read = self._init_obsvars_to_read(vars_to_read)
 
-        obs_reader = ReadUngridded(self.obs_id, data_dir=self.obs_data_dir)
+        obs_reader = ReadUngridded(self.obs_id, data_dirs=self.obs_data_dir)
         try:
             obs_vars = obs_reader.get_vars_supported(self.obs_id,
                                                  vars_to_read)

--- a/pyaerocom/combine_vardata_ungridded.py
+++ b/pyaerocom/combine_vardata_ungridded.py
@@ -491,12 +491,12 @@ if __name__=='__main__':
     filter_post = {'altitude' : [1500, 1700]}
     # Tests based on whole datasets
     vmro3 = pya.io.ReadUngridded('GHOST.EEA.daily',
-                                 data_dir=GHOST_DIR).read(vars_to_retrieve='vmro3',
+                                 data_dirs=GHOST_DIR).read(vars_to_retrieve='vmro3',
                                                           filter_post=filter_post)
 
                                                           # Tests based on whole datasets
     vmrno2 = pya.io.ReadUngridded('GHOST.EEA.daily',
-                                  data_dir=GHOST_DIR).read(vars_to_retrieve='vmrno2',
+                                  data_dirs=GHOST_DIR).read(vars_to_retrieve='vmrno2',
                                                            filter_post=filter_post)
 
 

--- a/pyaerocom/config.py
+++ b/pyaerocom/config.py
@@ -721,7 +721,7 @@ class Config(object):
             reading interface
         """
         check = reader(obs_id)
-        path = check.DATASET_PATH
+        path = check.data_dir
         assert path == data_dir
         try:
             check.get_file_list()

--- a/pyaerocom/io/cachehandler_ungridded.py
+++ b/pyaerocom/io/cachehandler_ungridded.py
@@ -17,7 +17,7 @@ class CacheHandlerUngridded(object):
 
     Cache filename mask is
 
-    <dataset_to_read>_<var>.pkl
+    <data_id>_<var>.pkl
 
     e.g. EBASMC_scatc550aer.pkl
 
@@ -60,12 +60,7 @@ class CacheHandlerUngridded(object):
     def reader(self, val):
         from pyaerocom.io import ReadUngriddedBase
         if not isinstance(val, ReadUngriddedBase):
-            try:
-                val = val.get_reader()
-                if not isinstance(val, ReadUngriddedBase):
-                    raise TypeError('Invalid input for reader')
-            except Exception:
-                raise TypeError('Invalid input for reader')
+            raise TypeError('Invalid input for reader')
         self._reader = val
         self.loaded_data = {}
 
@@ -84,9 +79,9 @@ class CacheHandlerUngridded(object):
         self._cache_dir = val
 
     @property
-    def dataset_to_read(self):
+    def data_id(self):
         """Data ID of the associated dataset"""
-        return self.reader.dataset_to_read
+        return self.reader.data_id
 
     @property
     def src_data_dir(self):
@@ -94,7 +89,7 @@ class CacheHandlerUngridded(object):
 
         Needed to check whether an existing cache file is outdated
         """
-        return self.reader.DATASET_PATH
+        return self.reader.data_dir
 
     def default_file_name(self, var_name):
         """File name of cache file
@@ -110,7 +105,7 @@ class CacheHandlerUngridded(object):
         str
             file name of pickle file
         """
-        name = '_'.join([self.dataset_to_read, var_name])
+        name = '_'.join([self.data_id, var_name])
         return name + '.pkl'
 
     def file_path(self, var_or_file_name, cache_dir=None):

--- a/pyaerocom/io/helpers.py
+++ b/pyaerocom/io/helpers.py
@@ -11,7 +11,9 @@ from time import time
 
 from pyaerocom import const
 from pyaerocom.io import AerocomBrowser
-from pyaerocom.exceptions import (VarNotAvailableError, VariableDefinitionError)
+from pyaerocom.exceptions import (VarNotAvailableError,
+                                  VariableDefinitionError,
+                                  )
 
 #: country code file name
 #: will be prepended with the path later on
@@ -231,13 +233,13 @@ def get_obsnetwork_dir(obs_id):
         if directory does not exist
     """
     if not obs_id in const.OBSLOCS_UNGRIDDED:
-        raise ValueError("Observation network ID {} does not exist"
-                         .format(obs_id))
+        raise ValueError(f"Observation network ID {obs_id} does not exist")
 
     data_dir = const.OBSLOCS_UNGRIDDED[obs_id]
     if not os.path.exists(data_dir):
-        raise IOError("Data directory {} of observation network {} does not "
-                      "exists".format(data_dir, obs_id))
+        raise FileNotFoundError(
+            f'Data directory {data_dir} for observation network {obs_id} does '
+            f'not exist')
     return data_dir
 
 def save_dict_json(d, fp, ignore_nan=True, indent=None):

--- a/pyaerocom/io/iris_io.py
+++ b/pyaerocom/io/iris_io.py
@@ -12,7 +12,13 @@ reading of Cubes, and some methods to perform quality checks of the data, e.g.
 import cf_units
 from datetime import datetime
 import iris
-from iris.experimental.equalise_cubes import equalise_attributes
+try:
+    # as of iris version 3
+    from iris.util  import equalise_attributes
+except ImportError:
+    # old iris version installed
+    from iris.experimental.equalise_cubes import equalise_attributes
+
 from numpy import datetime64, asarray, arange
 import os
 import pandas as pd
@@ -645,10 +651,3 @@ def concatenate_iris_cubes(cubes, error_on_mismatch=True):
 
     return cubes_concat[0]
 
-if __name__== "__main__":
-    import pyaerocom as pya
-
-    r = pya.io.ReadGridded('BCC-CUACE_HIST')
-
-    d = r.read_var('zg')
-    print(d)

--- a/pyaerocom/io/read_aeolus_l2a_data.py
+++ b/pyaerocom/io/read_aeolus_l2a_data.py
@@ -96,10 +96,12 @@ class ReadL2Data(ReadL2DataBase):
     PROVIDES_VARIABLES = [_EC355NAME, _BS355NAME, _LODNAME, _SRNAME, _QANAME]
 
     GLOBAL_ATTRIBUTES = {}
-    DATASET_PATH = '/lustre/storeB/project/fou/kl/admaeolus/data.rev.TD01/download/'
 
-    def __init__(self, dataset_to_read=None, index_pointer=0, loglevel=logging.INFO, verbose=False):
-        super(ReadL2Data, self).__init__(dataset_to_read)
+    data_dir = '/lustre/storeB/project/fou/kl/admaeolus/data.rev.TD01/download/'
+
+    def __init__(self, data_id=None, index_pointer=0, loglevel=logging.INFO,
+                 verbose=False):
+        super(ReadL2Data, self).__init__(data_id)
         self.verbose = verbose
         self.metadata = {}
         self.data = []
@@ -927,7 +929,7 @@ class ReadL2Data(ReadL2DataBase):
             pattern = self._FILEMASK
 
         if basedir is None:
-            basedir = self.DATASET_PATH
+            basedir = self.data_dir
 
         self.logger.info('searching for data files at {}. This might take a while...'.format(basedir))
         files = glob.glob(os.path.join(basedir, '**',

--- a/pyaerocom/io/read_aeronet_invv2.py
+++ b/pyaerocom/io/read_aeronet_invv2.py
@@ -44,11 +44,10 @@ from pyaerocom.stationdata import StationData
 class ReadAeronetInvV2(ReadAeronetBase):
     """Interface for reading Aeronet inversion V2 Level 1.5 and 2.0 data
 
-    Parameters
-    ----------
-    dataset_to_read
-        string specifying either of the supported datasets that are defined
-        in ``SUPPORTED_DATASETS``
+    Note
+    ----
+    Maintenance for AERONET version 2 data is deprecated since pyaerocom
+    version 0.11.0. Please use version 3 data and associated pyaerocom readers.
     """
     #: Mask for identifying datafiles
     _FILEMASK = '*.dubovikday'
@@ -67,11 +66,6 @@ class ReadAeronetInvV2(ReadAeronetBase):
     #: that are provided in a defined temporal resolution
     TS_TYPES = {const.AERONET_INV_V2L2_DAILY_NAME   :   'daily',
                 const.AERONET_INV_V2L15_DAILY_NAME  :   'daily'}
-
-    #: Mapping for dataset location for different data levels that can be
-    #: read with this interface (can be used when creating the object)
-    DATA_LEVELS = {2.0      :   SUPPORTED_DATASETS[0],
-                   1.5      :   SUPPORTED_DATASETS[1]}
 
     #: default variables for read method
     DEFAULT_VARS = ['ssa675aer','ssa440aer', 'ssa870aer', 'ssa1020aer',
@@ -138,29 +132,6 @@ class ReadAeronetInvV2(ReadAeronetBase):
     #: by auxiliary variables on class init, for details see __init__ method of
     #: base class ReadUngriddedBase)
     PROVIDES_VARIABLES = list(VAR_NAMES_FILE.keys())
-
-    def __init__(self, dataset_to_read=None, level=None):
-        super(ReadAeronetInvV2, self).__init__(dataset_to_read)
-        if level is not None:
-            self.change_data_level(level)
-
-    def change_data_level(self, level):
-        """Change level of Inversion data
-
-        Parameters
-        ----------
-        level :obj:`float` or :obj:`int`,
-            data level (choose from 1.5 or 2)
-
-        Raises
-        ------
-        ValueError
-            if input level is not available
-        """
-        if not level in self.DATA_LEVELS:
-            raise ValueError('Invalid input for level, please choose '
-                             'from {}'.format(self.DATA_LEVELS.keys()))
-        super(ReadAeronetInvV2, self).__init__(self.DATA_LEVELS[level])
 
     def read_file(self, filename, vars_to_retrieve=None,
                   vars_as_series=False):

--- a/pyaerocom/io/read_aeronet_invv3.py
+++ b/pyaerocom/io/read_aeronet_invv3.py
@@ -46,7 +46,7 @@ class ReadAeronetInvV3(ReadAeronetBase):
 
     Parameters
     ----------
-    dataset_to_read
+    data_id
         string specifying either of the supported datasets that are defined
         in ``SUPPORTED_DATASETS``
     """
@@ -67,11 +67,6 @@ class ReadAeronetInvV3(ReadAeronetBase):
     #: that are provided in a defined temporal resolution
     TS_TYPES = {const.AERONET_INV_V3L15_DAILY_NAME   :   'daily',
                 const.AERONET_INV_V3L2_DAILY_NAME    :   'daily'}
-
-    #: Mapping for dataset location for different data levels that can be
-    #: read with this interface (can be used when creating the object)
-    DATA_LEVELS = {2.0      :   SUPPORTED_DATASETS[0],
-                   1.5      :   SUPPORTED_DATASETS[1]}
 
     #: default variables for read method
     DEFAULT_VARS = ['abs550aer',
@@ -118,29 +113,6 @@ class ReadAeronetInvV3(ReadAeronetBase):
     #: by auxiliary variables on class init, for details see __init__ method of
     #: base class ReadUngriddedBase)
     PROVIDES_VARIABLES = list(VAR_NAMES_FILE.keys())
-
-    def __init__(self, dataset_to_read=None, level=None):
-        super(ReadAeronetInvV3, self).__init__(dataset_to_read)
-        if level is not None:
-            self.change_data_level(level)
-
-    def change_data_level(self, level):
-        """Change level of Inversion data
-
-        Parameters
-        ----------
-        level :obj:`float` or :obj:`int`,
-            data level (choose from 1.5 or 2)
-
-        Raises
-        ------
-        ValueError
-            if input level is not available
-        """
-        if not level in self.DATA_LEVELS:
-            raise ValueError('Invalid input for level, please choose '
-                             'from {}'.format(self.DATA_LEVELS.keys()))
-        super(ReadAeronetInvV3, self).__init__(self.DATA_LEVELS[level])
 
     def read_file(self, filename, vars_to_retrieve=None,
                   vars_as_series=False):

--- a/pyaerocom/io/read_aeronet_sdav2.py
+++ b/pyaerocom/io/read_aeronet_sdav2.py
@@ -46,16 +46,10 @@ from pyaerocom.io.readaeronetbase import ReadAeronetBase
 class ReadAeronetSdaV2(ReadAeronetBase):
     """Interface for reading Aeronet Sun V2 Level 2 data
 
-    Todo
+    Note
     ----
-    Check if also level 1.5 works and include
-
-    Parameters
-    ----------
-    dataset_to_read
-        string specifying either of the supported datasets that are defined
-        in ``SUPPORTED_DATASETS``.
-
+    Maintenance for AERONET version 2 data is deprecated since pyaerocom
+    version 0.11.0. Please use version 3 data and associated pyaerocom readers.
     """
     #: Mask for identifying datafiles
     _FILEMASK = '*.ONEILL_20'

--- a/pyaerocom/io/read_aeronet_sunv2.py
+++ b/pyaerocom/io/read_aeronet_sunv2.py
@@ -44,19 +44,10 @@ from pyaerocom.stationdata import StationData
 class ReadAeronetSunV2(ReadAeronetBase):
     """Interface for reading Aeronet direct sun version 2 Level 2.0 data
 
-    .. seealso::
-
-        Base classes :class:`ReadAeronetBase` and :class:`ReadUngriddedBase`
-
-    Todo
+    Note
     ----
-    Check level 1.5 data and include
-
-    Parameters
-    ----------
-    dataset_to_read
-        string specifying either of the supported datasets that are defined
-        in ``SUPPORTED_DATASETS``.
+    Maintenance for AERONET version 2 data is deprecated since pyaerocom
+    version 0.11.0. Please use version 3 data and associated pyaerocom readers.
     """
     #: Mask for identifying datafiles
     _FILEMASK = '*.lev20'

--- a/pyaerocom/io/read_airnow.py
+++ b/pyaerocom/io/read_airnow.py
@@ -133,9 +133,9 @@ class ReadAirNow(ReadUngriddedBase):
     #: file containing station metadata
     STAT_METADATA_FILENAME = 'allStations_20191224.csv'
 
-    def __init__(self, dataset_to_read=None, data_dir=None):
-        super(ReadAirNow, self).__init__(dataset_to_read=dataset_to_read,
-                                         dataset_path=data_dir)
+    def __init__(self, data_id=None, data_dir=None):
+        super(ReadAirNow, self).__init__(data_id=data_id,
+                                         data_dir=data_dir)
         self.make_datetime64_array = np.vectorize(self._date_time_str_to_datetime64)
 
     def _date_time_str_to_datetime64(self, date, time):
@@ -193,7 +193,7 @@ class ReadAirNow(ReadUngriddedBase):
             metadata dataframe
 
         """
-        fn = os.path.join(self.DATASET_PATH, self.STAT_METADATA_FILENAME)
+        fn = os.path.join(self.data_dir, self.STAT_METADATA_FILENAME)
         cfg = pd.read_csv(fn,sep=',', converters={'aqsid': lambda x: str(x)})
         return cfg
 
@@ -259,7 +259,7 @@ class ReadAirNow(ReadUngriddedBase):
         -------
         list
         """
-        basepath = self.DATASET_PATH
+        basepath = self.data_dir
         pattern = f'{basepath}{self._FILEMASK}'
         files = sorted(glob(pattern))
         return files

--- a/pyaerocom/io/read_earlinet.py
+++ b/pyaerocom/io/read_earlinet.py
@@ -145,9 +145,10 @@ class ReadEarlinet(ReadUngriddedBase):
 # =============================================================================
     EXCLUDE_CASES = ['cirrus.txt']
 
-    def __init__(self, dataset_to_read=None):
+    def __init__(self, data_id=None, data_dir=None):
         # initiate base class
-        super(ReadEarlinet, self).__init__(dataset_to_read)
+        super(ReadEarlinet, self).__init__(data_id=data_id,
+                                           data_dir=data_dir)
         # make sure everything is properly set up
         if not all([x in self.VAR_PATTERNS_FILE for x in self.PROVIDES_VARIABLES]):
             raise AttributeError("Please specify file search masks in "
@@ -587,7 +588,7 @@ class ReadEarlinet(ReadUngriddedBase):
         """Get list of filenames that are supposed to be ignored"""
         exclude = []
         import glob
-        files = glob.glob('{}/EXCLUDE/*.txt'.format(self.DATASET_PATH))
+        files = glob.glob('{}/EXCLUDE/*.txt'.format(self.data_dir))
         for i, file in enumerate(files):
             if not os.path.basename(file) in self.EXCLUDE_CASES:
                 continue
@@ -662,7 +663,7 @@ class ReadEarlinet(ReadUngriddedBase):
             patterns.append(_pattern)
 
         matches = []
-        for root, dirnames, files in os.walk(self.DATASET_PATH):
+        for root, dirnames, files in os.walk(self.data_dir):
             paths = [os.path.join(root, f) for f in files]
             for _pattern in patterns:
                 for path in paths:
@@ -687,7 +688,7 @@ if __name__=="__main__":
     plt.close('all')
     r = ReadEarlinet()
 
-    print(r.DATASET_PATH)
+    print(r.data_dir)
     files = r.get_file_list(['ec532aer', 'bsc532aer'])
     data = r.read(['ec532aer', 'bsc532aer'], files=files[:20])
 

--- a/pyaerocom/io/read_ebas.py
+++ b/pyaerocom/io/read_ebas.py
@@ -159,7 +159,7 @@ class ReadEbas(ReadUngriddedBase):
 
     Parameters
     ----------
-    dataset_to_read
+    data_id
         string specifying either of the supported datasets that are defined
         in ``SUPPORTED_DATASETS``
     data_dir : str
@@ -181,7 +181,7 @@ class ReadEbas(ReadUngriddedBase):
     DATA_ID = const.EBAS_MULTICOLUMN_NAME
 
     #: Name of subdirectory containing data files (relative to
-    #: DATASET_PATH)
+    #: :attr:`data_dir`)
     FILE_SUBDIR_NAME = 'data'
 
     #: Name of sqlite database file
@@ -282,9 +282,9 @@ class ReadEbas(ReadUngriddedBase):
     #: List of variables that are provided by this dataset (will be extended
     #: by auxiliary variables on class init, for details see __init__ method of
     #: base class ReadUngriddedBase)
-    def __init__(self, dataset_to_read=None, data_dir=None):
+    def __init__(self, data_id=None, data_dir=None):
 
-        super(ReadEbas, self).__init__(dataset_to_read, dataset_path=data_dir)
+        super(ReadEbas, self).__init__(data_id=data_id, data_dir=data_dir)
 
         self._opts = {'default' : ReadEbasOptions()}
 
@@ -327,7 +327,7 @@ class ReadEbas(ReadUngriddedBase):
         """Directory containing EBAS NASA Ames files"""
         if self._file_dir is not None:
             return self._file_dir
-        return os.path.join(self.DATASET_PATH, self.FILE_SUBDIR_NAME)
+        return os.path.join(self.data_dir, self.FILE_SUBDIR_NAME)
 
     @file_dir.setter
     def file_dir(self, val):
@@ -366,7 +366,7 @@ class ReadEbas(ReadUngriddedBase):
     def sqlite_database_file(self):
         """Path to EBAS SQL database"""
         dbname = self.SQL_DB_NAME
-        loc_remote = os.path.join(self.DATASET_PATH, dbname)
+        loc_remote = os.path.join(self.data_dir, dbname)
         if self.data_id in self.CACHE_SQLITE_FILE and const.EBAS_DB_LOCAL_CACHE:
             loc_local = os.path.join(const.CACHEDIR, dbname)
             return _check_ebas_db_local_vs_remote(loc_remote, loc_local)

--- a/pyaerocom/io/read_eea_aqerep_base.py
+++ b/pyaerocom/io/read_eea_aqerep_base.py
@@ -201,7 +201,7 @@ class ReadEEAAQEREPBase(ReadUngriddedBase):
         }
 
     def __init__(self, data_dir=None):
-        super(ReadEEAAQEREPBase, self).__init__(None, dataset_path=data_dir)
+        super(ReadEEAAQEREPBase, self).__init__(None, data_dir=data_dir)
         self._metadata = None
 
     @property
@@ -377,7 +377,7 @@ class ReadEEAAQEREPBase(ReadUngriddedBase):
         """
 
         if filename is None:
-            filename = os.path.join(self.DATASET_PATH, self.DEFAULT_METADATA_FILE)
+            filename = os.path.join(self.data_dir, self.DEFAULT_METADATA_FILE)
         self.logger.warning("Reading file {}".format(filename))
 
         struct_data = {}
@@ -448,15 +448,15 @@ class ReadEEAAQEREPBase(ReadUngriddedBase):
             const.print_log.warning('using default pattern *.* for file search')
             pattern = '*.*'
         self.logger.info('Fetching data files. This might take a while...')
-        fp = os.path.join(self.DATASET_PATH, pattern)
+        fp = os.path.join(self.data_dir, pattern)
         files = sorted(glob.glob(fp, recursive=True))
         if not len(files) > 0:
-            all_str = list_to_shortstr(os.listdir(self.DATASET_PATH))
+            all_str = list_to_shortstr(os.listdir(self.data_dir))
             raise DataSourceError('No files could be detected matching file '
                                   'mask {} in dataset {}, files in folder {}:\n'
                                   'Files in folder:{}'.format(pattern,
-                                                              self.dataset_to_read,
-                                                              self.DATASET_PATH,
+                                                              self.data_id,
+                                                              self.data_dir,
                                                               all_str))
         self.files = files
         return files
@@ -529,7 +529,7 @@ class ReadEEAAQEREPBase(ReadUngriddedBase):
             last_file = len(files)
 
         if metadatafile is None:
-            metadatafile = os.path.join(self.DATASET_PATH, self.DEFAULT_METADATA_FILE)
+            metadatafile = os.path.join(self.data_dir, self.DEFAULT_METADATA_FILE)
 
         files = files[first_file:last_file]
 

--- a/pyaerocom/io/read_eea_aqerep_base.py
+++ b/pyaerocom/io/read_eea_aqerep_base.py
@@ -200,8 +200,9 @@ class ReadEEAAQEREPBase(ReadUngriddedBase):
         'vmrno2': NotImplementedError(),
         }
 
-    def __init__(self, data_dir=None):
-        super(ReadEEAAQEREPBase, self).__init__(None, data_dir=data_dir)
+    def __init__(self, data_id=None, data_dir=None):
+        super(ReadEEAAQEREPBase, self).__init__(data_id=data_id,
+                                                data_dir=data_dir)
         self._metadata = None
 
     @property

--- a/pyaerocom/io/read_ghost.py
+++ b/pyaerocom/io/read_ghost.py
@@ -236,7 +236,7 @@ class ReadGhost(ReadUngriddedBase):
         try:
             return self.TS_TYPES[self.data_id]
         except KeyError:
-            return self._ts_type_from_DATASET_PATH()
+            return self._ts_type_from_data_dir()
 
     def get_file_list(self, vars_to_read=None, pattern=None):
         """
@@ -275,7 +275,7 @@ class ReadGhost(ReadUngriddedBase):
                 # AeroCom variable name or GHOST variable name
                 var = self.VARNAMES_DATA[var]
 
-            _dir = os.path.join(self.DATASET_PATH, var)
+            _dir = os.path.join(self.data_dir, var)
             _files = glob.glob('{}/{}'.format(_dir, pattern))
             if len(_files) == 0:
                 raise DataSourceError(f'Could not find any data files for {var}')
@@ -318,9 +318,9 @@ class ReadGhost(ReadUngriddedBase):
             return True
         return False
 
-    def _ts_type_from_DATASET_PATH(self):
+    def _ts_type_from_data_dir(self):
         try:
-            freq = str(TsType(os.path.basename(self.DATASET_PATH)))
+            freq = str(TsType(os.path.basename(self.data_dir)))
         except Exception as e:
             freq = 'undefined'
         self.TS_TYPES[self.data_id] = freq

--- a/pyaerocom/io/read_marcopolo.py
+++ b/pyaerocom/io/read_marcopolo.py
@@ -146,9 +146,9 @@ class ReadMarcoPolo(ReadUngriddedBase):
 
     STAT_METADATA_FILENAME = 'station_info.xlsx'
 
-    def __init__(self, dataset_to_read=None, data_dir=None):
-        super(ReadMarcoPolo, self).__init__(dataset_to_read=dataset_to_read,
-                                         dataset_path=data_dir)
+    def __init__(self, data_id=None, data_dir=None):
+        super(ReadMarcoPolo, self).__init__(data_id=data_id,
+                                            data_dir=data_dir)
 
         try:
             import openpyxl
@@ -159,7 +159,7 @@ class ReadMarcoPolo(ReadUngriddedBase):
                 'Please install openpyxl via conda or pip.')
 
     def _read_metadata_file(self):
-        fn = os.path.join(self.DATASET_PATH, self.STAT_METADATA_FILENAME)
+        fn = os.path.join(self.data_dir, self.STAT_METADATA_FILENAME)
         cfg = pd.read_excel(fn,engine='openpyxl')
         return cfg
 

--- a/pyaerocom/io/read_sentinel5p_data.py
+++ b/pyaerocom/io/read_sentinel5p_data.py
@@ -55,7 +55,9 @@ class ReadL2Data(ReadL2DataBase):
     __version__ = "0.02"
     DATA_ID = const.SENTINEL5P_NAME
 
-    DATASET_PATH = '/lustre/storeB/project/fou/kl/vals5p/download'
+    # jgliss commented out DATASET_PATH on 22.4.21 since it is not used
+    # Note that DATASET_PATH is deprecated as of v0.11.0, use data_dir
+    # DATASET_PATH = '/lustre/storeB/project/fou/kl/vals5p/download'
     # Flag if the dataset contains all years or not
     DATASET_IS_YEARLY = False
 
@@ -70,9 +72,10 @@ class ReadL2Data(ReadL2DataBase):
 
     TS_TYPE = 'undefined'
 
-    def __init__(self, dataset_to_read=None, index_pointer=0, loglevel=logging.INFO, verbose=False,
+    def __init__(self, data_id=None, index_pointer=0,
+                 loglevel=logging.INFO, verbose=False,
                  read_averaging_kernel=True):
-        super(ReadL2Data, self).__init__(dataset_to_read)
+        super(ReadL2Data, self).__init__(data_id)
         self.verbose = verbose
         self.metadata = {}
         self.data = None

--- a/pyaerocom/io/readaeronetbase.py
+++ b/pyaerocom/io/readaeronetbase.py
@@ -62,8 +62,9 @@ class ReadAeronetBase(ReadUngriddedBase):
     UNITS = {}
 
     IGNORE_META_KEYS = ['date', 'time', 'day_of_year']
-    def __init__(self, dataset_to_read=None):
-        super(ReadAeronetBase, self).__init__(dataset_to_read)
+    def __init__(self, data_id=None, data_dir=None):
+        super(ReadAeronetBase, self).__init__(data_id=data_id,
+                                              data_dir=data_dir)
 
         # dictionary that contains information about the file columns
         # is written in method _update_col_index
@@ -485,16 +486,25 @@ if __name__=="__main__":
     class ReadUngriddedImplementationExample(ReadUngriddedBase):
         _FILEMASK = ".txt"
         DATA_ID = "Blaaa"
-        SUPPORTED_DATASETS = ['Blaaa', 'Blub']
         __version__ = "0.01"
         PROVIDES_VARIABLES = ["od550aer"]
+        REVISION_FILE = const.REVISION_FILE
 
-        def __init__(self, dataset_to_read=None):
-            if dataset_to_read is not None:
-                self.DATA_ID = dataset_to_read
+
+        def __init__(self, data_id=None, data_dir=None):
+            super(ReadUngriddedImplementationExample, self).__init__(
+                    data_id, data_dir)
 
         @property
-        def col_index(self):
+        def DEFAULT_VARS(self):
+            return self.PROVIDES_VARIABLES
+
+        @property
+        def SUPPORTED_DATASETS(self):
+            return [self.DATA_ID]
+
+        @property
+        def TS_TYPE(self):
             raise NotImplementedError
 
         def read(self):
@@ -503,5 +513,5 @@ if __name__=="__main__":
         def read_file(self):
             raise NotImplementedError
 
-    c = ReadUngriddedImplementationExample(dataset_to_read='AeronetSunV2Lev1.5.daily')
-    print(c.DATASET_PATH)
+    c = ReadUngriddedImplementationExample()
+

--- a/pyaerocom/io/readsatellitel2base.py
+++ b/pyaerocom/io/readsatellitel2base.py
@@ -52,7 +52,9 @@ class ReadL2DataBase(ReadUngriddedBase):
     __version__ = "0.01"
     DATA_ID = ''
 
-    DATASET_PATH = ''
+    # jgliss commented out DATASET_PATH on 22.4.21 since it is not used
+    # Note that DATASET_PATH is deprecated as of v0.11.0, use data_dir
+    #DATASET_PATH = ''
     # Flag if the dataset contains all years or not
     DATASET_IS_YEARLY = False
 
@@ -63,8 +65,9 @@ class ReadL2DataBase(ReadUngriddedBase):
 
     __baseversion__ = '0.01_' + ReadUngriddedBase.__baseversion__
 
-    def __init__(self, dataset_to_read=None, index_pointer=0, loglevel=logging.INFO, verbose=False):
-        super(ReadL2DataBase, self).__init__(dataset_to_read)
+    def __init__(self, data_id=None, index_pointer=0, loglevel=logging.INFO,
+                 verbose=False):
+        super(ReadL2DataBase, self).__init__(data_id)
         self.verbose = verbose
         self.metadata = {}
         self.data = None

--- a/pyaerocom/io/readungridded.py
+++ b/pyaerocom/io/readungridded.py
@@ -750,7 +750,7 @@ class ReadUngridded(object):
 
         else:
             # check if variable can be read from a dataset on disk
-            _oreader = self.get_reader(obs_id)
+            _oreader = self.get_lowlevel_reader(obs_id)
             for var in varlist_aerocom(vars_desired):
                 if _oreader.var_supported(var):
                     obs_vars.append(var)
@@ -759,7 +759,7 @@ class ReadUngridded(object):
     def __str__(self):
         s=''
         for ds in self.data_ids:
-            s += '\n{}'.format(self.get_reader(ds))
+            s += '\n{}'.format(self.self.get_lowlevel_reader(ds))
         return s
 
 if __name__=="__main__":

--- a/pyaerocom/io/test/test_read_aasetal.py
+++ b/pyaerocom/io/test/test_read_aasetal.py
@@ -57,7 +57,7 @@ def test__get_time_stamps():
 def test_reader():
     reader = ReadAasEtal(DATA_ID)
     assert reader.data_id == DATA_ID
-    assert reader.DATASET_PATH == DATA_DIR()
+    assert reader.data_dir == DATA_DIR()
     assert reader.PROVIDES_VARIABLES == ['concso2', 'concso4', 'pr',
                                          'wetso4', 'concso4pr']
     filenames = [os.path.basename(x) for x in reader.get_file_list()]

--- a/pyaerocom/io/test/test_read_airnow.py
+++ b/pyaerocom/io/test/test_read_airnow.py
@@ -239,8 +239,8 @@ class TestReadAirNow(object):
                                 station_id='160550006')
 
 
-    def test_DATASET_PATH_EXISTS(self, reader):
-        assert os.path.exists(reader.DATASET_PATH)
+    def test_data_dir_exists(self, reader):
+        assert os.path.exists(reader.data_dir)
 
     def test_get_file_list(self, reader):
         files = reader.get_file_list()

--- a/pyaerocom/io/test/test_read_ghost.py
+++ b/pyaerocom/io/test/test_read_ghost.py
@@ -100,8 +100,8 @@ class TestReadGhost(object):
         assert len(files) == filenum
         assert os.path.basename(files[-1]) == lastfilename
 
-    def test__ts_type_from_DATASET_PATH(self):
-        assert self.get_reader('ghost_eea_daily')._ts_type_from_DATASET_PATH() == 'daily'
+    def test__ts_type_from_data_dir(self):
+        assert self.get_reader('ghost_eea_daily')._ts_type_from_data_dir() == 'daily'
 
     @pytest.mark.parametrize('fixture_name,val', [
             ('ghost_eea_daily', 'daily'),

--- a/pyaerocom/io/test/test_readungriddedbase.py
+++ b/pyaerocom/io/test/test_readungriddedbase.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+import pytest
+from pyaerocom import const
+from pyaerocom.conftest import does_not_raise_exception
+from pyaerocom.io.readungriddedbase import ReadUngriddedBase
+
+class DummyReader(ReadUngriddedBase):
+    _FILEMASK = ".txt"
+    DATA_ID = "Blaaa"
+    __version__ = "0.01"
+    PROVIDES_VARIABLES = ["od550aer"]
+    REVISION_FILE = const.REVISION_FILE
+
+
+    def __init__(self, data_id=None, data_dir=None):
+        super(DummyReader, self).__init__(
+                data_id, data_dir)
+
+    @property
+    def DEFAULT_VARS(self):
+        return self.PROVIDES_VARIABLES
+
+    @property
+    def SUPPORTED_DATASETS(self):
+        return [self.DATA_ID]
+
+    @property
+    def TS_TYPE(self):
+        raise NotImplementedError
+
+    def read(self):
+        raise NotImplementedError
+
+    def read_file(self):
+        raise NotImplementedError
+
+@pytest.fixture(scope='module')
+def dummy_reader():
+    return DummyReader()
+
+def test___init__template():
+    with pytest.raises(TypeError):
+        ReadUngriddedBase()
+
+def test___init__dummy():
+    dummy = DummyReader()
+    assert dummy.data_id == 'Blaaa'
+
+@pytest.mark.parametrize('key,val,raises', [
+    ('_FILEMASK', '.txt', does_not_raise_exception()),
+    ('TS_TYPE', None, pytest.raises(NotImplementedError)),
+    ('__version__', '0.01', does_not_raise_exception()),
+    ('DATA_ID', 'Blaaa', does_not_raise_exception()),
+    ('SUPPORTED_DATASETS', ['Blaaa'], does_not_raise_exception()),
+    ('PROVIDES_VARIABLES', ['od550aer'], does_not_raise_exception()),
+    ('DEFAULT_VARS', ['od550aer'], does_not_raise_exception()),
+    ('data_dir', None, pytest.raises(ValueError)),
+    ('data_id', 'Blaaa', does_not_raise_exception()),
+    ('REVISION_FILE', 'Revision.txt', does_not_raise_exception()),
+    ('AUX_VARS', [], does_not_raise_exception()),
+    ('data_id', 'Blaaa', does_not_raise_exception()),
+    ])
+def test_DummyReader_attrs(dummy_reader, key, val, raises):
+    with raises:
+        assert getattr(dummy_reader, key) == val
+
+if __name__ == '__main__':
+    import sys
+    pytest.main(sys.argv)
+

--- a/pyaerocom/test/test_utils.py
+++ b/pyaerocom/test/test_utils.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import os
+import pytest
+from pyaerocom.conftest import does_not_raise_exception, testdata_unavail
+from pyaerocom import utils
+
+def test_print_file(tmpdir):
+    fp = os.path.join(tmpdir, 'file.txt')
+    with pytest.raises(IOError):
+        utils.print_file(fp)
+    with open(fp, 'w') as f:
+        f.write('Blaaaa\nBlub\n')
+    utils.print_file(fp)
+
+@testdata_unavail
+@pytest.mark.parametrize('kwargs,raises,tabshape', [
+    ({}, pytest.raises(TypeError), None),
+    ({'model_ids' : 'TM5-met2010_CTRL-TEST',
+      'vars_or_var_patterns' : 'abs550*'}, does_not_raise_exception(), (2,11)),
+    ({'model_ids' : 'TM5-met2010_CTRL-TEST',
+      'vars_or_var_patterns' : '*550*'}, does_not_raise_exception(), (4,11)),
+    ({'model_ids' : 'TM5-met2010_CTRL-TEST',
+      'vars_or_var_patterns' : 'od550aer',
+      'read_data' : True}, does_not_raise_exception(), (2,11))
+    ])
+def test_create_varinfo_table(kwargs, raises, tabshape):
+    with raises:
+        df =  utils.create_varinfo_table(**kwargs)
+        assert df.shape == tabshape
+
+
+
+
+if __name__=='__main__':
+    import sys
+    pytest.main(sys.argv)

--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -3075,7 +3075,8 @@ if __name__ == "__main__":
     GHOST_EEA_LOCAL = os.path.join(OBS_LOCAL, 'GHOST/data/EEA_AQ_eReporting/daily')
 
     data = pya.io.ReadUngridded('GHOST.EEA.daily',
-                                data_dir=GHOST_EEA_LOCAL).read(vars_to_retrieve='vmro3')
+                                data_dirs=GHOST_EEA_LOCAL).read(
+                                    vars_to_retrieve='vmro3')
 
 
 

--- a/pyaerocom/utils.py
+++ b/pyaerocom/utils.py
@@ -111,7 +111,6 @@ def create_varinfo_table(model_ids, vars_or_var_patterns, read_data=False,
             failed.append(model)
 
     df = pd.DataFrame(result, columns=header)
-    #df.set_index(['Var'], inplace=True)
     if sort_by_cols:
         df.sort_values(sort_by_cols, inplace=True)
     return df

--- a/pyaerocom/web/aerocom_evaluation.py
+++ b/pyaerocom/web/aerocom_evaluation.py
@@ -1840,7 +1840,7 @@ class AerocomEvaluation(object):
             if os.path.normpath(coldir).endswith(chk) and os.path.exists(coldir):
                 const.print_log.info(f'Deleting everything under {coldir}')
                 shutil.rmtree(coldir)
-        self.update_menu()
+        self.update_menu(delete_mode=True)
 
     def _clean_modelmap_files(self):
         all_vars = self.all_modelmap_vars

--- a/pyaerocom/web/helpers_evaluation_iface.py
+++ b/pyaerocom/web/helpers_evaluation_iface.py
@@ -346,7 +346,8 @@ def _check_load_current_menu(config, ignore_experiments):
                                 .format(config.exp_id))
     return menu
 
-def update_menu_evaluation_iface(config, ignore_experiments=None):
+def update_menu_evaluation_iface(config, ignore_experiments=None,
+                                 delete_mode=False):
     """Update menu for Aerocom Evaluation interface
 
     The menu.json file is created based on the available json map files in the
@@ -359,12 +360,18 @@ def update_menu_evaluation_iface(config, ignore_experiments=None):
     ignore_experiments : list, optional
         list containing experiment IDs that may be in the current menu.json
         file and that are supposed to be removed from it.
-    """
+    delete_mode : bool
+        if True, then no attempts are being made to find json files for the
+        experiment specified in `config`.
 
-    try:
-        avail = _get_available_results_dict(config)
-    except FileNotFoundError:
-        avail = {}
+    """
+    avail = {}
+    if not delete_mode:
+        try:
+            avail.update(**_get_available_results_dict(config))
+        except FileNotFoundError:
+            pass
+
 
     avail = _sort_menu_entries(avail, config)
 


### PR DESCRIPTION
This turned out to be a larger PR than expected, but here it is, harmonised largely the API of ungridded reading with the gridded reading API.

**NOTE**: this will likely break old scripts and has some major implications on the ungridded API.


Major renaming includes:

In lowlevel ungridded readers: 

- `DATASET_PATH` deprecated, use `data_dir`
- `dataset_path` renamed to `data_dir`
- `dataset_to_read` deprecated, use `data_id`

In `ReadUngridded`

- `data_dir` renamed to `data_dirs`
- `datasets_to_read` renamed to `data_ids`