### PR TITLE
fix ungriddedata.UngriddedData.from_stationdata with single station

### DIFF
--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -268,7 +268,7 @@ class UngriddedData:
         elif not isinstance(add_meta_keys, list):
             raise ValueError(f"Invalid input for add_meta_keys {add_meta_keys}... need list")
         if isinstance(stats, StationData):
-            stats = [StationData]
+            stats = [stats]
         data_obj = UngriddedData(num_points=1000000)
 
         meta_key = 0.0

--- a/tests/test_ungriddeddata.py
+++ b/tests/test_ungriddeddata.py
@@ -8,7 +8,7 @@ from pyaerocom import UngriddedData, ungriddeddata
 from pyaerocom.exceptions import DataCoverageError
 from tests.synthetic_data import FakeStationDataAccess
 
-from .conftest import data_unavail, rg_unavail, FAKE_STATION_DATA
+from .conftest import FAKE_STATION_DATA, data_unavail, rg_unavail
 
 
 @pytest.fixture(scope="module")
@@ -253,6 +253,7 @@ def test_check_convert_var_units(data_scat_jungfraujoch):
             ratio = ratio[~np.isnan(ratio)]
 
             npt.assert_allclose(actual=[ratio.mean(), ratio.std()], desired=[fac, 0], atol=1e-20)
+
 
 def test_from_single_station_data():
     stat = FAKE_STATION_DATA["station_data1"]

--- a/tests/test_ungriddeddata.py
+++ b/tests/test_ungriddeddata.py
@@ -4,10 +4,11 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-from pyaerocom import UngriddedData
+from pyaerocom import UngriddedData, ungriddeddata
 from pyaerocom.exceptions import DataCoverageError
+from tests.synthetic_data import FakeStationDataAccess
 
-from .conftest import data_unavail, rg_unavail
+from .conftest import data_unavail, rg_unavail, FAKE_STATION_DATA
 
 
 @pytest.fixture(scope="module")
@@ -252,3 +253,10 @@ def test_check_convert_var_units(data_scat_jungfraujoch):
             ratio = ratio[~np.isnan(ratio)]
 
             npt.assert_allclose(actual=[ratio.mean(), ratio.std()], desired=[fac, 0], atol=1e-20)
+
+def test_from_single_station_data():
+    stat = FAKE_STATION_DATA["station_data1"]
+    d = ungriddeddata.UngriddedData.from_station_data(stat)
+    data0 = stat.ec550aer
+    data1 = d.all_datapoints_var("ec550aer")
+    npt.assert_allclose(data0, data1, atol=1e-20)


### PR DESCRIPTION
Fixes the bug with the ungriddeddata.UngriddedData.from_station_data() for loading single station data object.  

I also added a test for creating UngriddedData from single station data objects.