### PR TITLE
Treat warnings as errors

### DIFF
--- a/pyaerocom/_lowlevel_helpers.py
+++ b/pyaerocom/_lowlevel_helpers.py
@@ -1,12 +1,19 @@
 """
 Small helper utility functions for pyaerocom
 """
-import numpy as np
-import os, abc, logging, simplejson
-from pathlib import Path
+import abc
+import logging
+import os
 from collections.abc import MutableMapping
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import numpy as np
+import simplejson
+
 from pyaerocom import print_log
+from pyaerocom._warnings_management import ignore_warnings
+
 
 def round_floats(in_data, precision=5):
     """
@@ -704,7 +711,13 @@ def list_to_shortstr(lst, indent=0):
         lout = []
         for val in lin:
             try:
-                ndigits = -1*np.floor(np.log10(abs(np.asarray(val)))).astype(int) + 2
+                with ignore_warnings(
+                    True,
+                    RuntimeWarning,
+                    "divide by zero encountered in log10",
+                    "overflow encountered in long_scalars",
+                ):
+                    ndigits = -1*np.floor(np.log10(abs(np.asarray(val)))).astype(int) + 2
                 lout.append('{:.{}f}'.format(val, ndigits))
             except Exception:
                 lout.append(val)

--- a/pyaerocom/_warnings_management.py
+++ b/pyaerocom/_warnings_management.py
@@ -1,4 +1,6 @@
 import warnings
+
+
 def filter_warnings(apply, categories=None, messages=None):
     """
     Decorator that can be used to filter particular warnings
@@ -32,30 +34,22 @@ def filter_warnings(apply, categories=None, messages=None):
     if categories is None:
         categories = []
     elif not isinstance(categories, list):
-        raise ValueError('categories must be list or None')
+        raise ValueError("categories must be list or None")
     if messages is None:
         messages = []
     elif not isinstance(messages, list):
-        raise ValueError('messages must be list or None')
+        raise ValueError("messages must be list or None")
+
     def decorator(func):
         def wrapper(*args, **kwargs):
             with warnings.catch_warnings():
                 if apply:
                     for cat in categories:
-                        warnings.filterwarnings('ignore', category=cat)
+                        warnings.filterwarnings("ignore", category=cat)
                     for msg in messages:
-                        warnings.filterwarnings('ignore', message=msg)
+                        warnings.filterwarnings("ignore", message=msg)
                 return func(*args, **kwargs)
+
         return wrapper
+
     return decorator
-
-if __name__ == '__main__':
-
-    @filter_warnings(True,[UserWarning], messages=['Deprecated'])
-    def add_num_with_warnings(num1, num2):
-        warnings.warn(UserWarning('User Warning'))
-        warnings.warn(DeprecationWarning('Deprecated'))
-        warnings.warn(Warning('General warning'))
-        return num1 + num2
-
-    print(add_num_with_warnings(1, 2))

--- a/pyaerocom/_warnings_management.py
+++ b/pyaerocom/_warnings_management.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 import warnings
+from contextlib import contextmanager
 
 
-def filter_warnings(apply, categories=None, messages=None):
+@contextmanager
+def filter_warnings(apply: bool, categories: list | None = None, messages: list | None = None):
     """
     Decorator that can be used to filter particular warnings
 
@@ -40,16 +44,13 @@ def filter_warnings(apply, categories=None, messages=None):
     elif not isinstance(messages, list):
         raise ValueError("messages must be list or None")
 
-    def decorator(func):
-        def wrapper(*args, **kwargs):
-            with warnings.catch_warnings():
-                if apply:
-                    for cat in categories:
-                        warnings.filterwarnings("ignore", category=cat)
-                    for msg in messages:
-                        warnings.filterwarnings("ignore", message=msg)
-                return func(*args, **kwargs)
-
-        return wrapper
-
-    return decorator
+    try:
+        with warnings.catch_warnings():
+            if apply:
+                for cat in categories:
+                    warnings.filterwarnings("ignore", category=cat)
+                for msg in messages:
+                    warnings.filterwarnings("ignore", message=msg)
+            yield
+    finally:
+        pass

--- a/pyaerocom/_warnings_management.py
+++ b/pyaerocom/_warnings_management.py
@@ -2,32 +2,34 @@ from __future__ import annotations
 
 import warnings
 from contextlib import contextmanager
+from typing import Type
 
 
 @contextmanager
-def filter_warnings(apply: bool, categories: list | None = None, messages: list | None = None):
+def ignore_warnings(
+    apply: bool, category: Type[Warning] = Warning, *, messages: list[str] | str | None = None
+):
     """
-    Decorator that can be used to filter particular warnings
+    Ignore particular warnings with a decorator or context manager
 
     Parameters
     ----------
     apply : bool
-        if True warnings will be filtered, else not.
-    categories : list, optional
-        list of warning categories to be filtered. E.g.
-        [UserWarning, DeprecationWarning]. The default is None. For each
-        `<entry>` :func:`warnigns.filterwarnings('ignore', category=<entry>)`
-        is called.
-    messages : list, optional
-        list of warning messages to be filtered. E.g.
+        if True warnings will be ignored, else not.
+    category : subclass of Warning (default: Warning)
+        warning category to be ignored. E.g. UserWarning, DeprecationWarning.
+        The default is Warning.
+    messages : list[str], str, optional
+        list of warning messages to be ignored. E.g.
         ['Warning that can safely be ignored']. The default is None. For each
-        `<entry>` :func:`warnigns.filterwarnings('ignore', message=<entry>)`
+        `<entry>` :func:`warnigns.filterwarnings('ignore', category, message=<entry>)`
         is called.
 
     Example
     -------
-    @filter_warnings(categories=[UserWarning, DeprecationWarning],
-                     messages=['I REALLY'])
+    @ignore_warnings(True, UserWarning)
+    @ignore_warnings(True, DeprecationWarning)
+    @ignore_warnings(True, messages=['I REALLY'])
     def warn_randomly_and_add_numbers(num1, num2):
         warnings.warn(UserWarning('Harmless user warning'))
         warnings.warn(DeprecationWarning('This function is deprecated'))
@@ -35,22 +37,26 @@ def filter_warnings(apply: bool, categories: list | None = None, messages: list 
         return num1+num2
 
     """
-    if categories is None:
-        categories = []
-    elif not isinstance(categories, list):
-        raise ValueError("categories must be list or None")
-    if messages is None:
-        messages = []
-    elif not isinstance(messages, list):
+    if not issubclass(category, Warning):
+        raise ValueError("category must be a Warning subclass")
+
+    if not messages:
+        messages = [""]
+    elif type(messages) == str:
+        messages = [messages]
+
+    if not isinstance(messages, list):
         raise ValueError("messages must be list or None")
+    elif not all(type(msg) == str for msg in messages):
+        raise ValueError("messages must be list of strings")
 
     try:
+        if not apply:
+            yield
+            return
         with warnings.catch_warnings():
-            if apply:
-                for cat in categories:
-                    warnings.filterwarnings("ignore", category=cat)
-                for msg in messages:
-                    warnings.filterwarnings("ignore", message=msg)
+            for msg in messages:
+                warnings.filterwarnings("ignore", category=category, message=msg)
             yield
     finally:
         pass

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1013,7 +1013,7 @@ def _calc_temporal_corr(coldata):
         return np.nan, np.nan
     corr_time = xr.corr(arr[1], arr[0], dim='time')
     with ignore_warnings(
-        True, RuntimeWarning, messages=["Mean of empty slice", "All-NaN slice encountered"]
+        True, RuntimeWarning, "Mean of empty slice", "All-NaN slice encountered"
     ):
         return (np.nanmean(corr_time.data), np.nanmedian(corr_time.data))
 

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -8,6 +8,7 @@ import pandas as pd
 from datetime import datetime
 from pyaerocom import const
 from pyaerocom._lowlevel_helpers import read_json, write_json
+from pyaerocom._warnings_management import ignore_warnings
 from pyaerocom.helpers import start_stop
 from pyaerocom.trends_helpers import _get_season_from_months
 from pyaerocom.aeroval.helpers import (_period_str_to_timeslice,
@@ -1011,7 +1012,10 @@ def _calc_temporal_corr(coldata):
     if np.prod(arr.shape) == 0:
         return np.nan, np.nan
     corr_time = xr.corr(arr[1], arr[0], dim='time')
-    return (np.nanmean(corr_time.data), np.nanmedian(corr_time.data))
+    with ignore_warnings(
+        True, RuntimeWarning, messages=["Mean of empty slice", "All-NaN slice encountered"]
+    ):
+        return (np.nanmean(corr_time.data), np.nanmedian(corr_time.data))
 
 def _select_period_season_coldata(coldata, period, season):
     tslice = _period_str_to_timeslice(period)

--- a/pyaerocom/colocateddata.py
+++ b/pyaerocom/colocateddata.py
@@ -1710,7 +1710,7 @@ class ColocatedData(object):
             if ndrop == nstats:
                 raise DataCoverageError(f'No data available in region {region_id}')
             elif ndrop > 0:
-                arr = arr.drop(dim='station_name', labels=drop_idx)
+                arr = arr.drop_sel({"station_name": drop_idx})
         data.data = arr
         return data
 

--- a/pyaerocom/colocation.py
+++ b/pyaerocom/colocation.py
@@ -769,7 +769,7 @@ def colocate_gridded_ungridded(data, data_ref, ts_type=None,
     time_num = len(time_idx)
     stat_num = len(obs_stat_data)
 
-    arr = np.empty((2, time_num, stat_num))*np.nan
+    arr = np.full((2, time_num, stat_num), np.nan)
 
     lons = [np.nan] * stat_num
     lats = [np.nan] * stat_num

--- a/pyaerocom/griddeddata.py
+++ b/pyaerocom/griddeddata.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import xarray as xr
 
 from pyaerocom import const, logger, print_log
-from pyaerocom._warnings_management import filter_warnings
+from pyaerocom._warnings_management import ignore_warnings
 from pyaerocom.helpers_landsea_masks import load_region_mask_iris
 from pyaerocom.tstype import TsType
 from pyaerocom.exceptions import (CoordinateError,
@@ -1759,8 +1759,8 @@ class GriddedData(object):
             data = self._resample_time_iris(to_ts_type)
         return data
 
-    @filter_warnings(const.FILTER_IRIS_WARNINGS,
-                     messages=["Using DEFAULT_SPHERICAL_EARTH_RADIUS."])
+    @ignore_warnings(const.FILTER_IRIS_WARNINGS,
+                     messages="Using DEFAULT_SPHERICAL_EARTH_RADIUS.")
     def calc_area_weights(self):
         """Calculate area weights for grid"""
         if not self.has_latlon_dims:

--- a/pyaerocom/griddeddata.py
+++ b/pyaerocom/griddeddata.py
@@ -678,7 +678,7 @@ class GriddedData(object):
 
 
     @ignore_warnings(
-        True, UserWarning, messages="Ignoring netCDF variable '.*' invalid units '.*'"
+        True, UserWarning, "Ignoring netCDF variable '.*' invalid units '.*'"
     )
     def load_input(self, input, var_name=None, perform_fmt_checks=None):
         """Import input as cube
@@ -1763,8 +1763,7 @@ class GriddedData(object):
             data = self._resample_time_iris(to_ts_type)
         return data
 
-    @ignore_warnings(const.FILTER_IRIS_WARNINGS,
-                     messages="Using DEFAULT_SPHERICAL_EARTH_RADIUS.")
+    @ignore_warnings(const.FILTER_IRIS_WARNINGS, Warning, "Using DEFAULT_SPHERICAL_EARTH_RADIUS.")
     def calc_area_weights(self):
         """Calculate area weights for grid"""
         if not self.has_latlon_dims:

--- a/pyaerocom/griddeddata.py
+++ b/pyaerocom/griddeddata.py
@@ -676,6 +676,10 @@ class GriddedData(object):
             f'to add this variable to pyaerocom/data/variables.ini.')
         return vardef
 
+
+    @ignore_warnings(
+        True, UserWarning, messages="Ignoring netCDF variable '.*' invalid units '.*'"
+    )
     def load_input(self, input, var_name=None, perform_fmt_checks=None):
         """Import input as cube
 

--- a/pyaerocom/io/fileconventions.py
+++ b/pyaerocom/io/fileconventions.py
@@ -295,7 +295,6 @@ class FileConventionRead(object):
         Example
         -------
 
-        import re
         conf_aero2 = FileConventionRead(name="aerocom2")
         conf_aero3 = FileConventionRead(name="aerocom2")
 

--- a/pyaerocom/io/iris_io.py
+++ b/pyaerocom/io/iris_io.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from traceback import format_exc
 
 from pyaerocom import const, logger
-from pyaerocom._warnings_management import filter_warnings
+from pyaerocom._warnings_management import ignore_warnings
 from pyaerocom.exceptions import (NetcdfError, VariableDefinitionError,
                                   FileConventionError,
                                   UnresolvableTimeDefinitionError)
@@ -33,8 +33,7 @@ from pyaerocom.tstype import TsType
 from pyaerocom.io.helpers import add_file_to_log
 from pyaerocom.io.fileconventions import FileConventionRead
 
-@filter_warnings(apply=const.FILTER_IRIS_WARNINGS,
-                 categories=[UserWarning])
+@ignore_warnings(const.FILTER_IRIS_WARNINGS, UserWarning)
 def load_cubes_custom(files, var_name=None, file_convention=None,
                       perform_fmt_checks=True):
     """Load multiple NetCDF files into CubeList

--- a/pyaerocom/io/read_earlinet.py
+++ b/pyaerocom/io/read_earlinet.py
@@ -207,7 +207,7 @@ class ReadEarlinet(ReadUngriddedBase):
                     _meta = None
             data_out[k] = _meta
 
-        data_out['station_name'] = re.split('\s|,', data_out['location'])[0].strip()
+        data_out["station_name"] = re.split(r"\s|,", data_out["location"])[0].strip()
 
         str_dummy = str(data_in.StartDate)
         year, month, day = str_dummy[0:4], str_dummy[4:6], str_dummy[6:8]

--- a/pyaerocom/io/read_ebas.py
+++ b/pyaerocom/io/read_ebas.py
@@ -17,32 +17,52 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
 # MA 02110-1301, USA
-from geonum.atmosphere import p0, T0_STD
-import os, re
 import fnmatch
-import numpy as np
+import os
+import re
 from collections import OrderedDict as od
+from warnings import catch_warnings, filterwarnings
+
+import numpy as np
+from tqdm import tqdm
+
+with catch_warnings():
+    filterwarnings("ignore")
+    from geonum.atmosphere import T0_STD, p0
+
 from pyaerocom import const
-from pyaerocom.units_helpers import get_unit_conversion_fac
-from pyaerocom.aux_var_helpers import compute_ang4470dryaer_from_dry_scat, compute_sc550dryaer, compute_sc440dryaer, \
-    compute_sc700dryaer, compute_ac550dryaer, compute_wetoxs_from_concprcpoxs, compute_wetoxn_from_concprcpoxn, \
-    compute_wetrdn_from_concprcprdn, vmrx_to_concx, concx_to_vmrx
-from pyaerocom.molmasses import get_molmass
-from pyaerocom.io.readungriddedbase import ReadUngriddedBase
+from pyaerocom._lowlevel_helpers import BrowseDict
+from pyaerocom.aux_var_helpers import (
+    compute_ac550dryaer,
+    compute_ang4470dryaer_from_dry_scat,
+    compute_sc440dryaer,
+    compute_sc550dryaer,
+    compute_sc700dryaer,
+    compute_wetoxn_from_concprcpoxn,
+    compute_wetoxs_from_concprcpoxs,
+    compute_wetrdn_from_concprcprdn,
+    concx_to_vmrx,
+    vmrx_to_concx,
+)
+from pyaerocom.exceptions import (
+    EbasFileError,
+    MetaDataError,
+    NotInFileError,
+    TemporalResolutionError,
+    TemporalSamplingError,
+    UnitConversionError,
+)
+from pyaerocom.io.ebas_file_index import EbasFileIndex, EbasSQLRequest
+from pyaerocom.io.ebas_nasa_ames import EbasNasaAmesFile
+from pyaerocom.io.ebas_varinfo import EbasVarInfo
 from pyaerocom.io.helpers import _check_ebas_db_local_vs_remote
+from pyaerocom.io.readungriddedbase import ReadUngriddedBase
+from pyaerocom.molmasses import get_molmass
 from pyaerocom.stationdata import StationData
 from pyaerocom.tstype import TsType
 from pyaerocom.ungriddeddata import UngriddedData
-from pyaerocom.io.ebas_varinfo import EbasVarInfo
-from pyaerocom.io.ebas_file_index import EbasFileIndex, EbasSQLRequest
-from pyaerocom.io.ebas_nasa_ames import EbasNasaAmesFile
-from pyaerocom.exceptions import (NotInFileError, EbasFileError,
-                                  MetaDataError,
-                                  UnitConversionError,
-                                  TemporalResolutionError,
-                                  TemporalSamplingError)
-from pyaerocom._lowlevel_helpers import BrowseDict
-from tqdm import tqdm
+from pyaerocom.units_helpers import get_unit_conversion_fac
+
 
 class ReadEbasOptions(BrowseDict):
     """Options for EBAS reading routine

--- a/pyaerocom/io/read_ebas.py
+++ b/pyaerocom/io/read_ebas.py
@@ -923,7 +923,7 @@ class ReadEbas(ReadUngriddedBase):
         try:
             ts_type = self.TS_TYPE_CODES[tres_code]
         except KeyError:
-            ival = re.findall('\d+', tres_code)[0]
+            ival = re.findall(r"\d+", tres_code)[0]
             code = tres_code.split(ival)[-1]
             if not code in self.TS_TYPE_CODES:
                 raise NotImplementedError('Cannot handle EBAS resolution code '

--- a/pyaerocom/io/readgridded.py
+++ b/pyaerocom/io/readgridded.py
@@ -604,7 +604,7 @@ class ReadGridded(object):
                 return np.array([9999])
         else:
             start_provided = True
-            if start == 9999:
+            if isinstance(start, int) and start == 9999:
                 return np.array([9999])
             start = to_pandas_timestamp(start)
 
@@ -1945,7 +1945,7 @@ class ReadGridded(object):
                            convert_unit_on_init=try_convert_units,
                            **meta)
         # crop cube in time (if applicable)
-        if not start == 9999:
+        if isinstance(start, int) and start != 9999:
             try:
                 data = self._check_crop_time(data, start, stop)
             except Exception:

--- a/pyaerocom/mathutils.py
+++ b/pyaerocom/mathutils.py
@@ -134,11 +134,9 @@ def weighted_corr(ref_data, data, weights):
 
 @ignore_warnings(
     True,
-    RuntimeWarning,
-    messages=[
-        "invalid value encountered in double_scalars",
-        "An input array is constant",
-    ],
+    RuntimeWarning,   
+    "invalid value encountered in double_scalars",
+    "An input array is constant",
 )
 def corr(ref_data, data, weights=None):
     """Compute correlation coefficient
@@ -183,9 +181,7 @@ def _nanmean_and_std(data):
     return (np.nanmean(data), np.nanstd(data))
 
 @ignore_warnings(
-    True, 
-    RuntimeWarning, 
-    messages=["An input array is constant", "invalid value encountered in true_divide"],
+    True, RuntimeWarning, "An input array is constant", "invalid value encountered in true_divide"
 )
 def calc_statistics(data, ref_data, lowlim=None, highlim=None,
                     min_num_valid=1, weights=None):

--- a/pyaerocom/mathutils.py
+++ b/pyaerocom/mathutils.py
@@ -5,6 +5,8 @@ import numpy as np
 
 from scipy.stats import pearsonr, spearmanr, kendalltau
 
+from pyaerocom._warnings_management import ignore_warnings
+
 ### LAMBDA FUNCTIONS
 in_range = lambda x, low, high: low <= x <= high
 
@@ -130,6 +132,14 @@ def weighted_corr(ref_data, data, weights):
     wsigmaxy = np.sqrt(wcovxx * wcovyy)
     return wcovxy / wsigmaxy
 
+@ignore_warnings(
+    True,
+    RuntimeWarning,
+    messages=[
+        "invalid value encountered in double_scalars",
+        "An input array is constant",
+    ],
+)
 def corr(ref_data, data, weights=None):
     """Compute correlation coefficient
 
@@ -172,6 +182,11 @@ def _nanmean_and_std(data):
         return (np.nan,np.nan)
     return (np.nanmean(data), np.nanstd(data))
 
+@ignore_warnings(
+    True, 
+    RuntimeWarning, 
+    messages=["An input array is constant", "invalid value encountered in true_divide"],
+)
 def calc_statistics(data, ref_data, lowlim=None, highlim=None,
                     min_num_valid=1, weights=None):
     """Calc statistical properties from two data arrays

--- a/pyaerocom/plot/mapping.py
+++ b/pyaerocom/plot/mapping.py
@@ -4,6 +4,7 @@ import numpy as np
 from cartopy.mpl.geoaxes import GeoAxes
 from cartopy.mpl.ticker import LatitudeFormatter, LongitudeFormatter
 from matplotlib.colors import BoundaryNorm, LogNorm, Normalize
+from matplotlib import MatplotlibDeprecationWarning
 from numpy import ceil, linspace, meshgrid
 from pandas import to_datetime
 
@@ -350,11 +351,13 @@ def plot_griddeddata_on_map(data, lons=None, lats=None, var_name=None,
                 norm = Normalize(vmin=vmin, vmax=vmax)
     cbar_extend = "neither"
     if c_under is not None:
+        cmap = cmap.copy()
         cmap.set_under(c_under)
         cbar_extend = "min"
         if bounds is not None:
             bounds.insert(0, bounds[0] - bounds[1])
     if c_over is not None:
+        cmap = cmap.copy()
         cmap.set_over(c_over)
         if bounds is not None:
             bounds.append(bounds[-1] + bounds[-2])
@@ -363,7 +366,7 @@ def plot_griddeddata_on_map(data, lons=None, lats=None, var_name=None,
         else:
             cbar_extend = "max"
     fig.norm = norm
-    disp = ax.pcolormesh(X, Y, data, cmap=cmap, norm=norm)
+    disp = ax.pcolormesh(X, Y, data, cmap=cmap, norm=norm, shading="auto")
 
     if add_cbar:
         cbar = fig.colorbar(disp, extend=cbar_extend, cax=ax_cbar, shrink=0.8)

--- a/pyaerocom/plot/mapping.py
+++ b/pyaerocom/plot/mapping.py
@@ -472,7 +472,7 @@ def plot_map_aerocom(data, region, **kwargs):
     var = data.var_name.upper()
     avg = data.mean()
     start = to_datetime(data.start).strftime("%Y%m%d")
-    tit = f'{var} {start} mean {avg:.3f}'
+    tit = f'{var} {start} mean {avg.round(3)}'
     ax.set_title(tit)
     return fig
 
@@ -562,7 +562,7 @@ def plot_nmb_map_colocateddata(coldata, in_percent=True, vmin=-100,
         valid = ~stacked.isnull()
         coords = stacked.latlon[valid].values
         lats, lons = list(zip(*list(coords)))
-        data = stacked.data[valid]
+        data = stacked.data[tuple(valid)]
 
     if ref_label is None:
         ref_label = coldata.metadata['data_source'][0]

--- a/pyaerocom/plot/mapping.py
+++ b/pyaerocom/plot/mapping.py
@@ -1,21 +1,23 @@
-import matplotlib.pyplot as plt
-from pandas import to_datetime
-import numpy as np
-from matplotlib.colors import BoundaryNorm, LogNorm, Normalize
-
 import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+import numpy as np
 from cartopy.mpl.geoaxes import GeoAxes
-from cartopy.mpl.ticker import LongitudeFormatter, LatitudeFormatter
-from numpy import meshgrid, linspace, ceil
+from cartopy.mpl.ticker import LatitudeFormatter, LongitudeFormatter
+from matplotlib.colors import BoundaryNorm, LogNorm, Normalize
+from numpy import ceil, linspace, meshgrid
+from pandas import to_datetime
 
-from pyaerocom import logger, const
+from pyaerocom import const
+from pyaerocom._warnings_management import ignore_warnings
 from pyaerocom.exceptions import DataDimensionError
-from pyaerocom.plot.config import COLOR_THEME, ColorTheme, MAP_AXES_ASPECT
-from pyaerocom.plot.helpers import (custom_mpl,
-                                    calc_pseudolog_cmaplevels,
-                                    projection_from_str,
-                                    calc_figsize)
 from pyaerocom.mathutils import exponent
+from pyaerocom.plot.config import COLOR_THEME, MAP_AXES_ASPECT, ColorTheme
+from pyaerocom.plot.helpers import (
+    calc_figsize,
+    calc_pseudolog_cmaplevels,
+    custom_mpl,
+    projection_from_str,
+)
 from pyaerocom.region import Region
 
 MPL_PARAMS = custom_mpl()
@@ -295,8 +297,9 @@ def plot_griddeddata_on_map(data, lons=None, lats=None, var_name=None,
             cmap = plt.get_cmap(cmap)
         norm = BoundaryNorm(boundaries=bounds, ncolors=cmap.N, clip=False)
     else:
-        dmin = np.nanmin(data)
-        dmax = np.nanmax(data)
+        with ignore_warnings(True, RuntimeWarning, "All-NaN axis encountered"):
+            dmin = np.nanmin(data)
+            dmax = np.nanmax(data)
 
         if any([np.isnan(x) for x in [dmin, dmax]]):
             raise ValueError('Cannot plot map of data: all values are NaN')

--- a/pyaerocom/plot/plotscatter.py
+++ b/pyaerocom/plot/plotscatter.py
@@ -149,9 +149,9 @@ def plot_scatter_aerocom(x_vals, y_vals, var_name=None, var_name_ref=None,
             low = 10**(float(exponent(abs(low)) - 1))
         xlim[0] = low
         ylim[0] = low
-    with ignore_warnings(True, UserWarning, messages="Attempted to set non-positive left xlim on a log-scaled axis"):
+    with ignore_warnings(True, UserWarning, "Attempted to set non-positive left xlim on a log-scaled axis"):
         ax.set_xlim(xlim)
-    with ignore_warnings(True, UserWarning, messages="Attempted to set non-positive bottom ylim on a log-scaled axis"):
+    with ignore_warnings(True, UserWarning, "Attempted to set non-positive bottom ylim on a log-scaled axis"):
         ax.set_ylim(ylim)
     xlbl = '{}'.format(x_name)
     if var_name_ref is not None:

--- a/pyaerocom/plot/plotscatter.py
+++ b/pyaerocom/plot/plotscatter.py
@@ -1,13 +1,14 @@
 """
 This module contains scatter plot routines for Aerocom data.
 """
-from matplotlib.ticker import ScalarFormatter
-import os
 import matplotlib.pyplot as plt
 import numpy as np
+
 from pyaerocom import const
+from pyaerocom._warnings_management import ignore_warnings
 from pyaerocom.helpers import start_stop_str
 from pyaerocom.mathutils import calc_statistics, exponent
+
 
 def plot_scatter(x_vals, y_vals, **kwargs):
     """Scatter plot
@@ -148,8 +149,10 @@ def plot_scatter_aerocom(x_vals, y_vals, var_name=None, var_name_ref=None,
             low = 10**(float(exponent(abs(low)) - 1))
         xlim[0] = low
         ylim[0] = low
-    ax.set_xlim(xlim)
-    ax.set_ylim(ylim)
+    with ignore_warnings(True, UserWarning, messages="Attempted to set non-positive left xlim on a log-scaled axis"):
+        ax.set_xlim(xlim)
+    with ignore_warnings(True, UserWarning, messages="Attempted to set non-positive bottom ylim on a log-scaled axis"):
+        ax.set_ylim(ylim)
     xlbl = '{}'.format(x_name)
     if var_name_ref is not None:
         xlbl += ' ({})'.format(var_name_ref)

--- a/pyaerocom/time_config.py
+++ b/pyaerocom/time_config.py
@@ -1,9 +1,12 @@
 """
 Definitions and helpers related to time conversion
 """
-
-from iris import coord_categorisation
 from datetime import datetime
+from warnings import catch_warnings, filterwarnings
+
+with catch_warnings():
+    filterwarnings("ignore")
+    from iris import coord_categorisation
 
 TS_TYPES = ['minutely', 'hourly', 'daily', 'weekly', 'monthly', 'yearly',
             'native']

--- a/pyaerocom/tstype.py
+++ b/pyaerocom/tstype.py
@@ -76,7 +76,7 @@ class TsType(object):
                 'Invalid input, please provide valid frequency string...')
         mulfac = 1
         if val[0].isdigit():
-            ivalstr = re.findall('\d+', val)[0]
+            ivalstr = re.findall(r"\d+", val)[0]
             val = val.split(ivalstr)[-1]
             mulfac = int(ivalstr)
         if not val in self.VALID:

--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -134,7 +134,7 @@ class UngriddedData(object):
         self._index = self._init_index(add_cols)
 
         #keep private, this is not supposed to be used by the user
-        self._data = np.empty([num_points, self._COLNO]) * np.nan
+        self._data = np.full([num_points, self._COLNO], np.nan) 
 
         self.metadata = od()
         # single value data revision is deprecated
@@ -631,7 +631,7 @@ class UngriddedData(object):
         """
         if size is None or size < self._chunksize:
             size = self._chunksize
-        chunk = np.empty([size, self._COLNO])*np.nan
+        chunk = np.full([size, self._COLNO], np.nan)
         self._data = np.append(self._data, chunk, axis=0)
         logger.info("adding chunk, new array size ({})".format(self._data.shape))
 

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -9,6 +9,7 @@ dependencies:
   - matplotlib >=3.0.1
   - scipy >=1.1.0
   - pandas >=1.3.0
+  - numpy >= 0.12.0
   - seaborn >=0.8.0
   - dask
   - geonum

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,18 @@ build-backend = "setuptools.build_meta"
 minversion = "6.0"
 addopts = "--failed-first"
 testpaths = ["tests"]
+filterwarnings = [
+    "error:Ignoring netCDF variable '.*' invalid units '.*':UserWarning",
+    "error:Using DEFAULT_SPHERICAL_EARTH_RADIUS.:UserWarning",
+    "error:All-NaN axis encountered:RuntimeWarning",
+    "error:All-NaN slice encountered:RuntimeWarning",
+    "error:An input array is constant:RuntimeWarning",
+    "error:Mean of empty slice:RuntimeWarning",
+    "error:invalid value encountered in double_scalars:RuntimeWarning",
+    "error:invalid value encountered in true_divide:RuntimeWarning",
+    "error:Attempted to set non-positive left xlim on a log-scaled axis:UserWarning",
+    "error:Attempted to set non-positive bottom ylim on a log-scaled axis:UserWarning",
+]
 
 [tool.coverage.run]
 source = ["pyaerocom"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ filterwarnings = [
     "error:invalid value encountered in true_divide:RuntimeWarning",
     "error:Attempted to set non-positive left xlim on a log-scaled axis:UserWarning",
     "error:Attempted to set non-positive bottom ylim on a log-scaled axis:UserWarning",
+    "error:divide by zero encountered in log10:RuntimeWarning",
+    "error:overflow encountered in long_scalars:RuntimeWarning",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,18 +7,11 @@ minversion = "6.0"
 addopts = "--failed-first"
 testpaths = ["tests"]
 filterwarnings = [
-    "error:Ignoring netCDF variable '.*' invalid units '.*':UserWarning",
-    "error:Using DEFAULT_SPHERICAL_EARTH_RADIUS.:UserWarning",
-    "error:All-NaN axis encountered:RuntimeWarning",
-    "error:All-NaN slice encountered:RuntimeWarning",
-    "error:An input array is constant:RuntimeWarning",
-    "error:Mean of empty slice:RuntimeWarning",
-    "error:invalid value encountered in double_scalars:RuntimeWarning",
-    "error:invalid value encountered in true_divide:RuntimeWarning",
-    "error:Attempted to set non-positive left xlim on a log-scaled axis:UserWarning",
-    "error:Attempted to set non-positive bottom ylim on a log-scaled axis:UserWarning",
-    "error:divide by zero encountered in log10:RuntimeWarning",
-    "error:overflow encountered in long_scalars:RuntimeWarning",
+    "error::UserWarning",
+    "error::RuntimeWarning",
+    "error::DeprecationWarning",
+    "error::FutureWarning",
+    "error::matplotlib.MatplotlibDeprecationWarning",
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,8 @@ minversion = "6.0"
 addopts = "--failed-first"
 testpaths = ["tests"]
 filterwarnings = [
-    "error::UserWarning",
-    "error::RuntimeWarning",
-    "error::DeprecationWarning",
-    "error::FutureWarning",
-    "error::matplotlib.MatplotlibDeprecationWarning",
+  "error",
+  "ignore::pytest.PytestUnraisableExceptionWarning",
 ]
 
 [tool.coverage.run]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     geonum
     LatLon23 # required by geonum
     SRTM.py # required by geonum
-    numpy
+    numpy>=0.12.0
     simplejson
     requests
     reverse-geocode

--- a/tests/aeroval/test__processing_base.py
+++ b/tests/aeroval/test__processing_base.py
@@ -1,11 +1,13 @@
+from contextlib import nullcontext as does_not_raise_exception
+
 import pytest
 
 from pyaerocom import Colocator, GriddedData, UngriddedData
-from pyaerocom.aeroval import _processing_base as mod, EvalSetup
+from pyaerocom.aeroval import EvalSetup
+from pyaerocom.aeroval import _processing_base as mod
 from pyaerocom.aeroval.experiment_output import ExperimentOutput
 from pyaerocom.exceptions import EntryNotAvailable
 
-from ..conftest import does_not_raise_exception
 from .cfg_test_exp1 import CFG
 
 obs_cfg=dict(
@@ -58,4 +60,3 @@ class TestDataImporter:
         val = mod.DataImporter(EvalSetup(**CFG))
         data = val.read_ungridded_obsdata('AERONET-Sun', 'od550aer')
         assert isinstance(data, UngriddedData)
-

--- a/tests/aeroval/test_aeroval_HIGHLEV.py
+++ b/tests/aeroval/test_aeroval_HIGHLEV.py
@@ -47,6 +47,7 @@ CHK_CFG4 = {
     (cfgexp2,CHK_CFG2),
     (cfgexp4,CHK_CFG4),
 ])
+@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
 def test_ExperimentOutput__FILES(cfgdict,chk_files):
     cfg = EvalSetup(**cfgdict)
     fname = f'cfg_{cfg.proj_id}_{cfg.exp_id}.json'
@@ -73,6 +74,7 @@ def test_ExperimentOutput__FILES(cfgdict,chk_files):
                 numfiles = glob.glob(f'{val}/*.json')
                 assert len(numfiles) == check
 
+@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
 def test_reanalyse_existing():
     cfg = EvalSetup(**cfgexp4)
     assert cfg.colocation_opts.reanalyse_existing == True

--- a/tests/aeroval/test_aeroval_HIGHLEV.py
+++ b/tests/aeroval/test_aeroval_HIGHLEV.py
@@ -47,7 +47,6 @@ CHK_CFG4 = {
     (cfgexp2,CHK_CFG2),
     (cfgexp4,CHK_CFG4),
 ])
-@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
 def test_ExperimentOutput__FILES(cfgdict,chk_files):
     cfg = EvalSetup(**cfgdict)
     fname = f'cfg_{cfg.proj_id}_{cfg.exp_id}.json'
@@ -74,7 +73,6 @@ def test_ExperimentOutput__FILES(cfgdict,chk_files):
                 numfiles = glob.glob(f'{val}/*.json')
                 assert len(numfiles) == check
 
-@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
 def test_reanalyse_existing():
     cfg = EvalSetup(**cfgexp4)
     assert cfg.colocation_opts.reanalyse_existing == True

--- a/tests/aeroval/test_coldatatojson_helpers2.py
+++ b/tests/aeroval/test_coldatatojson_helpers2.py
@@ -1,7 +1,6 @@
 # ToDo: merge with test_coldatatojson_helpers.py
 
 import numpy as np
-
 import pytest
 
 import pyaerocom.aeroval.coldatatojson_helpers as mod
@@ -68,6 +67,7 @@ def test_get_jsdate(example_coldata):
      pytest.raises(exceptions.TemporalResolutionError)),
 
     ])
+@pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning")
 def test__process_statistics_timeseries(example_coldata,
                                         freq,region_ids,use_weights,
                                         use_country,data_freq,

--- a/tests/aeroval/test_coldatatojson_helpers2.py
+++ b/tests/aeroval/test_coldatatojson_helpers2.py
@@ -1,13 +1,13 @@
 # ToDo: merge with test_coldatatojson_helpers.py
 
+from contextlib import nullcontext as does_not_raise_exception
+
 import numpy as np
 import pytest
 
 import pyaerocom.aeroval.coldatatojson_helpers as mod
 import pyaerocom.exceptions as exceptions
 from pyaerocom import ColocatedData, TsType
-
-from ..conftest import does_not_raise_exception
 
 
 def test_get_heatmap_filename():

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -1,14 +1,20 @@
-import pytest
 import os
-import shutil
+from contextlib import nullcontext as does_not_raise_exception
+
+import pytest
+
 from pyaerocom import const
-from pyaerocom._lowlevel_helpers import read_json,write_json
-from pyaerocom.aeroval import experiment_output as mod, ExperimentProcessor
+from pyaerocom._lowlevel_helpers import read_json, write_json
+from pyaerocom.aeroval import ExperimentProcessor
+from pyaerocom.aeroval import experiment_output as mod
 from pyaerocom.aeroval.setupclasses import EvalSetup
-from ..conftest import does_not_raise_exception, geojson_unavail
+
+from ..conftest import geojson_unavail
 from .cfg_test_exp1 import CFG as cfgexp1
+
 BASEDIR_DEFAULT = os.path.join(const.OUTPUTDIR, 'aeroval/data')
 from ._outbase import AEROVAL_OUT as BASEOUT
+
 DUMMY_OUT = os.path.join(BASEOUT, 'dummy')
 
 @pytest.fixture(scope='module')
@@ -257,12 +263,3 @@ def test_ExperimentOutput_reorder_experiments(dummy_expout,add_names,order,
         new = read_json(fp)
         assert list(new) == result
     os.remove(fp)
-
-
-
-
-
-
-
-
-

--- a/tests/aeroval/test_experiment_processor.py
+++ b/tests/aeroval/test_experiment_processor.py
@@ -1,15 +1,17 @@
+from contextlib import nullcontext as does_not_raise_exception
+
 import pytest
 
+import pyaerocom.aeroval.experiment_processor as mod
 from pyaerocom.aeroval.experiment_output import ExperimentOutput
 from pyaerocom.aeroval.setupclasses import EvalSetup
-import pyaerocom.aeroval.experiment_processor as mod
 
+from ..conftest import geojson_unavail
 from .cfg_test_exp1 import CFG as cfgexp1
 from .cfg_test_exp2 import CFG as cfgexp2
 from .cfg_test_exp3 import CFG as cfgexp3
 from .cfg_test_exp4 import CFG as cfgexp4
 from .cfg_test_exp5 import CFG as cfgexp5
-from ..conftest import does_not_raise_exception, geojson_unavail
 
 
 @pytest.mark.parametrize('cfgdict,raises', [

--- a/tests/aeroval/test_experiment_processor.py
+++ b/tests/aeroval/test_experiment_processor.py
@@ -32,6 +32,10 @@ def test_ExperimentProcessor___init__(cfgdict,raises):
     (cfgexp3,{},does_not_raise_exception()),
     (cfgexp4,{},does_not_raise_exception()),
 ])
+@pytest.mark.filterwarnings("ignore:invalid value encountered in double_scalars:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore: Mean of empty slice:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore: All-NaN slice encountered:RuntimeWarning")
 def test_ExperimentProcessor_run(cfgdict,runkwargs,raises):
     cfg = EvalSetup(**cfgdict)
     with raises:

--- a/tests/aeroval/test_experiment_processor.py
+++ b/tests/aeroval/test_experiment_processor.py
@@ -34,10 +34,6 @@ def test_ExperimentProcessor___init__(cfgdict,raises):
     (cfgexp3,{},does_not_raise_exception()),
     (cfgexp4,{},does_not_raise_exception()),
 ])
-@pytest.mark.filterwarnings("ignore:invalid value encountered in double_scalars:RuntimeWarning")
-@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
-@pytest.mark.filterwarnings("ignore: Mean of empty slice:RuntimeWarning")
-@pytest.mark.filterwarnings("ignore: All-NaN slice encountered:RuntimeWarning")
 def test_ExperimentProcessor_run(cfgdict,runkwargs,raises):
     cfg = EvalSetup(**cfgdict)
     with raises:

--- a/tests/aeroval/test_helpers.py
+++ b/tests/aeroval/test_helpers.py
@@ -1,9 +1,11 @@
+from contextlib import nullcontext as does_not_raise_exception
+
 import pytest
-from pyaerocom import const
+
 import pyaerocom.aeroval.helpers as mod
+from pyaerocom import const
 from pyaerocom.exceptions import VariableDefinitionError
 from pyaerocom.varcollection import VarCollection
-from ..conftest import does_not_raise_exception
 
 
 @pytest.mark.parametrize('dvar,var,raises', [

--- a/tests/aeroval/test_modelmaps_helpers.py
+++ b/tests/aeroval/test_modelmaps_helpers.py
@@ -1,5 +1,3 @@
-import pytest
-
 from pyaerocom.aeroval import modelmaps_helpers as mod
 
 def test__jsdate_list(data_tm5):
@@ -8,10 +6,6 @@ def test__jsdate_list(data_tm5):
     assert vals[0] == 1263513600000
     assert vals[-1] == 1292371200000
 
-# numpy DeprecationWarning triggered by iris
-@pytest.mark.filterwarnings(
-    "ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning"
-)
 def test_griddeddata_to_jsondict(data_tm5):
     result = mod.griddeddata_to_jsondict(data_tm5)
     assert isinstance(result, dict)

--- a/tests/aeroval/test_modelmaps_helpers.py
+++ b/tests/aeroval/test_modelmaps_helpers.py
@@ -1,5 +1,5 @@
 import pytest
-from ..conftest import data_tm5
+
 from pyaerocom.aeroval import modelmaps_helpers as mod
 
 def test__jsdate_list(data_tm5):
@@ -8,6 +8,10 @@ def test__jsdate_list(data_tm5):
     assert vals[0] == 1263513600000
     assert vals[-1] == 1292371200000
 
+# numpy DeprecationWarning triggered by iris
+@pytest.mark.filterwarnings(
+    "ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning"
+)
 def test_griddeddata_to_jsondict(data_tm5):
     result = mod.griddeddata_to_jsondict(data_tm5)
     assert isinstance(result, dict)

--- a/tests/aeroval/test_setupclasses.py
+++ b/tests/aeroval/test_setupclasses.py
@@ -1,9 +1,12 @@
+from contextlib import nullcontext as does_not_raise_exception
+
 import pytest
+
 from pyaerocom.aeroval import setupclasses as mod
 from pyaerocom.exceptions import EvalEntryNameError
 
 from .cfg_test_exp1 import CFG as cfgexp1
-from ..conftest import does_not_raise_exception
+
 
 @pytest.mark.parametrize('kwargs,raises', [
     (cfgexp1,does_not_raise_exception())

--- a/tests/aeroval/test_utils.py
+++ b/tests/aeroval/test_utils.py
@@ -1,14 +1,15 @@
+from contextlib import nullcontext as does_not_raise_exception
+
 import pytest
+
 import pyaerocom.aeroval.utils as mod
 from pyaerocom import GriddedData
 from pyaerocom.aeroval import EvalSetup, ExperimentProcessor
 
+from .._conftest_helpers import add_dummy_model_data
+from ._outbase import ADD_MODELS_DIR
 from .cfg_test_exp1 import CFG as cfg1
 from .cfg_test_exp2 import CFG as cfg2
-
-from ._outbase import ADD_MODELS_DIR
-from ..conftest import does_not_raise_exception
-from .._conftest_helpers import add_dummy_model_data
 
 # create some fake AOD model data
 MODEL_DIR = add_dummy_model_data('od550aer', '1', 'daily',
@@ -22,6 +23,7 @@ def test_make_config_template():
     assert isinstance(val, EvalSetup)
 
 from copy import deepcopy
+
 CFG1 = deepcopy(cfg1)
 # need more than one model
 CFG1['model_cfg']['DUMMY-MODEL'] = dict(model_id='DUMMY-MODEL',
@@ -61,4 +63,3 @@ def test_compute_model_average_and_diversity(cfg,addargs,raises):
             assert isinstance(q3_out, GriddedData)
         else:
             assert isinstance(std_out, GriddedData)
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ import os
 import matplotlib
 
 matplotlib.use('Agg')
-from contextlib import contextmanager
 
 import numpy as np
 import pytest
@@ -233,10 +232,6 @@ def coldata():
         'fake_3d_hr'    : cth._create_fake_coldata_3d_hourly(),
         'fake_3d_trends': cth._create_fake_trends_coldata_3d(),
         }
-
-@contextmanager
-def does_not_raise_exception():
-    yield
 
 TMPDIR = os.path.join(os.path.expanduser('~'), 'tmp', 'pyatest')
 os.makedirs(TMPDIR, exist_ok=True)

--- a/tests/io/test_ebas_file_index.py
+++ b/tests/io/test_ebas_file_index.py
@@ -1,10 +1,10 @@
-# -*- coding: utf-8 -*-
+from contextlib import nullcontext as does_not_raise_exception
 
 import pytest
 
 from pyaerocom.io import ebas_file_index as mod
 
-from ..conftest import EBAS_SQLite_DB, does_not_raise_exception
+from ..conftest import EBAS_SQLite_DB
 
 
 @pytest.mark.parametrize('args,kwargs,raises', [
@@ -131,7 +131,3 @@ def test_EbasFileIndex_get_table_names():
 def test_EbasFileIndex_get_column_names(table,names):
     val = mod.EbasFileIndex(EBAS_SQLite_DB).get_table_columns(table)
     assert val == names
-
-if __name__ == '__main__':
-    import sys
-    pytest.main(sys.argv)

--- a/tests/io/test_ebas_nasa_ames.py
+++ b/tests/io/test_ebas_nasa_ames.py
@@ -1,18 +1,11 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Wed Feb 19 15:28:03 2020
-
-@author: jonasg
-"""
 from collections import OrderedDict
+from contextlib import nullcontext as does_not_raise_exception
 
 import numpy as np
 import pytest
 
 from pyaerocom.io import ebas_nasa_ames as ena
 
-from ..conftest import does_not_raise_exception
 from ..conftest import loaded_nasa_ames_example as filedata
 
 

--- a/tests/io/test_ebas_varinfo.py
+++ b/tests/io/test_ebas_varinfo.py
@@ -1,17 +1,9 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Wed Feb 19 15:28:03 2020
+from contextlib import nullcontext as does_not_raise_exception
 
-@author: jonasg
-"""
 import pytest
 
-from pyaerocom import const
 from pyaerocom.io.ebas_file_index import EbasSQLRequest
 from pyaerocom.io.ebas_varinfo import EbasVarInfo
-
-from ..conftest import does_not_raise_exception
 
 TESTDATA = [('DEFAULT', None, None, None, None, None, 1),
             ('sc550aer', ['aerosol_light_scattering_coefficient'],
@@ -162,31 +154,3 @@ def test_make_sql_requests(var,constraints,raises,num):
 def test___str__():
     s = EbasVarInfo('concpm10').__str__()
     assert isinstance(s, str)
-
-if __name__=='__main__':
-
-    #info = EbasVarInfo()
-    def to_tuple(var_name):
-        var = EbasVarInfo(var_name)
-        return (var_name, var.component, var.matrix, var.instrument,
-                var.statistics, var.requires, var.scale_factor)
-    import sys
-    from time import time
-    t0 =time()
-    pytest.main(sys.argv)
-    print(time()-t0)
-
-    ok = []
-    notok = []
-    for var in EbasVarInfo.open_config():
-        if var in const.VARS:
-            ok.append(var)
-        else:
-            notok.append(var)
-
-    print('OK')
-    print(ok)
-
-    print()
-    print('NOT OK')
-    print(notok)

--- a/tests/io/test_iris_io.py
+++ b/tests/io/test_iris_io.py
@@ -1,24 +1,22 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Mon Mar 22 14:53:00 2021
+from contextlib import nullcontext as does_not_raise_exception
 
-@author: jonasg
-"""
 import iris.cube
+import numpy as np
 import pytest
 from iris import load
 from iris.cube import Cube
 from iris.exceptions import TranslationError
-import numpy as np
+
+from pyaerocom.exceptions import (
+    FileConventionError,
+    NetcdfError,
+    TemporalResolutionError,
+    UnresolvableTimeDefinitionError,
+)
 from pyaerocom.io import FileConventionRead
-from pyaerocom.exceptions import (TemporalResolutionError,
-                                  UnresolvableTimeDefinitionError,
-                                  NetcdfError,
-                                  FileConventionError)
 from pyaerocom.io import iris_io as mod
 
-from ..conftest import TESTDATADIR, does_not_raise_exception
+from ..conftest import TESTDATADIR
 
 tm5fname1 = 'aerocom3_TM5_AP3-CTRL2016_od550aer_Column_2010_monthly.nc'
 TM5_DIR = TESTDATADIR.joinpath('modeldata/TM5-met2010_CTRL-TEST/renamed')
@@ -67,6 +65,7 @@ aod_cube_nounit.units = ''
 
 import tempfile
 from pathlib import Path
+
 tmpdirnc = Path(tempfile.gettempdir()).joinpath('test_iris_io')
 if not tmpdirnc.exists():
     tmpdirnc.mkdir()
@@ -172,6 +171,7 @@ def test__check_correct_time_dim(cube, file, raises):
 
 from .._conftest_helpers import make_dummy_cube_3D_daily
 
+
 def make_cubelist(dtype):
     return iris.cube.CubeList([make_dummy_cube_3D_daily(2010,
                                                         dtype=dtype),
@@ -199,8 +199,3 @@ def test_concatenate_iris_cubes(cubes, sh, raises):
 
     assert isinstance(result, iris.cube.Cube)
     assert result.shape == sh
-
-
-if __name__ == '__main__':
-    import sys
-    pytest.main(sys.argv)

--- a/tests/io/test_read_airnow.py
+++ b/tests/io/test_read_airnow.py
@@ -1,11 +1,5 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Mon Feb  1 09:31:15 2021
-
-@author: jonasg
-"""
 import os
+from contextlib import nullcontext as does_not_raise_exception
 
 import numpy as np
 import numpy.testing as npt
@@ -16,8 +10,6 @@ from pyaerocom.exceptions import DataRetrievalError
 from pyaerocom.io.read_airnow import ReadAirNow
 from pyaerocom.stationdata import StationData
 from pyaerocom.ungriddeddata import UngriddedData
-
-from ..conftest import does_not_raise_exception
 
 
 @pytest.fixture(scope='module')
@@ -364,9 +356,3 @@ class TestReadAirNow(object):
         assert len(data.metadata) == num_meta_blocks
         assert len(data.unique_station_names) == num_stats
         assert sorted(data.contains_vars) == sorted(vars_to_retrieve)
-
-if __name__ == '__main__':
-
-    import sys
-    print(list(ReadAirNow().VAR_MAP.keys()))
-    pytest.main(sys.argv)

--- a/tests/io/test_read_earlinet.py
+++ b/tests/io/test_read_earlinet.py
@@ -1,13 +1,14 @@
-import pytest
 import os
+from contextlib import nullcontext as does_not_raise_exception
 
 import numpy as np
 import numpy.testing as npt
+import pytest
 
 from pyaerocom import VerticalProfile
 from pyaerocom.io.read_earlinet import ReadEarlinet
 
-from ..conftest import TEST_RTOL, does_not_raise_exception
+from ..conftest import TEST_RTOL
 
 FILES = ['ev/ev1008192050.e532',
          'ev/ev1009162031.e532',
@@ -126,5 +127,3 @@ def test_ReadEarlinet__get_exclude_filelist():
     reader.EXCLUDE_CASES.append('onefile.txt')
     files = reader.get_file_list(reader.PROVIDES_VARIABLES)
     assert len(files) == 5
-
-

--- a/tests/io/test_read_ebas.py
+++ b/tests/io/test_read_ebas.py
@@ -1,34 +1,11 @@
-#!/usr/bin/env python3
-# this file is part of the pyaerocom package
-# Copyright (C) 2018 met.no
-# Contact information:
-# Norwegian Meteorological Institute
-# Box 43 Blindern
-# 0313 OSLO
-# NORWAY
-# Author: Jonas Gliss
-# E-mail: jonasg@met.no
-# License: https://github.com/metno/pyaerocom/blob/master/LICENSE
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 3 of the License, or
-# (at your option) any later version.
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
-# MA 02110-1301, USA
-
 import os
+from contextlib import nullcontext as does_not_raise_exception
 
 import numpy as np
-import pyaerocom.aux_var_helpers
-import pyaerocom.exceptions as err
 import pytest
 
+import pyaerocom.aux_var_helpers
+import pyaerocom.exceptions as err
 from pyaerocom import const
 from pyaerocom.exceptions import DataCoverageError, MetaDataError, TemporalResolutionError
 from pyaerocom.io.ebas_nasa_ames import EbasNasaAmesFile
@@ -37,13 +14,7 @@ from pyaerocom.io.read_ebas import ReadEbas, ReadEbasOptions
 from pyaerocom.stationdata import StationData
 from pyaerocom.ungriddeddata import UngriddedData
 
-from ..conftest import (
-    EBAS_FILEDIR,
-    EBAS_FILES,
-    EBAS_ISSUE_FILES,
-    data_unavail,
-    does_not_raise_exception,
-)
+from ..conftest import EBAS_FILEDIR, EBAS_FILES, EBAS_ISSUE_FILES, data_unavail
 
 
 @pytest.fixture(scope='module')
@@ -513,7 +484,3 @@ class TestReadEbas(object):
                     if var in meta['var_info']:
                         unit_desired = const.VARS[var].units
                         assert meta['var_info'][var]['units'] == unit_desired
-
-if __name__ == '__main__':
-    import sys
-    pytest.main(sys.argv)

--- a/tests/io/test_read_mscw_ctm.py
+++ b/tests/io/test_read_mscw_ctm.py
@@ -1,19 +1,18 @@
-import os, cf_units
+import os
+from contextlib import nullcontext as does_not_raise_exception
+
+import cf_units
 import numpy as np
 import pytest
 import xarray as xr
 
 import pyaerocom.exceptions as exc
-from pyaerocom.griddeddata import GriddedData
 from pyaerocom import get_variable
-from pyaerocom.io.read_mscw_ctm import (
-    ReadEMEP,
-    ReadMscwCtm,
-)
+from pyaerocom.griddeddata import GriddedData
+from pyaerocom.io.read_mscw_ctm import ReadEMEP, ReadMscwCtm
 
 from .._conftest_helpers import _create_fake_MSCWCtm_data
-from ..conftest import (EMEP_DIR, does_not_raise_exception,
-                        data_unavail)
+from ..conftest import EMEP_DIR, data_unavail
 
 VAR_MAP = {'abs550aer': 'AAOD_550nm', 'abs550bc': 'AAOD_EC_550nm', 
            'absc550aer': 'AbsCoeff', 'absc550dryaer': 'AbsCoeff', 
@@ -372,5 +371,3 @@ def test_read_emep_dummy_data(tmpdir,file_vars_and_units,freq,add_read,
             for var, mean in chk_mean.items():
                 np.testing.assert_allclose(objs[var].cube.data.mean(), mean,
                                            atol=0.1)
-
-

--- a/tests/io/test_readungridded.py
+++ b/tests/io/test_readungridded.py
@@ -1,14 +1,9 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Mon Jul  9 14:14:29 2018
-"""
+from contextlib import nullcontext as does_not_raise_exception
+
 import pytest
 
 from pyaerocom import const
 from pyaerocom.io import ReadUngridded
-
-from ..conftest import does_not_raise_exception
 
 
 def test_invalid_init_data_dirs():
@@ -123,7 +118,3 @@ def test_basic_attributes():
         reader.get_lowlevel_reader()
     with pytest.raises(AttributeError):
         reader.dataset_provides_variables()
-
-if __name__=="__main__":
-    import sys
-    pytest.main(sys.argv)

--- a/tests/io/test_readungriddedbase.py
+++ b/tests/io/test_readungriddedbase.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
+from contextlib import nullcontext as does_not_raise_exception
+
 import pytest
 
 from pyaerocom import const
 from pyaerocom.io.readungriddedbase import ReadUngriddedBase
-
-from ..conftest import does_not_raise_exception
 
 
 class DummyReader(ReadUngriddedBase):
@@ -66,8 +65,3 @@ def test___init__dummy():
 def test_DummyReader_attrs(dummy_reader, key, val, raises):
     with raises:
         assert getattr(dummy_reader, key) == val
-
-if __name__ == '__main__':
-    import sys
-    pytest.main(sys.argv)
-

--- a/tests/plot/test_config.py
+++ b/tests/plot/test_config.py
@@ -8,16 +8,16 @@ def test__cmap_lighttheme():
 def test__COLOR_THEMES():
     assert list(mod._COLOR_THEMES) == ['light', 'dark']
 
-@pytest.mark.parametrize('name', [
-    ('bla', 'light', 'dark')
+@pytest.mark.parametrize('name, theme_name', [
+    pytest.param(
+        "bla", mod.DEFAULT_THEME, id="invalid color theme", marks=pytest.mark.filterwarnings("ignore:Invalid name:UserWarning"),
+    ),
+    pytest.param("light", "light", id="light color theme"),
+    pytest.param("dark", "dark", id="dark color theme"),
 ])
-def test_ColorTheme___init__(name):
+def test_ColorTheme___init__(name, theme_name):
 
-    theme = mod.ColorTheme(name)
-    if not name in mod._COLOR_THEMES:
-        assert theme.name == mod.DEFAULT_THEME
-    else:
-        assert theme.name == name
+    assert mod.ColorTheme(name).name == theme_name
 
 def test_ColorTheme_to_dict():
     value = mod.ColorTheme('dark').to_dict()

--- a/tests/plot/test_heatmaps.py
+++ b/tests/plot/test_heatmaps.py
@@ -1,11 +1,13 @@
-import pytest
-import pandas as pd
+from contextlib import nullcontext as does_not_raise_exception
+
 import numpy as np
+import pandas as pd
+import pytest
 from matplotlib.axes import Axes
 from matplotlib.colors import BoundaryNorm
 
 import pyaerocom.plot.heatmaps as mod
-from ..conftest import does_not_raise_exception
+
 
 def make_dataframe():
     colnames = ['M1', 'M2', 'M3']

--- a/tests/plot/test_heatmaps.py
+++ b/tests/plot/test_heatmaps.py
@@ -77,6 +77,7 @@ one_nan[0,0] = np.nan
      does_not_raise_exception()),
 
 ])
+@pytest.mark.filterwarnings("ignore:More than 20 figures have been opened:RuntimeWarning")
 def test_df_to_heatmap(args,raises):
     with raises:
         val = mod.df_to_heatmap(**args)

--- a/tests/plot/test_mapping.py
+++ b/tests/plot/test_mapping.py
@@ -4,6 +4,7 @@ import cartopy.mpl.geoaxes
 import numpy as np
 import pytest
 from matplotlib.figure import Figure
+import pyaerocom
 
 import pyaerocom.plot.mapping as mod
 from pyaerocom import GriddedData
@@ -111,17 +112,24 @@ def test_plot_griddeddata_on_map(data_tm5,data,args,raises):
         val = mod.plot_griddeddata_on_map(data, **args)
         assert isinstance(val, Figure)
 
-@pytest.mark.parametrize('region,kwargs,raises', [
-    ('WORLD',{},does_not_raise_exception()),
-    ('EUROPE',{},does_not_raise_exception()),
-    ('EEUROPE',{},does_not_raise_exception()),
-])
-def test_plot_map_aerocom(data_tm5,region,kwargs,raises):
+@pytest.mark.parametrize(
+    "region",
+    [
+        ("WORLD"),
+        ("EUROPE"),
+        pytest.param(
+            "EEUROPE", marks=pytest.mark.filterwarnings("ignore:Out of bound index found:DeprecationWarning"),
+        ),
+    ],
+)
+def test_plot_map_aerocom(data_tm5, region):
+    val = mod.plot_map_aerocom(data_tm5, region)
+    assert isinstance(val, Figure)
+
+def test_plot_map_aerocom_error(data_tm5):
     with pytest.raises(ValueError):
         mod.plot_map_aerocom(42, 'WORLD')
-    with raises:
-        val = mod.plot_map_aerocom(data_tm5,region,**kwargs)
-        assert isinstance(val, Figure)
+
 
 def test_plot_nmb_map_colocateddata(coldata_tm5_aeronet):
     val = mod.plot_nmb_map_colocateddata(coldata_tm5_aeronet)

--- a/tests/plot/test_mapping.py
+++ b/tests/plot/test_mapping.py
@@ -1,13 +1,15 @@
+from contextlib import nullcontext as does_not_raise_exception
+
 import cartopy.mpl.geoaxes
 import numpy as np
 import pytest
 from matplotlib.figure import Figure
 
+import pyaerocom.plot.mapping as mod
 from pyaerocom import GriddedData
 from pyaerocom.exceptions import DataDimensionError
-from pyaerocom.plot.config import get_color_theme, ColorTheme
-import pyaerocom.plot.mapping as mod
-from ..conftest import does_not_raise_exception
+from pyaerocom.plot.config import ColorTheme, get_color_theme
+
 
 @pytest.mark.parametrize('color_theme,vmin,vmax,raises,name', [
     (None,None,None,does_not_raise_exception(), 'Blues'),
@@ -136,5 +138,3 @@ def test_plot_nmb_map_colocateddataFAIL(coldata):
     cd = coldata['fake_nodims']
     with pytest.raises(AssertionError):
         mod.plot_nmb_map_colocateddata(cd)
-
-

--- a/tests/plot/test_plotscatter.py
+++ b/tests/plot/test_plotscatter.py
@@ -1,8 +1,10 @@
-import pytest
+from contextlib import nullcontext as does_not_raise_exception
+
 import numpy as np
-import pyaerocom.plot.plotscatter as mod
+import pytest
 from matplotlib.axes import Axes
-from ..conftest import does_not_raise_exception
+
+import pyaerocom.plot.plotscatter as mod
 
 
 def test_plot_scatter():

--- a/tests/plot/test_plotscatter.py
+++ b/tests/plot/test_plotscatter.py
@@ -44,10 +44,6 @@ X, Y = np.arange(100), np.arange(100)*2
           loglog=True), does_not_raise_exception())
 
 ])
-@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
-@pytest.mark.filterwarnings("ignore:Attempted to set non-positive left xlim on a log-scaled axis:UserWarning")
-@pytest.mark.filterwarnings("ignore:Attempted to set non-positive left ylim on a log-scaled axis:UserWarning")
-@pytest.mark.filterwarnings("ignore:Attempted to set non-positive bottom ylim on a log-scaled axis:UserWarning")
 def test_plot_scatter_aerocom(args,raises):
     with raises:
         val = mod.plot_scatter_aerocom(**args)

--- a/tests/plot/test_plotscatter.py
+++ b/tests/plot/test_plotscatter.py
@@ -42,6 +42,10 @@ X, Y = np.arange(100), np.arange(100)*2
           loglog=True), does_not_raise_exception())
 
 ])
+@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:Attempted to set non-positive left xlim on a log-scaled axis:UserWarning")
+@pytest.mark.filterwarnings("ignore:Attempted to set non-positive left ylim on a log-scaled axis:UserWarning")
+@pytest.mark.filterwarnings("ignore:Attempted to set non-positive bottom ylim on a log-scaled axis:UserWarning")
 def test_plot_scatter_aerocom(args,raises):
     with raises:
         val = mod.plot_scatter_aerocom(**args)

--- a/tests/test__concprcp_units_helpers.py
+++ b/tests/test__concprcp_units_helpers.py
@@ -1,8 +1,9 @@
+from contextlib import nullcontext as does_not_raise_exception
+
 import pytest
 
 import pyaerocom._concprcp_units_helpers
-from .conftest import does_not_raise_exception
-import pyaerocom._concprcp_units_helpers as mod
+
 
 @pytest.mark.parametrize('unit,ts_type,result,raises', [
 ('mg m-2/h', 'hourly', 'mg m-2 h-1', does_not_raise_exception()),

--- a/tests/test__init_helpers.py
+++ b/tests/test__init_helpers.py
@@ -1,7 +1,10 @@
+from contextlib import nullcontext as does_not_raise_exception
+
 import pytest
+
 from pyaerocom import _init_helpers as mod
 from pyaerocom import logger, print_log
-from .conftest import does_not_raise_exception
+
 
 def test_LOGLEVELS():
     assert mod.LOGLEVELS == {'debug': 10,
@@ -54,11 +57,9 @@ def test_change_verbosity(new_level, log, raises):
 ### Functions for package initialisation
 def test__init_supplemental():
     import os
-    from pkg_resources import get_distribution
     from os.path import abspath, dirname
+
+    from pkg_resources import get_distribution
     version, fpath = mod._init_supplemental()
     assert version == get_distribution('pyaerocom').version
     assert os.path.normpath(fpath).endswith('/pyaerocom')
-
-
-

--- a/tests/test__lowlevel_helpers.py
+++ b/tests/test__lowlevel_helpers.py
@@ -1,10 +1,11 @@
-import numpy as np
 import os
+from contextlib import nullcontext as does_not_raise_exception
+
+import numpy as np
 import pytest
 import simplejson
+
 from pyaerocom import _lowlevel_helpers as mod
-from .conftest import does_not_raise_exception
-import numpy as np
 
 
 def test_round_floats():
@@ -149,9 +150,3 @@ def test_sort_dict_by_name(input,pref_list,output_keys,raises):
     with raises:
         sorted = mod.sort_dict_by_name(input,pref_list)
         assert list(sorted.keys()) == output_keys
-
-
-
-
-
-

--- a/tests/test_colocateddata.py
+++ b/tests/test_colocateddata.py
@@ -200,8 +200,6 @@ def test_ColocatedData_get_coords_valid_obs(coldata,which,num_coords,raises):
     ('fake_4d', {'use_area_weights' : True}, does_not_raise_exception(),{'nmb':0}),
 
     ])
-@pytest.mark.filterwarnings("ignore:invalid value encountered in double_scalars:RuntimeWarning")
-@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
 def test_ColocatedData_calc_statistics(coldata,which,args,raises,chk):
     cd = coldata[which]
     with raises:
@@ -228,7 +226,6 @@ def test_ColocatedData_calc_statistics(coldata,which,args,raises,chk):
     ('tm5_aeronet', {'aggr' : 'max'},
      pytest.raises(ValueError),None),
     ])
-@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
 def test_ColocatedData_calc_temporal_statistics(coldata,which,args,raises,chk):
     cd = coldata[which]
     with raises:
@@ -255,8 +252,6 @@ def test_ColocatedData_calc_temporal_statistics(coldata,which,args,raises,chk):
     ('tm5_aeronet', {'aggr' : 'max'},
      pytest.raises(ValueError),None),
     ])
-@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
-@pytest.mark.filterwarnings("ignore:invalid value encountered in double_scalars:RuntimeWarning")
 def test_ColocatedData_calc_spatial_statistics(coldata,which,args,raises,chk):
     cd = coldata[which]
     with raises:
@@ -278,7 +273,6 @@ def test_ColocatedData_calc_spatial_statistics(coldata,which,args,raises,chk):
     ('fake_4d', {}, does_not_raise_exception()),
 
     ])
-@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
 def test_ColocatedData_plot_scatter(coldata,which,args,raises):
     cd = coldata[which]
     with raises:

--- a/tests/test_colocateddata.py
+++ b/tests/test_colocateddata.py
@@ -18,7 +18,6 @@ from pyaerocom.exceptions import DataCoverageError, DataDimensionError
 
 from .conftest import CHECK_PATHS, TESTDATADIR, does_not_raise_exception
 
-
 EXAMPLE_FILE = TESTDATADIR.joinpath(CHECK_PATHS['coldata_tm5_aeronet'])
 
 
@@ -207,6 +206,8 @@ def test_ColocatedData_get_coords_valid_obs(coldata,which,num_coords,raises):
     ('fake_4d', {'use_area_weights' : True}, does_not_raise_exception(),{'nmb':0}),
 
     ])
+@pytest.mark.filterwarnings("ignore:invalid value encountered in double_scalars:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
 def test_ColocatedData_calc_statistics(coldata,which,args,raises,chk):
     cd = coldata[which]
     with raises:
@@ -233,6 +234,7 @@ def test_ColocatedData_calc_statistics(coldata,which,args,raises,chk):
     ('tm5_aeronet', {'aggr' : 'max'},
      pytest.raises(ValueError),None),
     ])
+@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
 def test_ColocatedData_calc_temporal_statistics(coldata,which,args,raises,chk):
     cd = coldata[which]
     with raises:
@@ -259,6 +261,8 @@ def test_ColocatedData_calc_temporal_statistics(coldata,which,args,raises,chk):
     ('tm5_aeronet', {'aggr' : 'max'},
      pytest.raises(ValueError),None),
     ])
+@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:invalid value encountered in double_scalars:RuntimeWarning")
 def test_ColocatedData_calc_spatial_statistics(coldata,which,args,raises,chk):
     cd = coldata[which]
     with raises:
@@ -280,6 +284,7 @@ def test_ColocatedData_calc_spatial_statistics(coldata,which,args,raises,chk):
     ('fake_4d', {}, does_not_raise_exception()),
 
     ])
+@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
 def test_ColocatedData_plot_scatter(coldata,which,args,raises):
     cd = coldata[which]
     with raises:

--- a/tests/test_colocateddata.py
+++ b/tests/test_colocateddata.py
@@ -1,11 +1,5 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Thu Apr 12 14:45:43 2018
-
-@author: jonasg
-"""
 import os
+from contextlib import nullcontext as does_not_raise_exception
 
 import numpy as np
 import numpy.testing as npt
@@ -16,7 +10,7 @@ from matplotlib.axes import Axes
 from pyaerocom import ColocatedData
 from pyaerocom.exceptions import DataCoverageError, DataDimensionError
 
-from .conftest import CHECK_PATHS, TESTDATADIR, does_not_raise_exception
+from .conftest import CHECK_PATHS, TESTDATADIR
 
 EXAMPLE_FILE = TESTDATADIR.joinpath(CHECK_PATHS['coldata_tm5_aeronet'])
 

--- a/tests/test_colocation.py
+++ b/tests/test_colocation.py
@@ -120,12 +120,16 @@ def test_colocate_gridded_ungridded_new_var(data_tm5, aeronetsunv3lev2_subset):
      'yearly', (2,1,8), 0.417676, 0.275671)
 
     ])
+# numpy DeprecationWarning triggered by iris
+@pytest.mark.filterwarnings(
+    "ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning"
+)
 def test_colocate_gridded_ungridded(data_tm5, aeronetsunv3lev2_subset,
                                     addargs, ts_type, shape,
                                     obsmean, modmean):
 
     coldata = colocate_gridded_ungridded(data_tm5, aeronetsunv3lev2_subset,
-                                         **addargs)
+                                        **addargs)
 
     assert isinstance(coldata, ColocatedData)
     assert coldata.ts_type == ts_type
@@ -165,6 +169,10 @@ def test_colocate_gridded_ungridded_nonglobal(aeronetsunv3lev2_subset):
 
 
 @data_unavail
+# numpy DeprecationWarning triggered by iris
+@pytest.mark.filterwarnings(
+    "ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning"
+)
 def test_colocate_gridded_gridded_same_new_var(data_tm5):
     data = data_tm5.copy()
     data.var_name = 'Blaaa'
@@ -173,6 +181,10 @@ def test_colocate_gridded_gridded_same_new_var(data_tm5):
     assert coldata.metadata['var_name'] == ['od550aer', 'Blaaa']
 
 @data_unavail
+# numpy DeprecationWarning triggered by iris
+@pytest.mark.filterwarnings(
+    "ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning"
+)
 def test_colocate_gridded_gridded_same(data_tm5):
     coldata = colocate_gridded_gridded(data_tm5, data_tm5)
 

--- a/tests/test_colocation.py
+++ b/tests/test_colocation.py
@@ -120,10 +120,6 @@ def test_colocate_gridded_ungridded_new_var(data_tm5, aeronetsunv3lev2_subset):
      'yearly', (2,1,8), 0.417676, 0.275671)
 
     ])
-# numpy DeprecationWarning triggered by iris
-@pytest.mark.filterwarnings(
-    "ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning"
-)
 def test_colocate_gridded_ungridded(data_tm5, aeronetsunv3lev2_subset,
                                     addargs, ts_type, shape,
                                     obsmean, modmean):
@@ -169,10 +165,6 @@ def test_colocate_gridded_ungridded_nonglobal(aeronetsunv3lev2_subset):
 
 
 @data_unavail
-# numpy DeprecationWarning triggered by iris
-@pytest.mark.filterwarnings(
-    "ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning"
-)
 def test_colocate_gridded_gridded_same_new_var(data_tm5):
     data = data_tm5.copy()
     data.var_name = 'Blaaa'
@@ -181,10 +173,6 @@ def test_colocate_gridded_gridded_same_new_var(data_tm5):
     assert coldata.metadata['var_name'] == ['od550aer', 'Blaaa']
 
 @data_unavail
-# numpy DeprecationWarning triggered by iris
-@pytest.mark.filterwarnings(
-    "ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning"
-)
 def test_colocate_gridded_gridded_same(data_tm5):
     coldata = colocate_gridded_gridded(data_tm5, data_tm5)
 

--- a/tests/test_colocation_auto.py
+++ b/tests/test_colocation_auto.py
@@ -192,6 +192,12 @@ def test_Colocator_update(what,raises):
             assert col[key] == val
 
 
+# numpy DeprecationWarning triggered by iris
+@pytest.mark.filterwarnings(
+    "ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning"
+)
+# dask RuntimeWarning triggered by iris
+@pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide:RuntimeWarning")
 def test_Colocator_run_gridded_gridded(tm5_aero_stp):
     col = Colocator(**tm5_aero_stp)
     col.obs_id = col.model_id
@@ -241,9 +247,13 @@ def test_Colocator_run_gridded_gridded(tm5_aero_stp):
          pytest.raises(ColocationSetupError))
 
     ])
-def test_Colocator_run_gridded_ungridded(tm5_aero_stp,update_col,
-                                         chk_mvar,chk_ovar,sh,
-                                         mean_obs, mean_mod, raises):
+# numpy DeprecationWarning triggered by iris
+@pytest.mark.filterwarnings(
+    "ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning"
+)
+def test_Colocator_run_gridded_ungridded(
+    tm5_aero_stp, update_col, chk_mvar, chk_ovar, sh, mean_obs, mean_mod, raises
+):
     stp = ColocationSetup(**tm5_aero_stp)
     stp.update(**update_col)
     with raises:
@@ -404,6 +414,12 @@ def test_colocator_with_model_data_dir_ungridded():
     assert str(cd.stop) == '2010-12-15T00:00:00.000000000'
 
 
+# numpy DeprecationWarning triggered by iris
+@pytest.mark.filterwarnings(
+    "ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning"
+)
+# dask RuntimeWarning triggered by iris
+@pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide:RuntimeWarning")
 def test_colocator_with_obs_data_dir_gridded():
     col = Colocator(save_coldata=False)
     col.model_id='TM5-met2010_CTRL-TEST'

--- a/tests/test_colocation_auto.py
+++ b/tests/test_colocation_auto.py
@@ -98,7 +98,6 @@ def test_Colocator__add_attr(col):
     ('daily', 'monthly', False, does_not_raise_exception()),
     ('monthly', 'monthly', False, does_not_raise_exception()),
     ])
-@pytest.mark.filterwarnings("ignore:invalid value encountered in reduce:RuntimeWarning")
 def test_Colocator_model_ts_type_read(tm5_aero_stp,ts_type_desired,
                                       ts_type, flex, raises):
     col = Colocator(**tm5_aero_stp)
@@ -194,13 +193,6 @@ def test_Colocator_update(what,raises):
             assert col[key] == val
 
 
-# numpy DeprecationWarning triggered by iris
-@pytest.mark.filterwarnings(
-    "ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning"
-)
-# dask RuntimeWarning triggered by iris
-@pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide:RuntimeWarning")
-@pytest.mark.filterwarnings("ignore:invalid value encountered in reduce:RuntimeWarning")
 def test_Colocator_run_gridded_gridded(tm5_aero_stp):
     col = Colocator(**tm5_aero_stp)
     col.obs_id = col.model_id
@@ -250,10 +242,6 @@ def test_Colocator_run_gridded_gridded(tm5_aero_stp):
          pytest.raises(ColocationSetupError))
 
     ])
-# numpy DeprecationWarning triggered by iris
-@pytest.mark.filterwarnings(
-    "ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning"
-)
 def test_Colocator_run_gridded_ungridded(
     tm5_aero_stp, update_col, chk_mvar, chk_ovar, sh, mean_obs, mean_mod, raises
 ):
@@ -417,12 +405,6 @@ def test_colocator_with_model_data_dir_ungridded():
     assert str(cd.stop) == '2010-12-15T00:00:00.000000000'
 
 
-# numpy DeprecationWarning triggered by iris
-@pytest.mark.filterwarnings(
-    "ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning"
-)
-# dask RuntimeWarning triggered by iris
-@pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide:RuntimeWarning")
 def test_colocator_with_obs_data_dir_gridded():
     col = Colocator(save_coldata=False)
     col.model_id='TM5-met2010_CTRL-TEST'

--- a/tests/test_colocation_auto.py
+++ b/tests/test_colocation_auto.py
@@ -1,4 +1,5 @@
 import os
+from contextlib import nullcontext as does_not_raise_exception
 
 import numpy as np
 import numpy.testing as npt
@@ -10,7 +11,7 @@ from pyaerocom.exceptions import ColocationError, ColocationSetupError
 from pyaerocom.io import ReadMscwCtm
 from pyaerocom.io.aux_read_cubes import add_cubes
 
-from .conftest import data_unavail, does_not_raise_exception, tda
+from .conftest import data_unavail, tda
 
 HOME = os.path.expanduser('~')
 COL_OUT_DEFAULT = os.path.join(HOME, 'MyPyaerocom/colocated_data')
@@ -439,8 +440,3 @@ def test_colocator_with_obs_data_dir_gridded():
     assert cd.ts_type=='monthly'
     assert str(cd.start) == '2010-01-15T12:00:00.000000000'
     assert str(cd.stop) == '2010-12-15T12:00:00.000000000'
-
-
-if __name__ == '__main__':
-    import sys
-    pytest.main(sys.argv)

--- a/tests/test_colocation_auto.py
+++ b/tests/test_colocation_auto.py
@@ -97,6 +97,7 @@ def test_Colocator__add_attr(col):
     ('daily', 'monthly', False, does_not_raise_exception()),
     ('monthly', 'monthly', False, does_not_raise_exception()),
     ])
+@pytest.mark.filterwarnings("ignore:invalid value encountered in reduce:RuntimeWarning")
 def test_Colocator_model_ts_type_read(tm5_aero_stp,ts_type_desired,
                                       ts_type, flex, raises):
     col = Colocator(**tm5_aero_stp)
@@ -198,6 +199,7 @@ def test_Colocator_update(what,raises):
 )
 # dask RuntimeWarning triggered by iris
 @pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:invalid value encountered in reduce:RuntimeWarning")
 def test_Colocator_run_gridded_gridded(tm5_aero_stp):
     col = Colocator(**tm5_aero_stp)
     col.obs_id = col.model_id

--- a/tests/test_combine_vardata_ungridded.py
+++ b/tests/test_combine_vardata_ungridded.py
@@ -1,10 +1,4 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Thu Oct 22 10:14:59 2020
-
-@author: jonasg
-"""
+from contextlib import nullcontext as does_not_raise_exception
 
 import numpy as np
 import numpy.testing as npt
@@ -12,7 +6,7 @@ import pytest
 
 import pyaerocom.combine_vardata_ungridded as testmod
 
-from .conftest import aeronetsdav3lev2_subset, aeronetsunv3lev2_subset, does_not_raise_exception
+from .conftest import aeronetsdav3lev2_subset, aeronetsunv3lev2_subset
 
 SUN_DATA = aeronetsunv3lev2_subset
 SDA_DATA = aeronetsdav3lev2_subset
@@ -239,8 +233,3 @@ def test__combine_2_sites_same_site(stats_sun_aod, merge_how, merge_eval_fun,
     assert new.data_id == dataid
     assert len(stat1[var1].dropna()) == len(new[vno])
     assert new.get_unit(vno) == unitout
-
-
-if __name__ == '__main__':
-    import sys
-    pytest.main(sys.argv)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,13 +1,7 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Mon Nov 25 15:27:28 2019
-
-@author: jonasg
-"""
 import getpass
 import os
 import tempfile
+from contextlib import nullcontext as does_not_raise_exception
 
 import pytest
 
@@ -15,7 +9,7 @@ import pyaerocom.config as testmod
 from pyaerocom import const as DEFAULT_CFG
 from pyaerocom.config import Config
 
-from .conftest import PYADIR, does_not_raise_exception, lustre_avail
+from .conftest import PYADIR, lustre_avail
 
 USER = getpass.getuser()
 
@@ -303,8 +297,3 @@ def test_default_config():
 
     from pyaerocom.grid_io import GridIO
     assert isinstance(cfg.GRID_IO, GridIO)
-
-### NEED TO TEST MORE CLASS METHODS...
-if __name__ == '__main__':
-    import sys
-    pytest.main(sys.argv)

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -31,6 +31,10 @@ def test_filter_attributes():
     ('EUROPE-noMOUNTAINS-OCN', 0.1314668),
     ('EUROPE', 0.13605888)
     ])
+# numpy DeprecationWarning triggered by iris
+@pytest.mark.filterwarnings(
+    "ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning"
+)
 def test_filter_griddeddata(data_tm5, filter_name, mean):
 
     # use copy so that this fixture can be used elsewhere without being c

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -31,10 +31,6 @@ def test_filter_attributes():
     ('EUROPE-noMOUNTAINS-OCN', 0.1314668),
     ('EUROPE', 0.13605888)
     ])
-# numpy DeprecationWarning triggered by iris
-@pytest.mark.filterwarnings(
-    "ignore:`np.bool` is a deprecated alias for the builtin `bool`:DeprecationWarning"
-)
 def test_filter_griddeddata(data_tm5, filter_name, mean):
 
     # use copy so that this fixture can be used elsewhere without being c

--- a/tests/test_griddeddata.py
+++ b/tests/test_griddeddata.py
@@ -1,9 +1,5 @@
-"""
-Created on Thu Apr 12 14:45:43 2018
-
-@author: jonasg
-"""
 import os
+from contextlib import nullcontext as does_not_raise_exception
 from datetime import datetime
 
 import iris.cube
@@ -22,7 +18,7 @@ from pyaerocom.exceptions import (
 )
 from pyaerocom.io import ReadGridded
 
-from .conftest import TEST_RTOL, data_unavail, does_not_raise_exception
+from .conftest import TEST_RTOL, data_unavail
 
 TESTLATS =  [-10, 20]
 TESTLONS =  [-120, 69]

--- a/tests/test_griddeddata.py
+++ b/tests/test_griddeddata.py
@@ -361,13 +361,6 @@ def _make_fake_dataset(var_name, units):
     ('concco', 'ugC/m3', 'ug C m-3'),
 
 ])
-# iris UserWarning
-@pytest.mark.filterwarnings(
-    "ignore:Ignoring netCDF variable 'od550aer' invalid units 'invalid':UserWarning"
-)
-@pytest.mark.filterwarnings(
-    "ignore:Ignoring netCDF variable 'concco' invalid units 'ugC/m3':UserWarning"
-)
 def test_GriddedData__check_invalid_unit_alias(tmpdir, var_name, units, data_unit):
 
     ds = _make_fake_dataset(var_name,units)

--- a/tests/test_griddeddata.py
+++ b/tests/test_griddeddata.py
@@ -1,23 +1,25 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Created on Thu Apr 12 14:45:43 2018
 
 @author: jonasg
 """
-import iris.cube
 import os
 from datetime import datetime
+
+import iris.cube
 import numpy as np
 import numpy.testing as npt
 import pytest
 import xarray as xr
 
 from pyaerocom import GriddedData, Variable
-from pyaerocom.exceptions import (CoordinateError, DataDimensionError,
-                                  DataSearchError, VariableDefinitionError,
-                                  VariableNotFoundError)
-
+from pyaerocom.exceptions import (
+    CoordinateError,
+    DataDimensionError,
+    DataSearchError,
+    VariableDefinitionError,
+    VariableNotFoundError,
+)
 from pyaerocom.io import ReadGridded
 
 from .conftest import TEST_RTOL, data_unavail, does_not_raise_exception
@@ -363,14 +365,20 @@ def _make_fake_dataset(var_name, units):
     ('concco', 'ugC/m3', 'ug C m-3'),
 
 ])
-def test_GriddedData__check_invalid_unit_alias(tmpdir,var_name,units,
-                                               data_unit):
+# iris UserWarning
+@pytest.mark.filterwarnings(
+    "ignore:Ignoring netCDF variable 'od550aer' invalid units 'invalid':UserWarning"
+)
+@pytest.mark.filterwarnings(
+    "ignore:Ignoring netCDF variable 'concco' invalid units 'ugC/m3':UserWarning"
+)
+def test_GriddedData__check_invalid_unit_alias(tmpdir, var_name, units, data_unit):
 
     ds = _make_fake_dataset(var_name,units)
     path = os.path.join(tmpdir, 'output.nc')
     ds.to_netcdf(path)
     assert os.path.exists(path)
+
     data = GriddedData(path, var_name=var_name, check_unit=False)
     data._check_invalid_unit_alias()
     assert data.units == data_unit
-

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -87,6 +87,7 @@ def fake_hourly_ts():
     ('daily', '25percentile', None, 8, -0.64),
     ('daily', '75percentile', None, 8, 0.64),
     ])
+@pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning")
 def test_resample_timeseries(fake_hourly_ts, freq, how, min_num_obs, num, avg):
 
     s1 = helpers.resample_timeseries(fake_hourly_ts, freq=freq, how=how,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext as does_not_raise_exception
+
 import numpy as np
 import numpy.testing as npt
 import pandas as pd
@@ -6,8 +8,6 @@ import xarray as xr
 
 from pyaerocom import StationData, helpers
 from pyaerocom.exceptions import DataCoverageError, TemporalResolutionError, UnitConversionError
-
-from .conftest import does_not_raise_exception
 
 
 def test_get_standarad_name():
@@ -192,7 +192,3 @@ def test_seconds_in_periods(date, ts_type, expected):
     ts = np.datetime64(date)
     seconds = helpers.seconds_in_periods(ts, ts_type)
     assert seconds == expected*seconds_in_day
-
-if __name__ == "__main__":
-    import sys
-    pytest.main(sys.argv)

--- a/tests/test_mathutils.py
+++ b/tests/test_mathutils.py
@@ -135,8 +135,6 @@ nanmask[100:300] = np.nan
      does_not_raise_exception()),
 
     ])
-@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
-@pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide:RuntimeWarning")
 def test_calc_statistics(data, ref_data, lowlim, highlim, min_num_valid,
                          weights, expected, raises):
     with raises:

--- a/tests/test_mathutils.py
+++ b/tests/test_mathutils.py
@@ -1,15 +1,11 @@
-"""
-Tests for _lowlevel_helpers.py module of pyaerocom
-"""
+from contextlib import nullcontext as does_not_raise_exception
+
 import numpy as np
 import numpy.testing as npt
 import pytest
-from scipy.stats.stats import PearsonRConstantInputWarning
 
 import pyaerocom.aux_var_helpers
 import pyaerocom.mathutils as mu
-
-from .conftest import does_not_raise_exception
 
 
 @pytest.mark.parametrize('vmin, vmax, num', [

--- a/tests/test_mathutils.py
+++ b/tests/test_mathutils.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 """
 Tests for _lowlevel_helpers.py module of pyaerocom
 """
 import numpy as np
 import numpy.testing as npt
 import pytest
+from scipy.stats.stats import PearsonRConstantInputWarning
 
 import pyaerocom.aux_var_helpers
 import pyaerocom.mathutils as mu
@@ -140,11 +139,13 @@ nanmask[100:300] = np.nan
      does_not_raise_exception()),
 
     ])
+@pytest.mark.filterwarnings("ignore:An input array is constant:RuntimeWarning")
+@pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide:RuntimeWarning")
 def test_calc_statistics(data, ref_data, lowlim, highlim, min_num_valid,
                          weights, expected, raises):
     with raises:
         stats = mu.calc_statistics(data, ref_data, lowlim, highlim, min_num_valid,
-                                   weights)
+                                    weights)
         assert isinstance(stats, dict)
         assert len(stats) == len(expected)
         for key, val in expected.items():

--- a/tests/test_obs_io.py
+++ b/tests/test_obs_io.py
@@ -1,16 +1,8 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Fri Oct 23 10:13:58 2020
-
-@author: jonasg
-"""
+from contextlib import nullcontext as does_not_raise_exception
 
 import pytest
 
 from pyaerocom import obs_io as testmod
-
-from .conftest import does_not_raise_exception
 
 AuxInfoUngriddedTypes = dict(
     data_id = str,
@@ -103,7 +95,3 @@ def test_AuxInfoUngridded___init__(argdict, expectation):
         info = testmod.AuxInfoUngridded(**argdict)
         for key, dtype in AuxInfoUngriddedTypes.items():
             assert isinstance(info.__dict__[key], dtype)
-
-if __name__=='__main__':
-    import sys
-    pytest.main(sys.argv)

--- a/tests/test_stationdata.py
+++ b/tests/test_stationdata.py
@@ -217,6 +217,7 @@ def test_StationData__check_ts_types_for_merge(s1,s2,var_name,val):
     (stat1,'od550aer', 10, 20, True, np.nan, does_not_raise_exception())
 
 ])
+@pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning")
 def test_StationData_remove_outliers(stat,var_name,low,high,check_unit,mean,
                                      raises):
     with raises:

--- a/tests/test_stationdata.py
+++ b/tests/test_stationdata.py
@@ -1,15 +1,23 @@
-import numpy as np
-import pytest
-import pandas as pd
-from xarray import DataArray
-from matplotlib.axes import Axes
+from contextlib import nullcontext as does_not_raise_exception
 
-from pyaerocom.exceptions import MetaDataError, UnitConversionError, \
-    DataUnitError, CoordinateError, VarNotAvailableError, \
-    DataExtractionError
+import numpy as np
+import pandas as pd
+import pytest
+from matplotlib.axes import Axes
+from xarray import DataArray
+
 from pyaerocom import stationdata as mod
+from pyaerocom.exceptions import (
+    CoordinateError,
+    DataUnitError,
+    MetaDataError,
+    UnitConversionError,
+    VarNotAvailableError,
+)
 from pyaerocom.io import ReadEarlinet
-from .conftest import FAKE_STATION_DATA, does_not_raise_exception
+
+from .conftest import FAKE_STATION_DATA
+
 
 def get_earlinet_data(var_name):
     data = ReadEarlinet('Earlinet-test').read(vars_to_retrieve=var_name)

--- a/tests/test_time_resampler.py
+++ b/tests/test_time_resampler.py
@@ -1,10 +1,5 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Tue Nov 24 17:11:58 2020
+from contextlib import nullcontext as does_not_raise_exception
 
-@author: jonasg
-"""
 import numpy as np
 import pandas as pd
 import pytest
@@ -14,8 +9,6 @@ from iris.cube import Cube
 from pyaerocom import GriddedData, TsType
 from pyaerocom.helpers import resample_time_dataarray, resample_timeseries
 from pyaerocom.time_resampler import TimeResampler
-
-from .conftest import does_not_raise_exception
 
 # get default resampling "min_num_obs"
 min_num_obs_default = {'yearly': {'monthly': 3},
@@ -114,7 +107,3 @@ def test_TimeResampler_resample(fakedata_hourly, args, output_len,
     notnan = ~np.isnan(ts)
     assert notnan.sum() == output_numnotnan
     assert tr.last_units_preserved == lup
-
-if __name__ == '__main__':
-    import sys
-    pytest.main(sys.argv)

--- a/tests/test_tstype.py
+++ b/tests/test_tstype.py
@@ -1,17 +1,10 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Thu Apr 12 14:45:43 2018
+from contextlib import nullcontext as does_not_raise_exception
 
-@author: jonasg
-"""
 import numpy as np
 import pytest
 
 from pyaerocom.exceptions import TemporalResolutionError
 from pyaerocom.tstype import TsType
-
-from .conftest import does_not_raise_exception
 
 
 def test_TsType_VALID():
@@ -311,8 +304,3 @@ def test_TsType__str__():
 
 def test_TsType__repr__():
     assert repr(TsType('daily')) == 'daily'
-
-if __name__=="__main__":
-
-    import sys
-    pytest.main(sys.argv)

--- a/tests/test_ungriddeddata.py
+++ b/tests/test_ungriddeddata.py
@@ -160,6 +160,7 @@ def test_check_unit(data_scat_jungfraujoch):
         data_scat_jungfraujoch.check_unit('sc550aer', unit='m-1')
 
 
+@pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide:RuntimeWarning")
 def test_check_convert_var_units(data_scat_jungfraujoch):
 
     out = data_scat_jungfraujoch.check_convert_var_units('sc550aer', 'm-1',
@@ -174,8 +175,6 @@ def test_check_convert_var_units(data_scat_jungfraujoch):
 
             data0 =  data_scat_jungfraujoch._data[idx, data_idx]
             data1 = out._data[idx, data_idx]
-
-
 
             ratio = np.divide(data1, data0)#[~nans]
 

--- a/tests/test_units_helpers.py
+++ b/tests/test_units_helpers.py
@@ -1,20 +1,11 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-"""
-Created on Thu Apr 12 14:45:43 2018
+from contextlib import nullcontext as does_not_raise_exception
 
-@author: jonasg
-"""
 import numpy.testing as npt
 import pytest
 
-import pyaerocom._concprcp_units_helpers
-import pyaerocom.units_helpers
-from pyaerocom.exceptions import UnitConversionError
-from pyaerocom.griddeddata import GriddedData
 from pyaerocom import units_helpers as mod
+from pyaerocom.exceptions import UnitConversionError
 
-from .conftest import data_unavail, does_not_raise_exception
 
 @pytest.mark.parametrize('unit,val', [
     ('ug min-1', True),('ug/min', True),('ug', False),
@@ -100,5 +91,3 @@ def test_get_unit_conversion_fac(from_unit,to_unit,var_name,ts_type,result,
     with raises:
         val = mod.get_unit_conversion_fac(from_unit,to_unit,var_name,ts_type)
         npt.assert_allclose(val, result, rtol=1e-3)
-
-

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
+from contextlib import nullcontext as does_not_raise_exception
 import os
 
 import pytest
 
 from pyaerocom import utils
 
-from .conftest import data_unavail, does_not_raise_exception
+from .conftest import data_unavail
 
 
 def test_print_file(tmpdir):
@@ -31,10 +31,3 @@ def test_create_varinfo_table(kwargs, raises, tabshape):
     with raises:
         df =  utils.create_varinfo_table(**kwargs)
         assert df.shape == tabshape
-
-
-
-
-if __name__=='__main__':
-    import sys
-    pytest.main(sys.argv)

--- a/tests/test_varcollection.py
+++ b/tests/test_varcollection.py
@@ -1,10 +1,12 @@
-import pytest
 import os
+from contextlib import nullcontext as does_not_raise_exception
+
+import pytest
+
+import pyaerocom.varcollection as mod
 from pyaerocom import __dir__ as pyadir
 from pyaerocom.exceptions import VariableDefinitionError
 from pyaerocom.variable import Variable
-import pyaerocom.varcollection as mod
-from .conftest import does_not_raise_exception
 
 VAR_INI = os.path.join(pyadir, 'data', 'variables.ini')
 

--- a/tests/test_variable.py
+++ b/tests/test_variable.py
@@ -1,6 +1,9 @@
+from contextlib import nullcontext as does_not_raise_exception
+
 import pytest
+
 from pyaerocom.variable import Variable
-from .conftest import does_not_raise_exception
+
 
 @pytest.mark.parametrize('var_name,init,cfg,kwargs,raises', [
     (None, True, None, {}, does_not_raise_exception()),

--- a/tests/test_vertical_profile.py
+++ b/tests/test_vertical_profile.py
@@ -1,6 +1,9 @@
+from contextlib import nullcontext as does_not_raise_exception
+
 import pytest
+
 import pyaerocom.vertical_profile as mod
-from .conftest import does_not_raise_exception
+
 
 @pytest.mark.parametrize('args,raises', [
     (dict(), pytest.raises(TypeError)),

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,0 +1,17 @@
+import warnings
+
+import pytest
+
+from pyaerocom._warnings_management import filter_warnings
+
+@pytest.mark.filterwarnings("error")
+def test_filter_warnings():
+    @filter_warnings(True, [UserWarning], messages=["Deprecated"])
+    def add_num_with_warnings(num1, num2):
+        warnings.warn(UserWarning("User Warning"))
+        warnings.warn(DeprecationWarning("Deprecated"))
+        warnings.warn(Warning("General warning"))
+        return num1 + num2
+
+    with pytest.warns(Warning, match="General warning"):
+        add_num_with_warnings(1, 2)

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -7,8 +7,8 @@ from pyaerocom._warnings_management import ignore_warnings
 
 @pytest.mark.filterwarnings("error")
 def test_filter_warnings_decorator():
-    @ignore_warnings(True, UserWarning, messages="User Warning")
-    @ignore_warnings(True, DeprecationWarning, messages="Deprecated")
+    @ignore_warnings(True, UserWarning, "User Warning")
+    @ignore_warnings(True, DeprecationWarning, "Deprecated")
     def add_num_with_warnings(num1, num2):
         warnings.warn(UserWarning("User Warning"))
         warnings.warn(DeprecationWarning("Deprecated"))
@@ -39,15 +39,15 @@ def test_filter_warnings_message():
     """filter one warning based on the warning message"""
 
     # ignore warning
-    with ignore_warnings(True, messages="Deprecated"):
+    with ignore_warnings(True, Warning, "Deprecated"):
         warnings.warn(Warning("Deprecated"))
 
-    with ignore_warnings(True, messages=["A", "B", "C"]):
+    with ignore_warnings(True, Warning, "A", "B", "C"):
         warnings.warn(Warning("A"))
         warnings.warn(Warning("B"))
         warnings.warn(Warning("C"))
 
     # raise warning
     with pytest.warns(Warning, match="Deprecated"):
-        with ignore_warnings(False, messages=["Deprecated"]):
+        with ignore_warnings(False, Warning, "Deprecated"):
             warnings.warn(Warning("Deprecated"))

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -2,19 +2,20 @@ import warnings
 
 import pytest
 
-from pyaerocom._warnings_management import filter_warnings
+from pyaerocom._warnings_management import ignore_warnings
 
 
 @pytest.mark.filterwarnings("error")
 def test_filter_warnings_decorator():
-    @filter_warnings(True, [UserWarning], messages=["Deprecated"])
+    @ignore_warnings(True, UserWarning, messages="User Warning")
+    @ignore_warnings(True, DeprecationWarning, messages="Deprecated")
     def add_num_with_warnings(num1, num2):
         warnings.warn(UserWarning("User Warning"))
         warnings.warn(DeprecationWarning("Deprecated"))
-        warnings.warn(Warning("General warning"))
+        warnings.warn(UserWarning("General warning"))
         return num1 + num2
 
-    with pytest.warns(Warning, match="General warning"):
+    with pytest.warns(UserWarning, match="General warning"):
         add_num_with_warnings(1, 2)
 
 
@@ -23,17 +24,13 @@ def test_filter_warnings_category():
     """filter one warning based on the type of warning"""
 
     # ignore warning
-    with filter_warnings(True, [RuntimeWarning]):
+    with ignore_warnings(True, RuntimeWarning):
         warnings.warn(RuntimeWarning("somethng unexpected..."))
 
-    with filter_warnings(True, [RuntimeWarning, UserWarning, DeprecationWarning]):
-        warnings.warn(RuntimeWarning("somethng unexpected?."))
-        warnings.warn(UserWarning("somethng unusual?"))
-        warnings.warn(DeprecationWarning("somethng deprecated?"))
 
     # raise warning
     with pytest.warns(RuntimeWarning):
-        with filter_warnings(False, [RuntimeWarning]):
+        with ignore_warnings(False, RuntimeWarning):
             warnings.warn(RuntimeWarning("somethng unexpected..."))
 
 
@@ -42,15 +39,15 @@ def test_filter_warnings_message():
     """filter one warning based on the warning message"""
 
     # ignore warning
-    with filter_warnings(True, messages=["Deprecated"]):
+    with ignore_warnings(True, messages="Deprecated"):
         warnings.warn(Warning("Deprecated"))
 
-    with filter_warnings(True, messages=["A", "B", "C"]):
+    with ignore_warnings(True, messages=["A", "B", "C"]):
         warnings.warn(Warning("A"))
         warnings.warn(Warning("B"))
         warnings.warn(Warning("C"))
 
     # raise warning
     with pytest.warns(Warning, match="Deprecated"):
-        with filter_warnings(False, messages=["Deprecated"]):
+        with ignore_warnings(False, messages=["Deprecated"]):
             warnings.warn(Warning("Deprecated"))

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -4,8 +4,9 @@ import pytest
 
 from pyaerocom._warnings_management import filter_warnings
 
+
 @pytest.mark.filterwarnings("error")
-def test_filter_warnings():
+def test_filter_warnings_decorator():
     @filter_warnings(True, [UserWarning], messages=["Deprecated"])
     def add_num_with_warnings(num1, num2):
         warnings.warn(UserWarning("User Warning"))
@@ -15,3 +16,41 @@ def test_filter_warnings():
 
     with pytest.warns(Warning, match="General warning"):
         add_num_with_warnings(1, 2)
+
+
+@pytest.mark.filterwarnings("error")
+def test_filter_warnings_category():
+    """filter one warning based on the type of warning"""
+
+    # ignore warning
+    with filter_warnings(True, [RuntimeWarning]):
+        warnings.warn(RuntimeWarning("somethng unexpected..."))
+
+    with filter_warnings(True, [RuntimeWarning, UserWarning, DeprecationWarning]):
+        warnings.warn(RuntimeWarning("somethng unexpected?."))
+        warnings.warn(UserWarning("somethng unusual?"))
+        warnings.warn(DeprecationWarning("somethng deprecated?"))
+
+    # raise warning
+    with pytest.warns(RuntimeWarning):
+        with filter_warnings(False, [RuntimeWarning]):
+            warnings.warn(RuntimeWarning("somethng unexpected..."))
+
+
+@pytest.mark.filterwarnings("error")
+def test_filter_warnings_message():
+    """filter one warning based on the warning message"""
+
+    # ignore warning
+    with filter_warnings(True, messages=["Deprecated"]):
+        warnings.warn(Warning("Deprecated"))
+
+    with filter_warnings(True, messages=["A", "B", "C"]):
+        warnings.warn(Warning("A"))
+        warnings.warn(Warning("B"))
+        warnings.warn(Warning("C"))
+
+    # raise warning
+    with pytest.warns(Warning, match="Deprecated"):
+        with filter_warnings(False, messages=["Deprecated"]):
+            warnings.warn(Warning("Deprecated"))


### PR DESCRIPTION
Deal with warnings raised while testing
- [x] ignore warnings raised when importing external modules
- [x] ignore warnings raised on external modules
- [x] address `DeprecationWarnings` raised on pyaercom modules
- [x] address warnings raised on internal modules (ignore when large refactor would be needed)
- [x] new warnings to raise an error (configure `filterwarnings`)
