### PR TITLE
Adds only trends statitics if add_trends

### DIFF
--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -8,6 +8,7 @@ from pyaerocom._lowlevel_helpers import (DirLoc, StrType, JSONFile,
 
 from pyaerocom.exceptions import VariableDefinitionError, EntryNotAvailable
 from pyaerocom.aeroval.glob_defaults import (statistics_defaults,
+                                             statistics_trend,
                                              var_ranges_defaults,
                                              var_web_info)
 from pyaerocom.aeroval.helpers import read_json, write_json
@@ -355,6 +356,8 @@ class ExperimentOutput(ProjectOutput):
 
     def _create_statistics_json(self):
         stats_info = statistics_defaults
+        if self.cfg.statistics_opts.add_trends:
+            stats_info = dict(statistics_defaults.items() + statistics_trend.items())
         write_json(stats_info, self.statistics_file, indent=4)
 
 

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -357,7 +357,7 @@ class ExperimentOutput(ProjectOutput):
     def _create_statistics_json(self):
         stats_info = statistics_defaults
         if self.cfg.statistics_opts.add_trends:
-            stats_info = dict(statistics_defaults.items() + statistics_trend.items())
+            stats_info.update(statistics_trend)
         write_json(stats_info, self.statistics_file, indent=4)
 
 

--- a/pyaerocom/aeroval/glob_defaults.py
+++ b/pyaerocom/aeroval/glob_defaults.py
@@ -223,7 +223,12 @@ statistics_defaults = {
     "unit": "1",
     "decimals": 2
   },
-  "obs/mod_trend": {
+  
+
+}
+
+statistics_trend = {
+    "obs/mod_trend": {
         "name": "Obs/Mod-Trends",
         "longname": "Trends",
         "scale": [
@@ -277,7 +282,6 @@ statistics_defaults = {
         "unit": "%/yr",
         "decimals": 1
     },
-
 }
 
 


### PR DESCRIPTION
Menu options for trend statistics will now only be made if add_trends is true. If user sets add_trends to true, but data is to short to make trends, empty menu options will show. So further check will have to be made