### PR TITLE
corrected heatmap data when entire season is full of NaNs

### DIFF
--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1120,7 +1120,7 @@ def _process_heatmap_data(
             hm_freq[regname] = {}
             for per in periods:
                 for season in seasons:
-                    use_dummy = cd is None
+                    use_dummy = coldata is None
                     perstr = f"{per}-{season}"
                     if use_dummy:
                         stats = stats_dummy


### PR DESCRIPTION
Correct #658 
The heatmap data is basically computed using the same loop as the map data. The fix just moves the resetting of `use_dummy` into the season loop.