### PR TITLE
made EEA AQeRep.v2 reading more robust; added possibility to read gzipped files

### DIFF
--- a/pyaerocom/io/read_eea_aqerep_base.py
+++ b/pyaerocom/io/read_eea_aqerep_base.py
@@ -69,7 +69,7 @@ class ReadEEAAQEREPBase(ReadUngriddedBase):
     _FILEMASK = '*.csv'
 
     #: Version log of this class (for caching)
-    __version__ = '0.05'
+    __version__ = '0.06'
 
     #: Column delimiter
     FILE_COL_DELIM = ','

--- a/pyaerocom/io/read_eea_aqerep_v2.py
+++ b/pyaerocom/io/read_eea_aqerep_v2.py
@@ -72,22 +72,22 @@ if __name__ == "__main__":
         r = ReadEEAAQEREP_V2()
         data = r.read_file(filename, 'concpm10')
 
-        filename = '/lustre/storeA/project/aerocom/aerocom1/AEROCOM_OBSDATA/EEA_AQeRep.v2/download/AT/AT_5_48900_2019_timeseries.csv'
+        filename = '/lustre/storeA/project/aerocom/aerocom1/AEROCOM_OBSDATA/EEA_AQeRep.v2/download/AT/AT_5_48900_2019_timeseries.csv.gz'
         r = ReadEEAAQEREP_V2()
         data2 = r.read_file(filename, 'concpm10')
 
 
         import logging
         # limit the data read for testing
-        ReadEEAAQEREP_V2.FILE_MASKS['concso2'] = '**/AT*_1_*_timeseries.csv'
-        ReadEEAAQEREP_V2.FILE_MASKS['concpm10'] = '**/XK*_5_*_timeseries.csv'
-        ReadEEAAQEREP_V2.FILE_MASKS['conco3'] = '**/XK*_7_*_timeseries.csv'
-        ReadEEAAQEREP_V2.FILE_MASKS['vmro3'] = '**/XK*_7_*_timeseries.csv'
-        ReadEEAAQEREP_V2.FILE_MASKS['concno2'] = '**/XK*_8_*_timeseries.csv'
-        ReadEEAAQEREP_V2.FILE_MASKS['concno2'] = '**/AT*_8_*_timeseries.csv'
-        ReadEEAAQEREP_V2.FILE_MASKS['concco'] = '**/AT*_10_*_timeseries.csv'
-        ReadEEAAQEREP_V2.FILE_MASKS['concno'] = '**/AT*_38_*_timeseries.csv'
-        ReadEEAAQEREP_V2.FILE_MASKS['concpm25'] = '**/XK*_6001_*_timeseries.csv'
+        ReadEEAAQEREP_V2.FILE_MASKS['concso2'] = '**/AT*_1_*_timeseries.csv*'
+        ReadEEAAQEREP_V2.FILE_MASKS['concpm10'] = '**/XK*_5_*_timeseries.csv*'
+        ReadEEAAQEREP_V2.FILE_MASKS['conco3'] = '**/XK*_7_*_timeseries.csv*'
+        ReadEEAAQEREP_V2.FILE_MASKS['vmro3'] = '**/XK*_7_*_timeseries.csv*'
+        ReadEEAAQEREP_V2.FILE_MASKS['concno2'] = '**/XK*_8_*_timeseries.csv*'
+        ReadEEAAQEREP_V2.FILE_MASKS['concno2'] = '**/AT*_8_*_timeseries.csv*'
+        ReadEEAAQEREP_V2.FILE_MASKS['concco'] = '**/AT*_10_*_timeseries.csv*'
+        ReadEEAAQEREP_V2.FILE_MASKS['concno'] = '**/AT*_38_*_timeseries.csv*'
+        ReadEEAAQEREP_V2.FILE_MASKS['concpm25'] = '**/XK*_6001_*_timeseries.csv*'
         station_id = {}
         station_id['concso2'] = 'AT31703'
         station_id['concpm10'] = 'XK0001A'

--- a/pyaerocom/io/read_eea_aqerep_v2.py
+++ b/pyaerocom/io/read_eea_aqerep_v2.py
@@ -67,6 +67,16 @@ if __name__ == "__main__":
     username = getpass.getuser()
     if username == 'jang':
         from pyaerocom.io.read_eea_aqerep_v2 import ReadEEAAQEREP_V2
+
+        filename = '/lustre/storeA/project/aerocom/aerocom1/AEROCOM_OBSDATA/EEA_AQeRep.v2/download/AT/AT_5_48881_2019_timeseries.csv.gz'
+        r = ReadEEAAQEREP_V2()
+        data = r.read_file(filename, 'concpm10')
+
+        filename = '/lustre/storeA/project/aerocom/aerocom1/AEROCOM_OBSDATA/EEA_AQeRep.v2/download/AT/AT_5_48900_2019_timeseries.csv'
+        r = ReadEEAAQEREP_V2()
+        data2 = r.read_file(filename, 'concpm10')
+
+
         import logging
         # limit the data read for testing
         ReadEEAAQEREP_V2.FILE_MASKS['concso2'] = '**/AT*_1_*_timeseries.csv'


### PR DESCRIPTION
This pull request addresses the failed reading of incomplete files @hansbrenna discovered (issues #404 and #405) 
I also adds the capability to read compressed csv.gz files instead of just csv files which makes local development easier since the EEA data is quite huge.

To make use of that, one just has to gzip all the files in the data directories.

In case you wonder why I removed the DataSourceError exception: https://github.com/metno/pyaerocom/blob/6612ec6ced010eeba63e96136796c262b397d299/pyaerocom/io/read_eea_aqerep_base.py#L456-L461 It is possible for a country to not provide all variables we might want to read. So this exception is just wrong