### PR TITLE
pip install on machines with old/new versions of Proj

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,17 +1,17 @@
 # .readthedocs.yml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
-
+---
 version: 2
 
 sphinx:
-   configuration: docs/conf.py
+  configuration: docs/conf.py
 
 formats:
-   - pdf
+  - pdf
 
 build:
-  image: latest
+  os: ubuntu-20.04
   apt_packages:
     - libudunits2-dev
     - libgeos-dev
@@ -25,4 +25,5 @@ python:
     - method: pip
       path: .
       extra_requirements:
+        - proj-legacy
         - docs

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -23,7 +23,13 @@ Via pip
 This will install the latest released version of pyaerocom and its depencencies.
 **NOTE** this same pacakge as distributed via *conda-forge* (see prev. point).::
 
-	python3 -m pip install pyaerocom
+	# install pyaerocom on machines with Proj8 or newer
+	# e.g. Ubuntu 22.04 LTS (Jammy Jellyfish)
+	python3 -m pip install pyaerocom[proj8]
+
+	# install pyaerocom on machiles with an older version of Proj
+	# e.g. Ubuntu 20.04 LTS (Focal Fossa)
+	python3 -m pip install pyaerocom[proj-legacy]
 
 Or into a new virtual environment (recommended) named *.venv* via::
 
@@ -31,9 +37,16 @@ Or into a new virtual environment (recommended) named *.venv* via::
 	python3 -m venv --prompt pya .venv
 	source .venv/bin/activate
 
-	# update pip and install pyaerocom
+	# update pip
 	pip -m install -U pip
-	pip install pyaerocom
+
+	# install pyaerocom on machines with Proj8 or newer
+	# e.g. Ubuntu 22.04 LTS (Jammy Jellyfish)
+	pip install pyaerocom[proj8]
+
+	# install pyaerocom on machiles with an older version of Proj
+	# e.g. Ubuntu 20.04 LTS (Focal Fossa)
+	pip install pyaerocom[proj-legacy]
 
 
 Install from source into a conda environment

--- a/pyaerocom/aeroval/fairmode_stats.py
+++ b/pyaerocom/aeroval/fairmode_stats.py
@@ -12,7 +12,6 @@ This module contains methods to cmpute the relevant FAIRMODE statistics.
 
 from numpy import isclose, isnan, nan, sqrt
 
-
 SPECIES = dict(
     concno2=dict(UrRV=0.24, RV=200, alpha=0.2),
     vmro3=dict(UrRV=0.18, RV=120, alpha=0.79),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ commands_pre =
 commands =
     pytest -ra -q {posargs:--cov}
 extras = 
+    proj-legacy
     test
 
 [testenv:format]
@@ -117,6 +118,7 @@ commands =
     black --check .
     isort --check .
 extras = 
+    proj-legacy
     format
 
 [testenv:lint]
@@ -127,11 +129,13 @@ commands =
     pycodestyle pyaerocom/
     pydocstyle pyaerocom/
 extras = 
+    proj-legacy
     lint
 
 [testenv:docs]
 commands =
     sphinx-build {posargs:-T} docs/ docs/_build/html
 extras = 
+    proj-legacy
     docs
 """

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,9 +27,9 @@ classifiers =
 [options]
 python_requires = >=3.8
 install_requires =
-    scitools-iris>=3.1.0,!=3.2.*
+  # scitools-iris>=3.1.0,!=3.2.*
     xarray>=0.16.0
-    cartopy>=0.16.0,!=0.20.* # cartopy-0.20+ fails to install on CI    
+  # cartopy>=0.16.0,!=0.20.* # cartopy-0.20+ fails to install on CI    
     matplotlib>=3.0.1
     scipy>=1.1.0
     pandas>=0.23.0
@@ -63,6 +63,12 @@ console_scripts =
     pya = pyaerocom.scripts.cli:main
 
 [options.extras_require]
+proj-legacy = # proj<8, e.g CI    
+    cartopy>=0.16.0,!=0.20.*
+    scitools-iris>=3.1.0,!=3.2.*
+proj8 =
+    cartopy>=0.20
+    scitools-iris>=3.2
 docs =
     sphinx>=4.2.0
     sphinxcontrib-napoleon


### PR DESCRIPTION
Different versions for cartopy require different versions of Proj, see #583
This PR moves cartopy and iris (which depends on a specific version of cartopy)
to extras and updates the installation docs accordingly:

``` bash
# install pyaerocom on machines with Proj8 or newer
# e.g. Ubuntu 22.04 LTS (Jammy Jellyfish)
pip install pyaerocom[proj8]

# install pyaerocom on machiles with an older version of Proj
# e.g. Ubuntu 20.04 LTS (Focal Fossa)
pip install pyaerocom[proj-legacy]
```