### PR TITLE
Increase flexibility of ColocationSetup attributes 

### DIFF
--- a/pyaerocom/__init__.py
+++ b/pyaerocom/__init__.py
@@ -56,3 +56,6 @@ from .utils import create_varinfo_table
 from .testdata_access import initialise as initialise_testdata
 
 from . import aeroval
+
+# toplevel functions
+from pyaerocom.tools import browse_database

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -1,5 +1,4 @@
 import matplotlib
-matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import cartopy.crs as ccrs
 from matplotlib.axes import Axes
@@ -49,11 +48,10 @@ def griddeddata_to_jsondict(data, lat_res_deg=5, lon_res_deg=5):
         sd['lat'] = lat
         sd['lon'] = lon
         sd['data'] = vals.tolist()
-    plt.close('all')
     return output
 
 def calc_contour_json(data, vmin, vmax, cmap, cmap_bins):
-
+    matplotlib.use('Agg')
     try:
         import geojsoncontour
     except ModuleNotFoundError:

--- a/pyaerocom/colocation_auto.py
+++ b/pyaerocom/colocation_auto.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pandas as pd
 import traceback
 
-from pyaerocom._lowlevel_helpers import (ConstrainedContainer,
+from pyaerocom._lowlevel_helpers import (BrowseDict,
                                          StrWithDefault,
                                          ListOfStrings,
                                          chk_make_subdir)
@@ -27,7 +27,7 @@ from pyaerocom.io.helpers import get_all_supported_ids_ungridded
 from pyaerocom.exceptions import (ColocationError, DataCoverageError,
                                   DeprecationError)
 
-class ColocationSetup(ConstrainedContainer):
+class ColocationSetup(BrowseDict):
     """Setup class for model / obs intercomparison
 
     An instance of this setup class can be used to run a colocation analysis

--- a/tests/test__lowlevel_helpers.py
+++ b/tests/test__lowlevel_helpers.py
@@ -8,11 +8,22 @@ class Constrainer(mod.ConstrainedContainer):
         self.blub='str'
         self.opt = None
 
+class NestedData(mod.NestedContainer):
+    def __init__(self):
+        self.bla=dict(a=1, b=2)
+        self.blub=dict(c=3, d=4)
+        self.d=42
+
 def test_Constrainer():
     cont = Constrainer()
     assert cont.bla == 42
     assert cont.blub == 'str'
     assert cont.opt is None
+
+def test_NestedData():
+    cont = NestedData()
+    assert cont.bla == dict(a=1, b=2)
+    assert cont.blub == dict(c=3, d=4)
 
 @pytest.mark.parametrize('kwargs,raises', [
     (dict(), does_not_raise_exception()),
@@ -26,4 +37,40 @@ def test_ConstrainedContainer_update(kwargs,raises):
         cont.update(**kwargs)
         for key, val in kwargs.items():
             assert cont[key] == val
+
+def test_NestedData_keys_unnested():
+    cont = NestedData()
+    keys = cont.keys_unnested()
+    assert sorted(keys) == ['a', 'b', 'bla', 'blub', 'c', 'd', 'd']
+
+@pytest.mark.parametrize('key,val,raises', [
+    ('a', 1, pytest.raises(KeyError)),
+    ('d', 42, does_not_raise_exception()),
+])
+def test_NestedData___getitem__(key, val, raises):
+    cont = NestedData()
+    with raises:
+        assert cont[key] == val
+
+@pytest.mark.parametrize('kwargs,raises', [
+    (dict(bla=42), does_not_raise_exception()),
+    (dict(a=400), does_not_raise_exception()),
+    (dict(abc=400), pytest.raises(AttributeError)),
+    (dict(d=400), does_not_raise_exception()),
+
+])
+def test_NestedData_update(kwargs,raises):
+    cont = NestedData()
+    keys = cont.keys_unnested()
+    with raises:
+        cont.update(**kwargs)
+        for key, value in kwargs.items():
+            if key in cont.__dict__.keys(): # toplevel entry
+                assert cont[key] == value
+            for val in cont.values():
+                if isinstance(val, dict) and key in val:
+                    assert val[key] == value
+
+
+
 

--- a/tests/test__lowlevel_helpers.py
+++ b/tests/test__lowlevel_helpers.py
@@ -1,0 +1,29 @@
+import pytest
+from pyaerocom import _lowlevel_helpers as mod
+from .conftest import does_not_raise_exception
+
+class Constrainer(mod.ConstrainedContainer):
+    def __init__(self):
+        self.bla=42
+        self.blub='str'
+        self.opt = None
+
+def test_Constrainer():
+    cont = Constrainer()
+    assert cont.bla == 42
+    assert cont.blub == 'str'
+    assert cont.opt is None
+
+@pytest.mark.parametrize('kwargs,raises', [
+    (dict(), does_not_raise_exception()),
+    (dict(bla=400), does_not_raise_exception()),
+    (dict(blaaaa=400), pytest.raises(ValueError)),
+    (dict(bla=45, opt={}), does_not_raise_exception()),
+])
+def test_ConstrainedContainer_update(kwargs,raises):
+    cont = Constrainer()
+    with raises:
+        cont.update(**kwargs)
+        for key, val in kwargs.items():
+            assert cont[key] == val
+

--- a/tests/test__lowlevel_helpers.py
+++ b/tests/test__lowlevel_helpers.py
@@ -50,8 +50,6 @@ def test_invalid_input_err_str():
 def test_check_dir_access(dir,val):
     assert mod.check_dir_access(dir) == val
 
-
-
 def test_Constrainer():
     cont = Constrainer()
     assert cont.bla == 42
@@ -108,6 +106,19 @@ def test_NestedData_update(kwargs,raises):
             for val in cont.values():
                 if isinstance(val, dict) and key in val:
                     assert val[key] == value
+
+@pytest.mark.parametrize('input,pref_list,output_keys,raises', [
+    ({'b':1, 'a':2, 'kl':42}, [], ['a', 'b', 'kl'],does_not_raise_exception()),
+    ({'b':1, 'a':2, 'kl':42}, ['blaaa'], ['a', 'b', 'kl'],does_not_raise_exception()),
+    ({'b':1, 'a':2, 'kl':42}, ['kl'], ['kl', 'a', 'b'],does_not_raise_exception()),
+    ({'b':1, 'a':2, 'kl':42}, ['kl', 'b'], ['kl', 'b', 'a'],does_not_raise_exception()),
+])
+def test_sort_dict_by_name(input,pref_list,output_keys,raises):
+    with raises:
+        sorted = mod.sort_dict_by_name(input,pref_list)
+        assert list(sorted.keys()) == output_keys
+
+
 
 
 

--- a/tests/test_colocation_auto.py
+++ b/tests/test_colocation_auto.py
@@ -52,7 +52,7 @@ def tm5_aero_stp():
 
 @pytest.fixture(scope='function')
 def col():
-    return Colocator(raise_exceptions=True, reanalyze_existing=True)
+    return Colocator(raise_exceptions=True, reanalyse_existing=True)
 
 
 @pytest.mark.parametrize('stp,should_be', [
@@ -78,7 +78,7 @@ def test_add_attr(col):
     col['blub'] = 42
 
     assert col.bla == 'blub'
-    assert not 'blub' in col
+    assert 'blub' in col
 
 
 @pytest.mark.parametrize('ts_type_desired, ts_type, flex, raises', [
@@ -167,10 +167,11 @@ def test_colocator_update_basedir_coldata(tmpdir):
 
 
 @pytest.mark.parametrize('what,raises', [
-    (dict(blaa=42), pytest.raises(KeyError)),
+    (dict(blaa=42), does_not_raise_exception()),
     (dict(obs_id='test', model_id='test'), does_not_raise_exception()),
-    (dict(gridded_reader_id='test'), pytest.raises(ValueError)),
+    (dict(gridded_reader_id='test'), does_not_raise_exception()),
     (dict(gridded_reader_id={'test' : 42}), does_not_raise_exception()),
+    (dict(resample_how={'daily' : {'hourly' : 'max'}}), does_not_raise_exception()),
     ])
 def test_colocator_update(what,raises):
     col = Colocator(raise_exceptions=True)


### PR DESCRIPTION
Inheritance from ConstrainedContainer, in ColocationSetup disables updating attr `resample_how` from str type (default) to dict type (nested). Until a consistent API for resample_how and min_num_obs is defined, the strictness in ColocationSetup wrt to attr. types needs to be removed.