### PR TITLE
Fix issue 413

### DIFF
--- a/pyaerocom/aeroval/_lowlev.py
+++ b/pyaerocom/aeroval/_lowlev.py
@@ -8,6 +8,12 @@ Created on Wed Jun  2 11:43:38 2021
 import abc
 
 class EvalEntry(abc.ABC):
+    """
+    Base class for model or obs evaluation entries for AeroVal experiment
+
+    See also :class:`pyaerocom.aeroval.obsentry.ObsEntry` and
+    :class:`pyaerocom.aeroval.modelentry.ModelEntry` for implementations.
+    """
     @abc.abstractmethod
     def get_all_vars(self) -> list:
         """
@@ -20,3 +26,15 @@ class EvalEntry(abc.ABC):
 
         """
         pass
+
+    def has_var(self, var_name):
+        """
+        Check if input variable is defined in entry
+
+        Returns
+        -------
+        bool
+            True if entry has variable available, else False
+
+        """
+        return True if var_name in self.get_all_vars() else False

--- a/pyaerocom/aeroval/collections.py
+++ b/pyaerocom/aeroval/collections.py
@@ -7,6 +7,7 @@ Created on Thu May 27 12:27:47 2021
 """
 from fnmatch import fnmatch
 from pyaerocom._lowlevel_helpers import BrowseDict
+from pyaerocom.exceptions import EntryNotAvailable
 from pyaerocom.aeroval.obsentry import ObsEntry
 from pyaerocom.aeroval.modelentry import ModelEntry
 
@@ -54,7 +55,10 @@ class BaseCollection(BrowseDict):
         KeyError
             if input name is not in this collection
         """
-        return self[key]
+        try:
+            return self[key]
+        except (AttributeError, KeyError):
+            raise EntryNotAvailable(f'no such entry {key}')
 
 
     def get_web_iface_name(self, key):

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -6,7 +6,7 @@ from pyaerocom import const
 from pyaerocom._lowlevel_helpers import (DirLoc, StrType, JSONFile,
                                          TypeValidator, sort_dict_by_name)
 
-from pyaerocom.exceptions import VariableDefinitionError
+from pyaerocom.exceptions import VariableDefinitionError, EntryNotAvailable
 from pyaerocom.aeroval.glob_defaults import (statistics_defaults,
                                              var_ranges_defaults,
                                              var_web_info)
@@ -403,24 +403,30 @@ class ExperimentOutput(ProjectOutput):
         new = {}
         tab = self._get_meta_from_map_files()
         for (obs_name, obs_var, vert_code, mod_name, mod_var) in tab:
-            mcfg = self.cfg.model_cfg.get_entry(mod_name)
-            var = mcfg.get_varname_web(mod_var, obs_var)
-            if not var in new:
-                new[var] = self._init_menu_entry(var)
+            try:
+                mcfg = self.cfg.model_cfg.get_entry(mod_name)
+                var = mcfg.get_varname_web(mod_var, obs_var)
+                if not var in new:
+                    new[var] = self._init_menu_entry(var)
 
-            if not obs_name in new[var]['obs']:
-                new[var]['obs'][obs_name] = {}
+                if not obs_name in new[var]['obs']:
+                    new[var]['obs'][obs_name] = {}
 
-            if not vert_code in new[var]['obs'][obs_name]:
-                new[var]['obs'][obs_name][vert_code] = {}
-            if not mod_name in new[var]['obs'][obs_name][vert_code]:
-                new[var]['obs'][obs_name][vert_code][mod_name] = {}
+                if not vert_code in new[var]['obs'][obs_name]:
+                    new[var]['obs'][obs_name][vert_code] = {}
+                if not mod_name in new[var]['obs'][obs_name][vert_code]:
+                    new[var]['obs'][obs_name][vert_code][mod_name] = {}
 
-            model_id = mcfg['model_id']
-            new[var]['obs'][obs_name][vert_code][mod_name] = {
-                'model_id'  : model_id,
-                'model_var' : mod_var,
-                'obs_var'   : obs_var}
+                model_id = mcfg['model_id']
+                new[var]['obs'][obs_name][vert_code][mod_name] = {
+                    'model_id'  : model_id,
+                    'model_var' : mod_var,
+                    'obs_var'   : obs_var}
+            except EntryNotAvailable:
+                const.print_log.warning(
+                    'No such model available in config: {mod_name}. Likely '
+                    'due to an outdated map file that has been part of this '
+                    'experiment before...')
         return new
 
 

--- a/pyaerocom/exceptions.py
+++ b/pyaerocom/exceptions.py
@@ -80,6 +80,9 @@ class NasaAmesReadError(IOError):
 class EbasFileError(ValueError):
     pass
 
+class EntryNotAvailable(KeyError):
+    pass
+
 class InitialisationError(ValueError):
     pass
 


### PR DESCRIPTION
Small PR that makes sure menu creation for AeroVal experiment does not crash anymore in case there are some outdated map json files lying around in the output folder. The latter can happen if some models or observations are removed in a future version of a config file and have not been cleared yet.