### PR TITLE
Docs551

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -132,6 +132,7 @@ All ungridded reading routines are based on this template class.
 
 AERONET
 ^^^^^^^^
+`Aerosol Robotic Network (AERONET) <https://aeronet.gsfc.nasa.gov/>`_
 
 AERONET base class
 """"""""""""""""""

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -174,7 +174,6 @@ AERONET Inversion (V3)
 EARLINET
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 `European Aerosol Research Lidar Network (EARLINET) <https://www.earlinet.org/index.php?id=earlinet_homepage>`_
-`European Aerosol Research Lidar Network (EARLINET) <https://www.earlinet.org/index.php?id=earlinet_homepage>`_
 
 .. automodule:: pyaerocom.io.read_earlinet
    :members:
@@ -183,8 +182,9 @@ EARLINET
    :show-inheritance:
 
 EBAS
-`EBAS <https://ebas.nilu.no/>`_ is a database with atmospheric measurement data hosted by the `Norwegian Institute for Air Research <https://www.nilu.no/>`_.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`EBAS <https://ebas.nilu.no/>`_ is a database with atmospheric measurement data hosted by the `Norwegian Institute for Air Research <https://www.nilu.no/>`_.
 
 .. automodule:: pyaerocom.io.read_ebas
    :members:
@@ -210,10 +210,10 @@ EBAS (low level)
 EEA data
 ^^^^^^^^
 
-Reader for `European air pollution data <https://www.eea.europa.eu/data-and-maps/data/aqereporting-9>`_.
+EEA base reader
 """""""""""""""
 
-Reader for European air pollution data.
+Reader for European air pollution data from `EEA AqERep files <https://www.eea.europa.eu/data-and-maps/data/aqereporting-9>`_.
 
 .. automodule:: pyaerocom.io.read_eea_aqerep_base
    :members:
@@ -237,19 +237,19 @@ Quality controlled EEA data.
    :members:
    :undoc-members:
 
-Reader for `air quality measurements from North America. <https://www.airnow.gov/about-the-data/>`_
+AirNow data
 ^^^^^^^^^^^
 
-Reader for air quality measurements from North America
+Reader for `air quality measurements from North America. <https://www.airnow.gov/about-the-data/>`_
 
 .. automodule:: pyaerocom.io.read_airnow
    :members:
    :undoc-members:
 
-Reader for air quality measurements for China from the `EU-FP7 project MarcoPolo <https://www.knmi.nl/kennis-en-datacentrum/project/marcopolo>`_.
+MarcoPolo data
 ^^^^^^^^^^^^^^
 
-Reader for air quality measurements from China.
+Reader for air quality measurements for China from the `EU-FP7 project MarcoPolo <https://www.knmi.nl/kennis-en-datacentrum/project/marcopolo>`_.
 
 .. automodule:: pyaerocom.io.read_marcopolo
    :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -256,6 +256,7 @@ Reader for air quality measurements for China from the `EU-FP7 project MarcoPolo
    :undoc-members:
 GHOST
 ^^^^^
+GHOST (Globally Harmonised Observational Surface Treatment) project developed at the Earth Sciences Department of the Barcelona Supercomputing Center (see e.g., `Petetin et al., 2020 <https://acp.copernicus.org/articles/20/11119/2020/acp-20-11119-2020.html>`_ for more information).
 
 .. automodule:: pyaerocom.io.read_ghost
    :members:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -173,6 +173,8 @@ AERONET Inversion (V3)
 
 EARLINET
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`European Aerosol Research Lidar Network (EARLINET) <https://www.earlinet.org/index.php?id=earlinet_homepage>`_
+`European Aerosol Research Lidar Network (EARLINET) <https://www.earlinet.org/index.php?id=earlinet_homepage>`_
 
 .. automodule:: pyaerocom.io.read_earlinet
    :members:
@@ -181,6 +183,7 @@ EARLINET
    :show-inheritance:
 
 EBAS
+`EBAS <https://ebas.nilu.no/>`_ is a database with atmospheric measurement data hosted by the `Norwegian Institute for Air Research <https://www.nilu.no/>`_.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: pyaerocom.io.read_ebas
@@ -207,7 +210,7 @@ EBAS (low level)
 EEA data
 ^^^^^^^^
 
-EEA base reader
+Reader for `European air pollution data <https://www.eea.europa.eu/data-and-maps/data/aqereporting-9>`_.
 """""""""""""""
 
 Reader for European air pollution data.
@@ -234,7 +237,7 @@ Quality controlled EEA data.
    :members:
    :undoc-members:
 
-AirNow data
+Reader for `air quality measurements from North America. <https://www.airnow.gov/about-the-data/>`_
 ^^^^^^^^^^^
 
 Reader for air quality measurements from North America
@@ -243,7 +246,7 @@ Reader for air quality measurements from North America
    :members:
    :undoc-members:
 
-MarcoPolo data
+Reader for air quality measurements for China from the `EU-FP7 project MarcoPolo <https://www.knmi.nl/kennis-en-datacentrum/project/marcopolo>`_.
 ^^^^^^^^^^^^^^
 
 Reader for air quality measurements from China.

--- a/pyaerocom/io/read_marcopolo.py
+++ b/pyaerocom/io/read_marcopolo.py
@@ -64,7 +64,7 @@ def _conc_to_vmr_marcopolo_stats(
 
 class ReadMarcoPolo(ReadUngriddedBase):
     """
-    Reading routine for chinese MarcoPolo observations
+    Reading routine for Chinese MarcoPolo observations
     """
 
     #: Data type of files


### PR DESCRIPTION
Addressing some of the desires in item #551 to enhance the documentation cataloging which observational data sets can be read by pyaercocom. Some of this information is in the "About" section of the documentation, however it can be easy to miss, so I made some modifications to docs > api.rst with relevant links. Want to discuss appropriate placement for this information and desired level of granularity (more, less).