### PR TITLE
Change pm25 UrRV to 0.36

### DIFF
--- a/pyaerocom/access_testdata.py
+++ b/pyaerocom/access_testdata.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from traceback import format_exc
 
 import requests
+
 from pyaerocom import const
 from pyaerocom.io import (
     ReadAeronetInvV3,

--- a/pyaerocom/access_testdata.py
+++ b/pyaerocom/access_testdata.py
@@ -22,7 +22,9 @@ logger = logging.getLogger(__name__)
 
 class AccessTestData:
     #: That's were the testdata can be downloaded from
-    URL_TESTDATA = "https://pyaerocom-ng.met.no/pyaerocom-suppl/testdata-minimal.tar.gz.ebas_202201"
+    URL_TESTDATA = (
+        "https://pyaerocom-ng.met.no/pyaerocom-suppl/testdata-minimal.tar.gz.ebas_202201"
+    )
 
     #: Directory where testdata will be downloaded into
     BASEDIR_DEFAULT = const.OUTPUTDIR

--- a/pyaerocom/aeroval/fairmode_stats.py
+++ b/pyaerocom/aeroval/fairmode_stats.py
@@ -16,7 +16,7 @@ SPECIES = dict(
     concno2=dict(UrRV=0.24, RV=200, alpha=0.2),
     vmro3=dict(UrRV=0.18, RV=120, alpha=0.79),
     concpm10=dict(UrRV=0.28, RV=50, alpha=0.13),
-    concpm25=dict(UrRV=0.28, RV=25, alpha=0.3),
+    concpm25=dict(UrRV=0.36, RV=25, alpha=0.3),
 )
 
 


### PR DESCRIPTION
Fix copy-paste error in `farimode_stats.py`. Changed UrRV to 0.36 from 0.28 so that our FAIRMODE statistics are computed correctly.