### PR TITLE
fix Cartopy build on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       PYTHON: 3.8
     steps:
@@ -29,7 +29,7 @@ jobs:
       run: tox -e lint
 
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       PYTHON: 3.8
     steps:
@@ -52,7 +52,7 @@ jobs:
       run: tox -e docs
 
   venv:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       PYTHON: 3.8
     steps:
@@ -29,7 +29,7 @@ jobs:
       run: tox -e lint
 
   docs:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       PYTHON: 3.8
     steps:
@@ -52,7 +52,7 @@ jobs:
       run: tox -e docs
 
   venv:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -25,11 +25,11 @@ This will install the latest released version of pyaerocom and its depencencies.
 
 	# install pyaerocom on machines with Proj8 or newer
 	# e.g. Ubuntu 22.04 LTS (Jammy Jellyfish)
-	python3 -m pip install pyaerocom[proj8]
+	python3 -m pip install --use-deprecated=legacy-resolver pyaerocom[proj8]
 
 	# install pyaerocom on machiles with an older version of Proj
 	# e.g. Ubuntu 20.04 LTS (Focal Fossa)
-	python3 -m pip install pyaerocom[proj-legacy]
+	python3 -m pip install --use-deprecated=legacy-resolver pyaerocom[proj-legacy]
 
 Or into a new virtual environment (recommended) named *.venv* via::
 
@@ -42,11 +42,11 @@ Or into a new virtual environment (recommended) named *.venv* via::
 
 	# install pyaerocom on machines with Proj8 or newer
 	# e.g. Ubuntu 22.04 LTS (Jammy Jellyfish)
-	pip install pyaerocom[proj8]
+	pip install --use-deprecated=legacy-resolver pyaerocom[proj8]
 
 	# install pyaerocom on machiles with an older version of Proj
 	# e.g. Ubuntu 20.04 LTS (Focal Fossa)
-	pip install pyaerocom[proj-legacy]
+	pip install --use-deprecated=legacy-resolver pyaerocom[proj-legacy]
 
 
 Install from source into a conda environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ filterwarnings = [
     'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
     # and not on this list
     "ignore:.*please install Basemap:UserWarning:geonum.*:",
-    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:"
+    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:",
 ]
 
 [tool.coverage.run]
@@ -106,6 +106,8 @@ requires =
     setuptools<=60.9.3
 
 [testenv]
+install_command = 
+    python -m pip install {opts} {packages} --use-deprecated=legacy-resolver
 commands_pre =
     python --version
 commands =
@@ -124,9 +126,6 @@ deps =
 ignore_outcome = True
 commands =
     mypy pyaerocom/
-    #pylint pyaerocom/
-    #pycodestyle pyaerocom/
-    #pydocstyle pyaerocom/
 extras = 
     proj-legacy
     lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ filterwarnings = [
     'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
     # and not on this list
     "ignore:.*please install Basemap:UserWarning:geonum.*:",
-    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:"
+    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:",
 ]
 
 [tool.coverage.run]
@@ -102,8 +102,6 @@ legacy_tox_ini = """
 envlist = py38, py39, py310, format, lint, docs
 skip_missing_interpreters = True
 isolated_build = True
-requires =
-    setuptools<=60.9.3
 
 [testenv]
 commands_pre =
@@ -111,7 +109,7 @@ commands_pre =
 commands =
     pytest -ra -q {posargs:--cov}
 extras = 
-    proj-legacy
+    proj8
     test
 
 [testenv:format]
@@ -124,17 +122,14 @@ deps =
 ignore_outcome = True
 commands =
     mypy pyaerocom/
-    #pylint pyaerocom/
-    #pycodestyle pyaerocom/
-    #pydocstyle pyaerocom/
 extras = 
-    proj-legacy
+    proj8
     lint
 
 [testenv:docs]
 commands =
     sphinx-build {posargs:-T} docs/ docs/_build/html
 extras = 
-    proj-legacy
+    proj8
     docs
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ filterwarnings = [
     'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
     # and not on this list
     "ignore:.*please install Basemap:UserWarning:geonum.*:",
-    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:",
+    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:"
 ]
 
 [tool.coverage.run]
@@ -102,6 +102,8 @@ legacy_tox_ini = """
 envlist = py38, py39, py310, format, lint, docs
 skip_missing_interpreters = True
 isolated_build = True
+requires =
+    setuptools<=60.9.3
 
 [testenv]
 commands_pre =
@@ -109,7 +111,7 @@ commands_pre =
 commands =
     pytest -ra -q {posargs:--cov}
 extras = 
-    proj8
+    proj-legacy
     test
 
 [testenv:format]
@@ -122,14 +124,17 @@ deps =
 ignore_outcome = True
 commands =
     mypy pyaerocom/
+    #pylint pyaerocom/
+    #pycodestyle pyaerocom/
+    #pydocstyle pyaerocom/
 extras = 
-    proj8
+    proj-legacy
     lint
 
 [testenv:docs]
 commands =
     sphinx-build {posargs:-T} docs/ docs/_build/html
 extras = 
-    proj8
+    proj-legacy
     docs
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ filterwarnings = [
     'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
     # and not on this list
     "ignore:.*please install Basemap:UserWarning:geonum.*:",
-    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:",
+    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:"
 ]
 
 [tool.coverage.run]
@@ -104,7 +104,6 @@ skip_missing_interpreters = True
 isolated_build = True
 requires =
     setuptools<=60.9.3
-    numpy>=1.10
 
 [testenv]
 commands_pre =
@@ -125,6 +124,9 @@ deps =
 ignore_outcome = True
 commands =
     mypy pyaerocom/
+    #pylint pyaerocom/
+    #pycodestyle pyaerocom/
+    #pydocstyle pyaerocom/
 extras = 
     proj-legacy
     lint

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ filterwarnings = [
     'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
     # and not on this list
     "ignore:.*please install Basemap:UserWarning:geonum.*:",
-    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:"
+    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:",
 ]
 
 [tool.coverage.run]
@@ -104,6 +104,7 @@ skip_missing_interpreters = True
 isolated_build = True
 requires =
     setuptools<=60.9.3
+    numpy>=1.10
 
 [testenv]
 commands_pre =
@@ -124,9 +125,6 @@ deps =
 ignore_outcome = True
 commands =
     mypy pyaerocom/
-    #pylint pyaerocom/
-    #pycodestyle pyaerocom/
-    #pydocstyle pyaerocom/
 extras = 
     proj-legacy
     lint


### PR DESCRIPTION
Caropy packages fail to install on CI with the following error

```
WARNING: Requested cartopy!=0.20.*,>=0.16.0 from https://files.pythonhosted.org/packages/ed/ca/524ce33692df3faeaa56852fb6a33b0b410be94cc288417565b96fef3f64/Cartopy-0.19.0.post1.tar.gz#sha256=4b8b4773a98ed7009fe17d9b6ec87ac3ac62b7d14634d7768c190eadc647d576 (from pyaerocom==0.13.1.post1), but installing version 0.0
Discarding https://files.pythonhosted.org/packages/ed/ca/524ce33692df3faeaa56852fb6a33b0b410be94cc288417565b96fef3f64/Cartopy-0.19.0.post1.tar.gz#sha256=4b8b4773a98ed7009fe17d9b6ec87ac3ac62b7d14634d7768c190eadc647d576 (from https://pypi.org/simple/cartopy/) (requires-python:>=3.5): Requested cartopy!=0.20.*,>=0.16.0 from https://files.pythonhosted.org/packages/ed/ca/524ce33692df3faeaa56852fb6a33b0b410be94cc288417565b96fef3f64/Cartopy-0.19.0.post1.tar.gz#sha256=4b8b4773a98ed7009fe17d9b6ec87ac3ac62b7d14634d7768c190eadc647d576 (from pyaerocom==0.13.1.post1) has inconsistent version: filename has '0.19.0.post1', but metadata has '0.0'
```

The documentation build process on Read the Docs shows the same error:
```
WARNING: Requested cartopy!=0.20.*,>=0.16.0 from https://files.pythonhosted.org/packages/ed/ca/524ce33692df3faeaa56852fb6a33b0b410be94cc288417565b96fef3f64/Cartopy-0.19.0.post1.tar.gz#sha256=4b8b4773a98ed7009fe17d9b6ec87ac3ac62b7d14634d7768c190eadc647d576 (from pyaerocom==0.13.1.post1), but installing version 0.0
Discarding https://files.pythonhosted.org/packages/ed/ca/524ce33692df3faeaa56852fb6a33b0b410be94cc288417565b96fef3f64/Cartopy-0.19.0.post1.tar.gz#sha256=4b8b4773a98ed7009fe17d9b6ec87ac3ac62b7d14634d7768c190eadc647d576 (from https://pypi.org/simple/cartopy/) (requires-python:>=3.5): Requested cartopy!=0.20.*,>=0.16.0 from https://files.pythonhosted.org/packages/ed/ca/524ce33692df3faeaa56852fb6a33b0b410be94cc288417565b96fef3f64/Cartopy-0.19.0.post1.tar.gz#sha256=4b8b4773a98ed7009fe17d9b6ec87ac3ac62b7d14634d7768c190eadc647d576 (from pyaerocom==0.13.1.post1) has inconsistent version: filename has '0.19.0.post1', but metadata has '0.0'
```


As far as I can tell the Caropy packages are incompatible with `pip` new dependency resolver,
and can be worked around with the `--use-deprecated=legacy-resolver` option.

