### PR TITLE
extract periods from date range, add new models

### DIFF
--- a/pyaerocom/io/cams2_83/models.py
+++ b/pyaerocom/io/cams2_83/models.py
@@ -7,15 +7,17 @@ from typing import NamedTuple
 
 
 class ModelName(str, Enum):
-    EMEP = "emep"
+    CHIMERE = "chimere"
     DEHM = "dehm"
+    EMEP = "emep"
     EURAD = "euradim"
     GEMAQ = "gemaq"
     LOTOS = "lotos"
     MATCH = "match"
-    SILAM = "silam"
+    MINNI = "minni"
     MOCAGE = "mocage"
-    CHIMERE = "chimere"
+    MONARCH = "monarch"
+    SILAM = "silam"
     ENSEMBLE = "ensemble"
 
     def __str__(self) -> str:

--- a/pyaerocom/scripts/cams2_83/cli.py
+++ b/pyaerocom/scripts/cams2_83/cli.py
@@ -97,13 +97,28 @@ def make_period(
     start_date: datetime,
     end_date: datetime,
 ) -> List[str]:
-    start_yr = start_date.strftime("%Y%m%d")  # .year
-    end_yr = end_date.strftime("%Y%m%d")  # .year
+    start_yr = start_date.year
+    end_yr = end_date.year
+    start_dt = start_date.strftime("%Y%m%d")  # .year
+    end_dt = end_date.strftime("%Y%m%d")  # .year
 
-    if start_yr == end_yr:
-        return [f"{start_yr}"]
+    if start_dt == end_dt:
+        return [f"{start_dt}"]
+    
+    periods = [f"{start_dt}-{end_dt}"]
+    if end_yr == start_yr:
+        return periods
+    
+    periods.append(f"{start_dt}-{start_yr}1231") # append first year portion
+    
+    if (end_yr - start_yr) >= 2 : # append full years in between if any
+        for y in range(start_yr+1,end_yr):
+            periods.append(f"{y}0101-{y}1231")
+ 
+    periods.append(f"{end_yr}0101-{end_dt}") # append last year portion
 
-    return [f"{start_yr}-{end_yr}"]
+    return periods
+
 
 
 def date_range(start_date: datetime | date, end_date: datetime | date) -> tuple[date, ...]:

--- a/pyaerocom/scripts/cams2_83/config.py
+++ b/pyaerocom/scripts/cams2_83/config.py
@@ -30,7 +30,7 @@ GLOBAL_CONFIG = dict(
     clear_existing_json=False,
     # if True, the analysis will stop whenever an error occurs (else, errors that
     # occurred will be written into the logfiles)
-    raise_exceptions=True,
+    raise_exceptions=False,
     # options for CAMS2-83
     use_cams2_83=True,
     # cams2_83_model=ModelName.EMEP,


### PR DESCRIPTION
note on edge cases where start/end dates are the end/beginning of a year:
  
with `make_period(datetime(2018,12,31),datetime(2022,1,1))` this gives   
`['20181231-20220101', '20181231-20181231', '20190101-20191231', '20200101-20201231', '20210101-20211231', '20220101-20220101']`  
I assume this is the intended behavior, but if not we can change the function