### PR TITLE
make ts file regions consistent

### DIFF
--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -182,7 +182,7 @@ class ColdataToJsonEngine(ProcessingEngine):
                 except TemporalResolutionError:
                     stats_ts = {}
 
-                fname = get_timeseries_file_name(reg, obs_name, var_name_web, vert_code)
+                fname = get_timeseries_file_name(regnames[reg], obs_name, var_name_web, vert_code)
                 ts_file = os.path.join(out_dirs["hm/ts"], fname)
                 _add_heatmap_entry_json(
                     ts_file, stats_ts, obs_name, var_name_web, vert_code, model_name, model_var

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -37,8 +37,7 @@ def get_heatmap_filename(ts_type):
 
 
 def get_timeseries_file_name(region, obs_name, var_name_web, vert_code):
-    reg = region.replace(" ", "_")
-    return f"{reg}-{obs_name}-{var_name_web}-{vert_code}.json"
+    return f"{region}-{obs_name}-{var_name_web}-{vert_code}.json"
 
 
 def get_stationfile_name(station_name, obs_name, var_name_web, vert_code):


### PR DESCRIPTION
Closes #720

Using the region name instead of the region. This will introduce spaces and commas into the timeseries json file names, but will be consistent with other output files