### PR TITLE
change URL to test new pyaerocom webserver with CI

### DIFF
--- a/pyaerocom/access_testdata.py
+++ b/pyaerocom/access_testdata.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from traceback import format_exc
 
 import requests
-
 from pyaerocom import const
 from pyaerocom.io import (
     ReadAeronetInvV3,
@@ -22,9 +21,8 @@ logger = logging.getLogger(__name__)
 
 
 class AccessTestData:
-
     #: That's were the testdata can be downloaded from
-    URL_TESTDATA = "https://pyaerocom.met.no/pyaerocom-suppl/testdata-minimal.tar.gz.ebas_202201"
+    URL_TESTDATA = "https://pyaerocom-ng.met.no/pyaerocom-suppl/testdata-minimal.tar.gz.ebas_202201"
 
     #: Directory where testdata will be downloaded into
     BASEDIR_DEFAULT = const.OUTPUTDIR


### PR DESCRIPTION
This is basically a pull request to test CI with a new pyaerocom.met.no web server in OSTACK.
For testing purposes only to make sure that the new server works with CI