### PR TITLE
improve filter/ignore warnings

### DIFF
--- a/pyaerocom/_lowlevel_helpers.py
+++ b/pyaerocom/_lowlevel_helpers.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import numpy as np
 import simplejson
 
-from pyaerocom._warnings_management import ignore_warnings
+from pyaerocom._warnings import ignore_warnings
 
 logger = logging.getLogger(__name__)
 
@@ -743,7 +743,6 @@ def list_to_shortstr(lst, indent=0):
         for val in lin:
             try:
                 with ignore_warnings(
-                    True,
                     RuntimeWarning,
                     "divide by zero encountered in log10",
                     "overflow encountered in long_scalars",

--- a/pyaerocom/_warnings.py
+++ b/pyaerocom/_warnings.py
@@ -6,29 +6,27 @@ from typing import Type
 
 
 @contextmanager
-def ignore_warnings(apply: bool, category: Type[Warning], *messages: str):
+def ignore_warnings(category: Type[Warning], *messages: str):
     """
     Ignore particular warnings with a decorator or context manager
 
     Parameters
     ----------
-    apply : bool
-        if True warnings will be ignored, else not.
     category : subclass of Warning
         warning category to be ignored. E.g. UserWarning, DeprecationWarning.
         The default is Warning.
     *messages : str, optional
         warning messages to be ignored. E.g.
-        ignore_warnings(True, Warning, 'Warning that can safely be ignored', 'Other warning to ignore').
+        ignore_warnings(Warning, 'Warning that can safely be ignored', 'Other warning to ignore').
         For each
         `<entry>` :func:`warnigns.filterwarnings('ignore', Warning, message=<entry>)`
         is called.
 
     Example
     -------
-    @ignore_warnings(True, UserWarning)
-    @ignore_warnings(True, DeprecationWarning)
-    @ignore_warnings(True, Warning, 'I REALLY')
+    @ignore_warnings(UserWarning)
+    @ignore_warnings(DeprecationWarning)
+    @ignore_warnings(Warning, 'I REALLY')
     def warn_randomly_and_add_numbers(num1, num2):
         warnings.warn(UserWarning('Harmless user warning'))
         warnings.warn(DeprecationWarning('This function is deprecated'))
@@ -47,9 +45,6 @@ def ignore_warnings(apply: bool, category: Type[Warning], *messages: str):
         raise ValueError("messages must be list of strings")
 
     try:
-        if not apply:
-            yield
-            return
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", category=category, message=message)
             yield

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -10,7 +10,7 @@ import pandas as pd
 import xarray as xr
 
 from pyaerocom._lowlevel_helpers import read_json, write_json
-from pyaerocom._warnings_management import ignore_warnings
+from pyaerocom._warnings import ignore_warnings
 from pyaerocom.aeroval.helpers import _get_min_max_year_periods, _period_str_to_timeslice
 from pyaerocom.colocateddata import ColocatedData
 from pyaerocom.exceptions import (
@@ -1061,7 +1061,7 @@ def _calc_temporal_corr(coldata):
     if np.prod(arr.shape) == 0:
         return np.nan, np.nan
     corr_time = xr.corr(arr[1], arr[0], dim="time")
-    with ignore_warnings(True, RuntimeWarning, "Mean of empty slice", "All-NaN slice encountered"):
+    with ignore_warnings(RuntimeWarning, "Mean of empty slice", "All-NaN slice encountered"):
         return (np.nanmean(corr_time.data), np.nanmedian(corr_time.data))
 
 

--- a/pyaerocom/config.py
+++ b/pyaerocom/config.py
@@ -189,11 +189,6 @@ class Config:
 
     _LUSTRE_CHECK_PATH = "/project/aerocom/aerocom1/"
 
-    #: bool: can be used to filter specific iris warnings, e.g. using decorator
-    #: :func:`pyaerocom._warnings_management.filter_warnings`. Used e.g. in
-    #: :func:`pyaerocom.io.iris_io.load_cubes_custom`.
-    FILTER_IRIS_WARNINGS = True
-
     def __init__(self, config_file=None, try_infer_environment=True):
 
         # Directories

--- a/pyaerocom/griddeddata.py
+++ b/pyaerocom/griddeddata.py
@@ -1780,7 +1780,6 @@ class GriddedData:
             data = self._resample_time_iris(to_ts_type)
         return data
 
-    @ignore_warnings(const.FILTER_IRIS_WARNINGS, Warning, "Using DEFAULT_SPHERICAL_EARTH_RADIUS.")
     def calc_area_weights(self):
         """Calculate area weights for grid"""
         if not self.has_latlon_dims:

--- a/pyaerocom/griddeddata.py
+++ b/pyaerocom/griddeddata.py
@@ -12,7 +12,7 @@ from iris.analysis import MEAN
 from iris.analysis.cartography import area_weights
 
 from pyaerocom import const
-from pyaerocom._warnings_management import ignore_warnings
+from pyaerocom._warnings import ignore_warnings
 from pyaerocom.exceptions import (
     CoordinateError,
     DataDimensionError,
@@ -689,7 +689,7 @@ class GriddedData:
         )
         return vardef
 
-    @ignore_warnings(True, UserWarning, "Ignoring netCDF variable '.*' invalid units '.*'")
+    @ignore_warnings(UserWarning, "Ignoring netCDF variable '.*' invalid units '.*'")
     def load_input(self, input, var_name=None, perform_fmt_checks=None):
         """Import input as cube
 

--- a/pyaerocom/io/iris_io.py
+++ b/pyaerocom/io/iris_io.py
@@ -28,7 +28,6 @@ from traceback import format_exc
 import numpy as np
 
 from pyaerocom import const
-from pyaerocom._warnings_management import ignore_warnings
 from pyaerocom.exceptions import (
     FileConventionError,
     NetcdfError,
@@ -43,7 +42,6 @@ from pyaerocom.tstype import TsType
 logger = logging.getLogger(__name__)
 
 
-@ignore_warnings(const.FILTER_IRIS_WARNINGS, UserWarning)
 def load_cubes_custom(files, var_name=None, file_convention=None, perform_fmt_checks=True):
     """Load multiple NetCDF files into CubeList
 

--- a/pyaerocom/io/read_ebas.py
+++ b/pyaerocom/io/read_ebas.py
@@ -1,16 +1,11 @@
 import fnmatch
+import logging
 import os
 import re
-from warnings import catch_warnings, filterwarnings
 
 import numpy as np
+from geonum.atmosphere import T0_STD, p0
 from tqdm import tqdm
-
-with catch_warnings():
-    filterwarnings("ignore")
-    from geonum.atmosphere import T0_STD, p0
-
-import logging
 
 from pyaerocom import const
 from pyaerocom._lowlevel_helpers import BrowseDict

--- a/pyaerocom/mathutils.py
+++ b/pyaerocom/mathutils.py
@@ -4,7 +4,7 @@ Mathematical low level utility methods of pyaerocom
 import numpy as np
 from scipy.stats import kendalltau, pearsonr, spearmanr
 
-from pyaerocom._warnings_management import ignore_warnings
+from pyaerocom._warnings import ignore_warnings
 
 ### LAMBDA FUNCTIONS
 in_range = lambda x, low, high: low <= x <= high
@@ -140,10 +140,7 @@ def weighted_corr(ref_data, data, weights):
 
 
 @ignore_warnings(
-    True,
-    RuntimeWarning,
-    "invalid value encountered in double_scalars",
-    "An input array is constant",
+    RuntimeWarning, "invalid value encountered in double_scalars", "An input array is constant"
 )
 def corr(ref_data, data, weights=None):
     """Compute correlation coefficient
@@ -190,7 +187,7 @@ def _nanmean_and_std(data):
 
 
 @ignore_warnings(
-    True, RuntimeWarning, "An input array is constant", "invalid value encountered in true_divide"
+    RuntimeWarning, "An input array is constant", "invalid value encountered in true_divide"
 )
 def calc_statistics(data, ref_data, lowlim=None, highlim=None, min_num_valid=1, weights=None):
     """Calc statistical properties from two data arrays

--- a/pyaerocom/plot/mapping.py
+++ b/pyaerocom/plot/mapping.py
@@ -8,7 +8,7 @@ from numpy import ceil, linspace, meshgrid
 from pandas import to_datetime
 
 from pyaerocom import const
-from pyaerocom._warnings_management import ignore_warnings
+from pyaerocom._warnings import ignore_warnings
 from pyaerocom.exceptions import DataDimensionError
 from pyaerocom.mathutils import exponent
 from pyaerocom.plot.config import COLOR_THEME, MAP_AXES_ASPECT, ColorTheme
@@ -330,7 +330,7 @@ def plot_griddeddata_on_map(
             cmap = plt.get_cmap(cmap)
         norm = BoundaryNorm(boundaries=bounds, ncolors=cmap.N, clip=False)
     else:
-        with ignore_warnings(True, RuntimeWarning, "All-NaN axis encountered"):
+        with ignore_warnings(RuntimeWarning, "All-NaN axis encountered"):
             dmin = np.nanmin(data)
             dmax = np.nanmax(data)
 

--- a/pyaerocom/plot/plotscatter.py
+++ b/pyaerocom/plot/plotscatter.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from pyaerocom import const
-from pyaerocom._warnings_management import ignore_warnings
+from pyaerocom._warnings import ignore_warnings
 from pyaerocom.helpers import start_stop_str
 from pyaerocom.mathutils import calc_statistics, exponent
 
@@ -164,11 +164,11 @@ def plot_scatter_aerocom(
         xlim[0] = low
         ylim[0] = low
     with ignore_warnings(
-        True, UserWarning, "Attempted to set non-positive left xlim on a log-scaled axis"
+        UserWarning, "Attempted to set non-positive left xlim on a log-scaled axis"
     ):
         ax.set_xlim(xlim)
     with ignore_warnings(
-        True, UserWarning, "Attempted to set non-positive bottom ylim on a log-scaled axis"
+        UserWarning, "Attempted to set non-positive bottom ylim on a log-scaled axis"
     ):
         ax.set_ylim(ylim)
     xlbl = f"{x_name}"

--- a/pyaerocom/time_config.py
+++ b/pyaerocom/time_config.py
@@ -2,12 +2,8 @@
 Definitions and helpers related to time conversion
 """
 from datetime import datetime
-from warnings import catch_warnings, filterwarnings
 
-with catch_warnings():
-    filterwarnings("ignore")
-    from iris import coord_categorisation
-
+from iris import coord_categorisation
 
 TS_TYPES = ["minutely", "hourly", "daily", "weekly", "monthly", "yearly", "native"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ filterwarnings = [
     # except deprecation and future warnings ouside this packege
     'ignore::DeprecationWarning:^(?!pyaerocom|tests).*:',
     'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
+    # and not on this list
+    "ignore:.*please install Basemap:UserWarning:geonum.*:",
+    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:"
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,16 +9,12 @@ log_cli_level = "WARNING"
 addopts = "--failed-first"
 testpaths = ["tests"]
 filterwarnings = [
-  "error",
-  "ignore::pytest.PytestUnraisableExceptionWarning",
-  # xarray calling importlib.metadata.entry_points on Python 3.10
-  "ignore:SelectableGroups dict interface is deprecated:DeprecationWarning",
-  # xarray calling distutils.version.LooseVersion on Python 3.10
-  "ignore:distutils Version classes are deprecated:DeprecationWarning",
-  # numpy calling distutils.sysconfig.customize_compiler on Python 3.10
-  "ignore:The distutils.sysconfig module is deprecated:DeprecationWarning",
-  # tornado calling asyncio.get_event_loop on Python 3.10
-  "ignore:There is no current event loop:DeprecationWarning",
+    # all warnings are errors
+    "error",
+    "ignore::pytest.PytestUnraisableExceptionWarning",
+    # except deprecation and future warnings ouside this packege
+    'ignore::DeprecationWarning:^(?!pyaerocom|tests).*:',
+    'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,9 @@ skipsdist=True
 commands =
     black --check .
     isort --check .
+deps =
+    # cartopy-0.20+ fails to install on CI
+    cartopy>=0.16,<0.20
 extras = 
     format
 
@@ -126,6 +129,9 @@ commands =
     pylint pyaerocom/
     pycodestyle pyaerocom/
     pydocstyle pyaerocom/
+deps =
+    # cartopy-0.20+ fails to install on CI
+    cartopy>=0.16,<0.20
 extras = 
     lint
 
@@ -133,6 +139,9 @@ extras =
 skipsdist=True
 commands =
     sphinx-build {posargs:-T} docs/ docs/_build/html
+deps =
+    # cartopy-0.20+ fails to install on CI
+    cartopy>=0.16,<0.20
 extras = 
     docs
 """

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -2,13 +2,13 @@ import warnings
 
 import pytest
 
-from pyaerocom._warnings_management import ignore_warnings
+from pyaerocom._warnings import ignore_warnings
 
 
 @pytest.mark.filterwarnings("error")
 def test_filter_warnings_decorator():
-    @ignore_warnings(True, UserWarning, "User Warning")
-    @ignore_warnings(True, DeprecationWarning, "Deprecated")
+    @ignore_warnings(UserWarning, "User Warning")
+    @ignore_warnings(DeprecationWarning, "Deprecated")
     def add_num_with_warnings(num1, num2):
         warnings.warn("User Warning", UserWarning)
         warnings.warn("Deprecated", DeprecationWarning)
@@ -23,30 +23,18 @@ def test_filter_warnings_decorator():
 def test_filter_warnings_category():
     """filter one warning based on the type of warning"""
 
-    # ignore warning
-    with ignore_warnings(True, RuntimeWarning):
+    with ignore_warnings(RuntimeWarning):
         warnings.warn(RuntimeWarning("somethng unexpected..."))
-
-    # raise warning
-    with pytest.warns(RuntimeWarning):
-        with ignore_warnings(False, RuntimeWarning):
-            warnings.warn(RuntimeWarning("somethng unexpected..."))
 
 
 @pytest.mark.filterwarnings("error")
 def test_filter_warnings_message():
     """filter one warning based on the warning message"""
 
-    # ignore warning
-    with ignore_warnings(True, Warning, "Deprecated"):
+    with ignore_warnings(Warning, "Deprecated"):
         warnings.warn(Warning("Deprecated"))
 
-    with ignore_warnings(True, Warning, "A", "B", "C"):
+    with ignore_warnings(Warning, "A", "B", "C"):
         warnings.warn(Warning("A"))
         warnings.warn(Warning("B"))
         warnings.warn(Warning("C"))
-
-    # raise warning
-    with pytest.warns(Warning, match="Deprecated"):
-        with ignore_warnings(False, Warning, "Deprecated"):
-            warnings.warn(Warning("Deprecated"))


### PR DESCRIPTION
- [X] ignore `DeprecationWarning` and `FutureWarning` raised outside pyaerocom
- [X] remove `ignore_warnings` apply option
- [X] ignore specific geonum and iris warnings on tests,
      instead using `ignore_warnings` to capture and ingore
      each trigger
- [X] remove `const.FILTER_IRIS_WARNINGS`