### PR TITLE
No tempfile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ install_command =
 commands_pre =
     python --version
 commands =
-    pytest -ra -q {posargs:--cov}
+    pytest -ra -q -n4 {posargs:--cov}
 extras = 
     proj-legacy
     test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ install_command =
 commands_pre =
     python --version
 commands =
-    pytest -ra -q -n4 {posargs:--cov}
+    pytest -ra -q {posargs:--cov}
 extras = 
     proj-legacy
     test

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,19 +79,16 @@ test =
     pytest>=6.0
     pytest-dependency
     pytest-cov
+    pytest-xdist
     packaging
 lint =
     mypy>=0.931
     types-requests
     types-setuptools        
     types-simplejson
-    #pylint>=2.9
-    #pycodestyle>=2.8
-    #pydocstyle[toml]>=6.1
 dev =
     %(test)s
     pytest-sugar
-    pytest-testmon
     %(lint)s
     pre-commit
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,7 +79,6 @@ test =
     pytest>=6.0
     pytest-dependency
     pytest-cov
-    pytest-xdist
     packaging
 lint =
     mypy>=0.931
@@ -89,6 +88,7 @@ lint =
 dev =
     %(test)s
     pytest-sugar
+    pytest-xdist
     %(lint)s
     pre-commit
 

--- a/tests/fixtures/collocated_data.py
+++ b/tests/fixtures/collocated_data.py
@@ -6,10 +6,10 @@ import xarray as xr
 from pyaerocom import ColocatedData, Filter
 from pyaerocom.config import ALL_REGION_NAME
 
-from .data_access import TestData
+from .data_access import DataForTests
 
 CHECK_PATHS = f"coldata/od550aer_REF-AeronetSunV3L2Subset.daily_MOD-TM5_AP3-CTRL2016_20100101_20101231_monthly_{ALL_REGION_NAME}-noMOUNTAINS.nc"
-EXAMPLE_FILE = TestData(CHECK_PATHS).path
+EXAMPLE_FILE = DataForTests(CHECK_PATHS).path
 
 
 def _create_fake_coldata_3d():

--- a/tests/fixtures/data_access.py
+++ b/tests/fixtures/data_access.py
@@ -28,7 +28,7 @@ TESTDATA_URL = f"https://pyaerocom-ng.met.no/pyaerocom-suppl/{TESTDATA_NAME}.tar
 TESTDATA_ROOT = Path(const.OUTPUTDIR) / TESTDATA_NAME
 
 
-class TestData(NamedTuple):
+class DataForTests(NamedTuple):
     relpath: str
     reader: Type[ReadUngriddedBase] | None = None
 
@@ -37,30 +37,32 @@ class TestData(NamedTuple):
         return TESTDATA_ROOT / self.relpath
 
 
-TEST_DATA: dict[str, TestData] = {
-    "MODELS": TestData("modeldata"),
-    "OBSERVATIONS": TestData("obsdata"),
-    "CONFIG": TestData("config"),
-    "AeronetSunV3L2Subset.daily": TestData(
+TEST_DATA: dict[str, DataForTests] = {
+    "MODELS": DataForTests("modeldata"),
+    "OBSERVATIONS": DataForTests("obsdata"),
+    "CONFIG": DataForTests("config"),
+    "AeronetSunV3L2Subset.daily": DataForTests(
         "obsdata/AeronetSunV3Lev2.daily/renamed", io.ReadAeronetSunV3
     ),
-    "AeronetSunV3L2Subset.AP": TestData(
+    "AeronetSunV3L2Subset.AP": DataForTests(
         "obsdata/AeronetSunV3Lev2.0.AP/renamed", io.ReadAeronetSunV3
     ),
-    "AeronetSDAV3L2Subset.daily": TestData(
+    "AeronetSDAV3L2Subset.daily": DataForTests(
         "obsdata/AeronetSDAV3Lev2.daily/renamed", io.ReadAeronetSdaV3
     ),
-    "AeronetInvV3L2Subset.daily": TestData(
+    "AeronetInvV3L2Subset.daily": DataForTests(
         "obsdata/AeronetInvV3Lev2.daily/renamed", io.ReadAeronetInvV3
     ),
-    "EBASSubset": TestData("obsdata/EBASMultiColumn", io.ReadEbas),
-    "AirNowSubset": TestData("obsdata/AirNowSubset", io.ReadAirNow),
-    "G.EEA.daily.Subset": TestData("obsdata/GHOST/data/EEA_AQ_eReporting/daily", io.ReadGhost),
-    "G.EEA.hourly.Subset": TestData("obsdata/GHOST/data/EEA_AQ_eReporting/hourly", io.ReadGhost),
-    "G.EBAS.daily.Subset": TestData("obsdata/GHOST/data/EBAS/daily", io.ReadGhost),
-    "G.EBAS.hourly.Subset": TestData("obsdata/GHOST/data/EBAS/hourly", io.ReadGhost),
-    "EEA_AQeRep.v2.Subset": TestData("obsdata/EEA_AQeRep.v2/renamed", io.ReadEEAAQEREP_V2),
-    "Earlinet-test": TestData("obsdata/Earlinet", io.ReadEarlinet),
+    "EBASSubset": DataForTests("obsdata/EBASMultiColumn", io.ReadEbas),
+    "AirNowSubset": DataForTests("obsdata/AirNowSubset", io.ReadAirNow),
+    "G.EEA.daily.Subset": DataForTests("obsdata/GHOST/data/EEA_AQ_eReporting/daily", io.ReadGhost),
+    "G.EEA.hourly.Subset": DataForTests(
+        "obsdata/GHOST/data/EEA_AQ_eReporting/hourly", io.ReadGhost
+    ),
+    "G.EBAS.daily.Subset": DataForTests("obsdata/GHOST/data/EBAS/daily", io.ReadGhost),
+    "G.EBAS.hourly.Subset": DataForTests("obsdata/GHOST/data/EBAS/hourly", io.ReadGhost),
+    "EEA_AQeRep.v2.Subset": DataForTests("obsdata/EEA_AQeRep.v2/renamed", io.ReadEEAAQEREP_V2),
+    "Earlinet-test": DataForTests("obsdata/Earlinet", io.ReadEarlinet),
 }
 
 

--- a/tests/fixtures/ebas.py
+++ b/tests/fixtures/ebas.py
@@ -10,10 +10,10 @@ from pyaerocom.io.ebas_file_index import EbasFileIndex
 from pyaerocom.io.ebas_nasa_ames import EbasNasaAmesFile
 from pyaerocom.io.read_ebas import ReadEbas
 
-from .data_access import TestData
+from .data_access import DataForTests
 
-EBAS_FILEDIR = TestData("obsdata/EBASMultiColumn/data").path
-ebas_info_file = TestData("scripts/ebas_files.json").path
+EBAS_FILEDIR = DataForTests("obsdata/EBASMultiColumn/data").path
+ebas_info_file = DataForTests("scripts/ebas_files.json").path
 assert ebas_info_file.exists()
 EBAS_FILES = simplejson.loads(ebas_info_file.read_text())
 for sites in EBAS_FILES.values():

--- a/tests/fixtures/tm5.py
+++ b/tests/fixtures/tm5.py
@@ -10,7 +10,7 @@ from pyaerocom import ColocatedData
 from pyaerocom.config import ALL_REGION_NAME
 from pyaerocom.griddeddata import GriddedData
 
-from .data_access import TestData
+from .data_access import DataForTests
 
 CHECK_PATHS = SimpleNamespace(
     tm5="modeldata/TM5-met2010_CTRL-TEST/renamed",
@@ -19,12 +19,12 @@ CHECK_PATHS = SimpleNamespace(
     tm5_tm5=f"coldata/od550aer_REF-TM5_AP3-CTRL2016_MOD-TM5_AP3-CTRL2016_20100101_20101231_monthly_{ALL_REGION_NAME}-noMOUNTAINS.nc",
 )
 
-TM5_DATA_PATH = TestData(CHECK_PATHS.tm5).path
+TM5_DATA_PATH = DataForTests(CHECK_PATHS.tm5).path
 
 
 @pytest.fixture(scope="session")
 def data_tm5() -> GriddedData:
-    path = TestData(CHECK_PATHS.tm5aod).path
+    path = DataForTests(CHECK_PATHS.tm5aod).path
     assert path.exists()
     data = GriddedData(path)
     return data
@@ -50,11 +50,11 @@ def load_coldata_tm5_aeronet_from_scratch(path: Path) -> ColocatedData:
 
 @pytest.fixture(scope="session")
 def coldata_tm5_aeronet() -> ColocatedData:
-    path = TestData(CHECK_PATHS.coldata_tm5_aeronet).path
+    path = DataForTests(CHECK_PATHS.coldata_tm5_aeronet).path
     return load_coldata_tm5_aeronet_from_scratch(path)
 
 
 @pytest.fixture(scope="session")
 def coldata_tm5_tm5() -> ColocatedData:
-    path = TestData(CHECK_PATHS.tm5_tm5).path
+    path = DataForTests(CHECK_PATHS.tm5_tm5).path
     return load_coldata_tm5_aeronet_from_scratch(path)

--- a/tests/io/test_iris_io.py
+++ b/tests/io/test_iris_io.py
@@ -22,7 +22,6 @@ from tests.fixtures.mscw_ctm import EMEP_DATA_PATH
 from tests.fixtures.tm5 import TM5_DATA_PATH
 
 TM5_FILE1 = TM5_DATA_PATH / "aerocom3_TM5_AP3-CTRL2016_od550aer_Column_2010_monthly.nc"
-TM5_FILE2 = TM5_DATA_PATH / "aerocom3_TM5-met2010_AP3-CTRL2019_od550aer_Column_2010_daily.nc"
 EMEP_FILE = EMEP_DATA_PATH / "Base_month.nc"
 
 aod_cube = load(str(TM5_FILE1))[0]

--- a/tests/io/test_iris_io.py
+++ b/tests/io/test_iris_io.py
@@ -63,7 +63,7 @@ aod_cube_only_longname_dims.coord("time").long_name = "time"
 aod_cube_nounit = aod_cube.copy()
 aod_cube_nounit.units = ""
 
-FAKE_FILE = Path(tempfile.gettempdir()) / "test_iris_io/invalid.nc"
+FAKE_FILE = Path(tempfile.mkdtemp()) / "test_iris_io/invalid.nc"
 FAKE_FILE.parent.mkdir(exist_ok=True, parents=True)
 FAKE_FILE.write_text("")
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,10 +19,15 @@ TMP_PATH = Path(tempfile.mkdtemp())
 CFG_FILE_WRONG = TMP_PATH / "paths.txt"
 CFG_FILE_WRONG.write_text("")
 
-LOCAL_DB_DIR = TMP_PATH / "data"
-LOCAL_DB_DIR.mkdir()
-(LOCAL_DB_DIR / "modeldata").mkdir()
-(LOCAL_DB_DIR / "obsdata").mkdir()
+
+@pytest.fixture()
+def local_db(tmp_path: Path) -> Path:
+    """temporary path to DB file structure"""
+    path = tmp_path / "data"
+    (path / "modeldata").mkdir(parents=True)
+    (path / "obsdata").mkdir()
+    assert path.is_dir()
+    return path
 
 
 with resources.path("pyaerocom.data", "paths.ini") as path:
@@ -35,10 +40,6 @@ def test_CFG_FILE_EXISTS():
 
 def test_CFG_FILE_WRONG_EXISTS():
     assert CFG_FILE_WRONG.exists()
-
-
-def test_LOCAL_DB_DIR_EXISTS():
-    assert LOCAL_DB_DIR.exists()
 
 
 @pytest.fixture(scope="module")
@@ -86,9 +87,9 @@ def test_Config___init___error(config_file: str, exception: Type[Exception], err
     assert str(e.value) == error
 
 
-def test_Config__infer_config_from_basedir():
+def test_Config__infer_config_from_basedir(local_db: Path):
     cfg = testmod.Config(try_infer_environment=False)
-    res = cfg._infer_config_from_basedir(LOCAL_DB_DIR)
+    res = cfg._infer_config_from_basedir(local_db)
     assert res[1] == "local-db"
 
 


### PR DESCRIPTION
Address some of the problems behind #692 by providing temporary files as fixtures.
These changes makes possible to run multiple tests in parallel with `pytest-xdist`.
