### PR TITLE
update conda CI jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -97,15 +97,6 @@ jobs:
         shell: bash -l {0}
     steps:
     - uses: actions/checkout@v2.3.4
-    - name: Set cache date
-      run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
-    - name: Cache conda environment
-      uses: actions/cache@v2
-      with:
-        path: /usr/share/miniconda3/envs/pya
-        key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('pyaerocom_env.yml') }}-${{ env.DATE }}
-        restore-keys: |
-          ${{ runner.os }}-conda-${{ matrix.python-version }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: conda-incubator/setup-miniconda@v2
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,14 +102,24 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         activate-environment: pya
-        environment-file: pyaerocom_env.yml
-        auto-activate-base: false
     - name: Conda info
       run: |
         conda --version
         conda info --envs
         which python
         python --version
+    - name: Set cache date
+      run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+    - uses: actions/cache@v2
+      with:
+        path: |
+          /usr/share/miniconda3/envs/pya
+        key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('pyaerocom_env.yml') }}-${{ env.DATE }}
+        restore-keys: |
+          ${{ runner.os }}-conda-${{ matrix.python-version }}
+    - name: Update environment
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: conda env update -n pya -f ./pyaerocom_env.yml
     - name: Install pyaerocom
       run: python -m pip install . --no-deps
     - name: Run pytest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -102,24 +102,14 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         activate-environment: pya
+        environment-file: pyaerocom_env.yml
+        auto-activate-base: false
     - name: Conda info
       run: |
         conda --version
         conda info --envs
         which python
         python --version
-    - name: Set cache date
-      run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
-    - uses: actions/cache@v2
-      with:
-        path: |
-          /usr/share/miniconda3/envs/pya
-        key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('pyaerocom_env.yml') }}-${{ env.DATE }}
-        restore-keys: |
-          ${{ runner.os }}-conda-${{ matrix.python-version }}
-    - name: Update environment
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: conda env update -n pya -f ./pyaerocom_env.yml
     - name: Install pyaerocom
       run: python -m pip install . --no-deps
     - name: Run pytest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,9 +52,10 @@ jobs:
     - name: Build docs
       run: tox -e docs
 
-  build:
+  venv:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.8, 3.9, '3.10']
     steps:
@@ -86,9 +87,9 @@ jobs:
       run: tox -e py
 
   conda:
-  # needs: lint
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.8, 3.9]
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,25 +92,26 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9]
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
     - uses: actions/checkout@v2.3.4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: s-weigand/setup-conda@v1.0.5
+      uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
+        activate-environment: pya
+        environment-file: pyaerocom_env.yml
+        auto-activate-base: false
     - name: Conda info
       run: |
         conda --version
         conda info --envs
         which python
         python --version
-    - name: Update test environment
-      run: |
-        conda env update -n base -f ./pyaerocom_env.yml
     - name: Install pyaerocom
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install . --no-deps
+      run: python -m pip install . --no-deps
     - name: Run pytest
       run: pytest --cov=pyaerocom/ --cov-report xml
     - name: Upload coverage to Codecov

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -114,7 +114,7 @@ jobs:
     - name: Run pytest
       run: pytest --cov=pyaerocom/ --cov-report xml
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1.0.3
+      uses: codecov/codecov-action@v2
       with:
           file: ./coverage.xml
           flags: unittests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ jobs:
     env:
       PYTHON: 3.8
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ env.PYTHON }}
       uses: actions/setup-python@v2
       with:
@@ -34,7 +34,7 @@ jobs:
     env:
       PYTHON: 3.8
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ env.PYTHON }}
       uses: actions/setup-python@v2
       with:
@@ -59,7 +59,7 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, '3.10']
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -96,7 +96,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: conda-incubator/setup-miniconda@v2
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -97,6 +97,15 @@ jobs:
         shell: bash -l {0}
     steps:
     - uses: actions/checkout@v2.3.4
+    - name: Set cache date
+      run: echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+    - name: Cache conda environment
+      uses: actions/cache@v2
+      with:
+        path: /usr/share/miniconda3/envs/pya
+        key: ${{ runner.os }}-conda-${{ matrix.python-version }}-${{ hashFiles('pyaerocom_env.yml') }}-${{ env.DATE }}
+        restore-keys: |
+          ${{ runner.os }}-conda-${{ matrix.python-version }}
     - name: Set up Python ${{ matrix.python-version }}
       uses: conda-incubator/setup-miniconda@v2
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, '3.10']
     defaults:
       run:
         shell: bash -l {0}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,7 +103,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
         activate-environment: pya
         environment-file: pyaerocom_env.yml
-        auto-activate-base: false
     - name: Conda info
       run: |
         conda --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ filterwarnings = [
   "ignore:distutils Version classes are deprecated:DeprecationWarning",
   # numpy calling distutils.sysconfig.customize_compiler on Python 3.10
   "ignore:The distutils.sysconfig module is deprecated:DeprecationWarning",
+  # tornado calling asyncio.get_event_loop on Python 3.10
+  "ignore:There is no current event loop:DeprecationWarning",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
- [x] use [setup-miniconda] gh-action
- [X] add Python 3.10 to conda matrix

After these updates, the conda jobs take ~[7 min] in total.
The time savings come from reducing the time to create a new conda environment down to ~[3 min].

Also tried caching the environment, following [this example][caching-environments].
Updating the environment (as recommended once every day) took ~[9 min] for Python 3.9 and ~[38 min] for Python 3.8.
Not sure what kind of time savings can caching bring, but they it is not worth the complexity and the time needed to update the environments.

[setup-miniconda]:  https://github.com/marketplace/actions/setup-miniconda
[caching-environments]: https://github.com/conda-incubator/setup-miniconda#caching-environments
[3 min]: https://github.com/metno/pyaerocom/runs/4776994306?check_suite_focus=true
[7 min]: https://github.com/metno/pyaerocom/actions/runs/1683091796
[9 min]: https://github.com/metno/pyaerocom/runs/4776383205?check_suite_focus=true
[38 min]: https://github.com/metno/pyaerocom/runs/4776383151?check_suite_focus=true