### PR TITLE
Splitting ColocatedData with the goal of accounting for vertical profiles

### DIFF
--- a/pyaerocom/__init__.py
+++ b/pyaerocom/__init__.py
@@ -45,7 +45,10 @@ from .stationdata import StationData
 from .griddeddata import GriddedData
 from .ungriddeddata import UngriddedData
 from .filter import Filter
-from .colocateddata import ColocatedData
+
+# from .colocateddata import ColocatedData
+from .colocateddata2d import ColocatedData2D
+from .colocateddata3d import ColocatedData3D
 from .colocation_auto import ColocationSetup, Colocator
 from .tstype import TsType
 from .time_resampler import TimeResampler

--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -2,7 +2,7 @@ import logging
 import os
 from time import time
 
-from pyaerocom import ColocatedData
+from pyaerocom import ColocatedData2D
 from pyaerocom._lowlevel_helpers import write_json
 from pyaerocom.aeroval._processing_base import ProcessingEngine
 from pyaerocom.aeroval.coldatatojson_helpers import (
@@ -49,12 +49,12 @@ class ColdataToJsonEngine(ProcessingEngine):
         converted = []
         for file in files:
             logger.info(f"Processing: {file}")
-            coldata = ColocatedData(file)
+            coldata = ColocatedData2D(file)
             self.process_coldata(coldata)
             converted.append(file)
         return converted
 
-    def process_coldata(self, coldata: ColocatedData):
+    def process_coldata(self, coldata: ColocatedData2D):
         """
         Creates all json files for one ColocatedData object
 
@@ -110,7 +110,7 @@ class ColdataToJsonEngine(ProcessingEngine):
         elif "altitude" in coldata.data.dims:
             raise NotImplementedError("Cannot yet handle profile data")
 
-        elif not isinstance(coldata, ColocatedData):
+        elif not isinstance(coldata, ColocatedData2D):
             raise ValueError(f"Need ColocatedData object, got {type(coldata)}")
 
         elif coldata.has_latlon_dims and regions_how == "country":

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -13,7 +13,7 @@ from pyaerocom._lowlevel_helpers import read_json, write_json
 from pyaerocom._warnings import ignore_warnings
 from pyaerocom.aeroval.fairmode_stats import fairmode_stats
 from pyaerocom.aeroval.helpers import _get_min_max_year_periods, _period_str_to_timeslice
-from pyaerocom.colocateddata import ColocatedData
+from pyaerocom.colocateddata2d import ColocatedData2D
 from pyaerocom.config import ALL_REGION_NAME
 from pyaerocom.exceptions import (
     AeroValConfigError,
@@ -1107,7 +1107,7 @@ def _select_period_season_coldata(coldata, period, season):
         mask = arr["season"] == season
         arr = arr.sel(time=arr["time"][mask])
 
-    return ColocatedData(arr)
+    return ColocatedData2D(arr)
 
 
 def _process_heatmap_data(
@@ -1301,7 +1301,7 @@ def _process_statistics_timeseries(data, freq, region_ids, use_weights, use_coun
         for i, js in enumerate(jsdate):
             per = to_idx_str[i]
             try:
-                arr = ColocatedData(subset.data.sel(time=per))
+                arr = ColocatedData2D(subset.data.sel(time=per))
                 stats = arr.calc_statistics(use_area_weights=use_weights)
                 output[regname][str(js)] = _prep_stats_json(stats)
             except DataCoverageError:

--- a/pyaerocom/aeroval/helpers.py
+++ b/pyaerocom/aeroval/helpers.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from pyaerocom import const
 from pyaerocom.aeroval.modelentry import ModelEntry
 from pyaerocom.aeroval.varinfo_web import VarinfoWeb
-from pyaerocom.colocateddata import ColocatedData
+from pyaerocom.colocateddata2d import ColocatedData2D
 from pyaerocom.colocation_auto import Colocator
 from pyaerocom.exceptions import TemporalResolutionError
 from pyaerocom.griddeddata import GriddedData

--- a/pyaerocom/aeroval/superobs_engine.py
+++ b/pyaerocom/aeroval/superobs_engine.py
@@ -6,7 +6,7 @@ import xarray as xr
 
 from pyaerocom.aeroval._processing_base import HasColocator, ProcessingEngine
 from pyaerocom.aeroval.coldatatojson_engine import ColdataToJsonEngine
-from pyaerocom.colocateddata import ColocatedData
+from pyaerocom.colocateddata2d import ColocatedData2D
 from pyaerocom.helpers import get_lowest_resolution
 
 logger = logging.getLogger(__name__)
@@ -106,13 +106,13 @@ class SuperObsEngine(ProcessingEngine, HasColocator):
             darrs.append(self._get_dataarray(fp, to_freq, obs_name))
 
         merged = xr.concat(darrs, dim="station_name")
-        coldata = ColocatedData(merged)
+        coldata = ColocatedData2D(merged)
         engine = ColdataToJsonEngine(self.cfg)
         engine.process_coldata(coldata)
 
     def _get_dataarray(self, fp, to_freq, obs_name):
         """Get dataarray needed for combination to superobs"""
-        data = ColocatedData(fp)
+        data = ColocatedData2D(fp)
         if data.ts_type != to_freq:
             data.resample_time(to_ts_type=to_freq, settings_from_meta=True, inplace=True)
         arr = data.data
@@ -141,7 +141,7 @@ class SuperObsEngine(ProcessingEngine, HasColocator):
                 f"{model_name}, {obs_name}, {var_name}: {cdf}..."
             )
         fp = cdf[0]
-        meta = ColocatedData.get_meta_from_filename(fp)
+        meta = ColocatedData2D.get_meta_from_filename(fp)
         ts_type = meta["ts_type"]
         vert_code = self.cfg.obs_cfg.get_entry(obs_name)["obs_vert_type"]
         return (fp, ts_type, vert_code)

--- a/pyaerocom/colocateddata.py
+++ b/pyaerocom/colocateddata.py
@@ -19,11 +19,13 @@ from pyaerocom.exceptions import (
     UnknownRegion,
     VarNotAvailableError,
 )
-from pyaerocom.geodesy import get_country_info_coords
+
+# from pyaerocom.geodesy import get_country_info_coords
 from pyaerocom.helpers import to_datestring_YYYYMMDD
 from pyaerocom.helpers_landsea_masks import get_mask_value, load_region_mask_xr
-from pyaerocom.mathutils import calc_statistics
-from pyaerocom.plot.plotscatter import plot_scatter
+
+# from pyaerocom.mathutils import calc_statistics
+# from pyaerocom.plot.plotscatter import plot_scatter
 from pyaerocom.region import Region
 from pyaerocom.region_defs import REGION_DEFS
 from pyaerocom.time_resampler import TimeResampler
@@ -92,6 +94,7 @@ class ColocatedData:
             elif isinstance(data, xarray.DataArray):
                 self.data = data
             elif isinstance(data, np.ndarray):
+                # LB: This may need to be removed for vertical profiles
                 if not data.ndim in (3, 4):
                     raise DataDimensionError("invalid input, need 3D or 4D numpy array")
                 elif not data.shape[0] == 2:
@@ -270,36 +273,6 @@ class ColocatedData:
         return len(obj.data.station_name)
 
     @property
-    def num_coords_with_data(self):
-        """Number of lat/lon coordinate pairs that contain at least one datapoint
-
-        Note
-        ----
-        Occurrence of valid data is only checked for obsdata (first index in
-        data_source dimension).
-        """
-        obj = self.flatten_latlondim_station_name() if self.has_latlon_dims else self
-        dims = obj.dims
-        if not "station_name" in dims:
-            raise DataDimensionError("Need dimension station_name")
-        obs = obj.data[0]
-        if len(dims) > 3:  # additional dimensions
-            default_dims = ("data_source", "time", "station_name")
-            add_dims = tuple(x for x in dims if not x in default_dims)
-            raise DataDimensionError(
-                f"Can only unambiguously retrieve no of coords with obs data "
-                f"for colocated data with dims {default_dims}, please reduce "
-                f"dimensionality first by selecting or aggregating additional "
-                f"dimensions: {add_dims}"
-            )
-
-        if "time" in dims:
-            val = (obs.count(dim="time") > 0).data.sum()
-        else:
-            val = (~np.isnan(obs.data)).sum()
-        return val
-
-    @property
     def has_time_dim(self):
         """Boolean specifying whether data has a time dimension"""
         return True if "time" in self.dims else False
@@ -308,6 +281,11 @@ class ColocatedData:
     def has_latlon_dims(self):
         """Boolean specifying whether data has latitude and longitude dimensions"""
         return all([dim in self.dims for dim in ["latitude", "longitude"]])
+
+    @property
+    def has_alt_dim(self):
+        """Boolean specifying whether data has an altitude dimension"""
+        return True if "altitude" in self.dims else False
 
     @property
     def countries_available(self):
@@ -363,6 +341,36 @@ class ColocatedData:
         Wrapper for :func:`calc_area_weights`
         """
         return self.calc_area_weights()
+
+    @property
+    def num_coords_with_data(self):
+        """Number of lat/lon coordinate pairs that contain at least one datapoint
+
+        Note
+        ----
+        Occurrence of valid data is only checked for obsdata (first index in
+        data_source dimension).
+        """
+        obj = self.flatten_latlondim_station_name() if self.has_latlon_dims else self
+        dims = obj.dims
+        if not "station_name" in dims:
+            raise DataDimensionError("Need dimension station_name")
+        obs = obj.data[0]
+        if len(dims) > 3:  # additional dimensions
+            default_dims = ("data_source", "time", "station_name")
+            add_dims = tuple(x for x in dims if not x in default_dims)
+            raise DataDimensionError(
+                f"Can only unambiguously retrieve no of coords with obs data "
+                f"for colocated data with dims {default_dims}, please reduce "
+                f"dimensionality first by selecting or aggregating additional "
+                f"dimensions: {add_dims}"
+            )
+
+        if "time" in dims:
+            val = (obs.count(dim="time") > 0).data.sum()
+        else:
+            val = (~np.isnan(obs.data)).sum()
+        return val
 
     def get_meta_item(self, key: str):
         """
@@ -550,32 +558,6 @@ class ColocatedData:
         col.data.attrs.update(trs)
         return col
 
-    def flatten_latlondim_station_name(self):
-        """Stack (flatten) lat / lon dimension into new dimension station_name
-
-        Returns
-        -------
-        ColocatedData
-            new colocated data object with dimension station_name and lat lon
-            arrays as additional coordinates
-        """
-        if not self.has_latlon_dims:
-            raise DataDimensionError("Need latitude and longitude dimensions")
-
-        newdims = []
-        for dim in self.dims:
-            if dim == "latitude":
-                newdims.append("station_name")
-            elif dim == "longitude":
-                continue
-            else:
-                newdims.append(dim)
-
-        arr = self.stack(station_name=["latitude", "longitude"], inplace=False).data
-
-        arr = arr.transpose(*newdims)
-        return ColocatedData(arr)
-
     def stack(self, inplace=False, **kwargs):
         """Stack one or more dimensions
 
@@ -623,143 +605,6 @@ class ColocatedData:
             data = self.copy()
         return data.unstack(**kwargs)
 
-    def get_coords_valid_obs(self):
-        """
-        Get latitude / longitude coordinates where obsdata is available
-
-        Returns
-        -------
-        list
-            latitute coordinates
-        list
-            longitude coordinates
-
-        """
-
-        obs = self.data[0]
-        if self.ndim == 4:
-            stacked = obs.stack(x=["latitude", "longitude"])
-            invalid = stacked.isnull().all(dim="time")
-            coords = stacked.x[~invalid].values
-            coords = zip(*list(coords))
-        else:
-            invalid = obs.isnull().all(dim="time")
-            lats = list(obs.latitude[~invalid].values)
-            lons = list(obs.longitude[~invalid].values)
-            coords = (lats, lons)
-        return list(coords)
-
-    def _iter_stats(self):
-        """Create a list that can be used to iterate over station dimension
-
-        Returns
-        -------
-        list
-            list containing 3-element tuples, one for each site i, comprising
-            (latitude[i], longitude[i], station_name[i]).
-        """
-        if not "station_name" in self.data.dims:
-            raise AttributeError(
-                "ColocatedData object has no dimension station_name. Consider stacking..."
-            )
-        if "latitude" in self.dims and "longitude" in self.dims:
-            raise AttributeError(
-                "Cannot init station iter index since latitude and longitude are othorgonal"
-            )
-        lats = self.data.latitude.values
-        lons = self.data.longitude.values
-        stats = self.data.station_name.values
-
-        return list(zip(lats, lons, stats))
-
-    def _get_stat_coords(self):
-        """
-        Get station coordinates
-
-        Raises
-        ------
-        DataDimensionError
-            if data is 4D and does not have latitude and longitude dimension
-
-        Returns
-        -------
-        list
-            list containing 2 element tuples (latitude, longitude)
-
-        """
-        if self.ndim == 4:
-            if not self.has_latlon_dims:
-                raise DataDimensionError("Invalid dimensions in 4D ColocatedData")
-            lats, lons = self.data.latitude.data, self.data.longitude.data
-            coords = np.dstack(np.meshgrid(lats, lons))
-            coords = coords.reshape(len(lats) * len(lons), 2)
-        else:
-            coords = zip(self.latitude.data, self.longitude.data)
-        return list(coords)
-
-    def check_set_countries(self, inplace=True, assign_to_dim=None):
-        """
-        Checks if country information is available and assigns if not
-
-        If not country information is available, countries will be assigned
-        for each lat / lon coordinate using
-        :func:`pyaerocom.geodesy.get_country_info_coords`.
-
-        Parameters
-        ----------
-        inplace : bool, optional
-            If True, modify and return this object, else a copy.
-            The default is True.
-        assign_to_dim : str, optional
-            name of dimension to which the country coordinate is assigned.
-            Default is None, in which case station_name is used.
-
-        Raises
-        ------
-        DataDimensionError
-            If data is 4D (i.e. if latitude and longitude are othorgonal
-            dimensions)
-
-        Returns
-        -------
-        ColocatedData
-            data object with countries assigned
-
-        """
-        if self.has_latlon_dims:
-            raise DataDimensionError(
-                "Countries cannot be assigned to 4D"
-                "ColocatedData with othorgonal lat / lon "
-                "dimensions. Please consider stacking "
-                "the latitude and longitude dimensions-"
-            )
-        if assign_to_dim is None:
-            assign_to_dim = "station_name"
-
-        if not assign_to_dim in self.dims:
-            raise DataDimensionError("No such dimension", assign_to_dim)
-
-        coldata = self if inplace else self.copy()
-
-        if "country" in coldata.data.coords:
-            logger.info("Country information is available")
-            return coldata
-        coords = coldata._get_stat_coords()
-
-        info = get_country_info_coords(coords)
-
-        countries, codes = [], []
-        for item in info:
-            countries.append(item["country"])
-            codes.append(item["country_code"])
-
-        arr = coldata.data
-        arr = arr.assign_coords(
-            country=(assign_to_dim, countries), country_code=(assign_to_dim, codes)
-        )
-        coldata.data = arr
-        return coldata
-
     def copy(self):
         """Copy this object"""
         return ColocatedData(self.data.copy())
@@ -785,229 +630,6 @@ class ColocatedData:
         cd.metadata["zeros_to_nan"] = True
 
         return cd
-
-    def calc_statistics(self, use_area_weights=False, **kwargs):
-        """Calculate statistics from model and obs data
-
-        Calculate standard statistics for model assessment. This is done by
-        taking all model and obs data points in this object as input for
-        :func:`pyaerocom.mathutils.calc_statistics`. For instance, if the
-        object is 3D with dimensions `data_source` (obs, model), `time` (e.g.
-        12 monthly values) and `station_name` (e.g. 4 sites), then the input
-        arrays for model and obs into
-        :func:`pyaerocom.mathutils.calc_statistics` will be each of size
-        12x4.
-
-        See also :func:`calc_temporal_statistics` and
-        :func:`calc_spatial_statistics`.
-
-        Parameters
-        ----------
-        use_area_weights : bool
-            if True and if data is 4D (i.e. has lat and lon dimension), then
-            area weights are applied when caluclating the statistics based on
-            the coordinate cell sizes. Defaults to False.
-        **kwargs
-            additional keyword args passed to
-            :func:`pyaerocom.mathutils.calc_statistics`
-
-        Returns
-        -------
-        dict
-            dictionary containing statistical parameters
-        """
-        if use_area_weights and not "weights" in kwargs and self.has_latlon_dims:
-            kwargs["weights"] = self.area_weights[0].flatten()
-
-        nc = self.num_coords
-        try:
-            ncd = self.num_coords_with_data
-        except DataDimensionError:
-            ncd = np.nan
-        obsvals = self.data.values[0].flatten()
-        modvals = self.data.values[1].flatten()
-        stats = calc_statistics(modvals, obsvals, **kwargs)
-
-        stats["num_coords_tot"] = nc
-        stats["num_coords_with_data"] = ncd
-        return stats
-
-    def calc_temporal_statistics(self, aggr=None, **kwargs):
-        """Calculate *temporal* statistics from model and obs data
-
-        *Temporal* statistics is computed by averaging first the spatial
-        dimension(s) (that is, `station_name` for 3D data, and
-        `latitude` and `longitude` for 4D data), so that only `data_source` and
-        `time` remains as dimensions. These 2D data are then used to calculate
-        standard statistics using :func:`pyaerocom.mathutils.calc_statistics`.
-
-        See also :func:`calc_statistics` and
-        :func:`calc_spatial_statistics`.
-
-        Parameters
-        ----------
-        aggr : str, optional
-            aggreagator to be used, currently only mean and median are
-            supported. Defaults to mean.
-        **kwargs
-            additional keyword args passed to
-            :func:`pyaerocom.mathutils.calc_statistics`
-
-        Returns
-        -------
-        dict
-            dictionary containing statistical parameters
-        """
-        if aggr is None:
-            aggr = "mean"
-        nc = self.num_coords
-        try:
-            ncd = self.num_coords_with_data
-        except:
-            ncd = np.nan
-        if self.has_latlon_dims:
-            dim = ("latitude", "longitude")
-        else:
-            dim = "station_name"
-
-        if aggr == "mean":
-            arr = self.data.mean(dim=dim)
-        elif aggr == "median":
-            arr = self.data.median(dim=dim)
-        else:
-            raise ValueError("So far only mean and median are supported aggregators")
-        obs, mod = arr[0].values.flatten(), arr[1].values.flatten()
-        stats = calc_statistics(mod, obs, **kwargs)
-        stats["num_coords_tot"] = nc
-        stats["num_coords_with_data"] = ncd
-        return stats
-
-    def calc_spatial_statistics(self, aggr=None, use_area_weights=False, **kwargs):
-        """Calculate *spatial* statistics from model and obs data
-
-        *Spatial* statistics is computed by averaging first the time
-        dimension and then, if data is 4D, flattening lat / lon dimensions into
-        new station_name dimension, so that the resulting dimensions are
-        `data_source` and `station_name`. These 2D data are then used to
-        calculate standard statistics using
-        :func:`pyaerocom.mathutils.calc_statistics`.
-
-        See also :func:`calc_statistics` and
-        :func:`calc_temporal_statistics`.
-
-        Parameters
-        ----------
-        aggr : str, optional
-            aggreagator to be used, currently only mean and median are
-            supported. Defaults to mean.
-        use_area_weights : bool
-            if True and if data is 4D (i.e. has lat and lon dimension), then
-            area weights are applied when caluclating the statistics based on
-            the coordinate cell sizes. Defaults to False.
-        **kwargs
-            additional keyword args passed to
-            :func:`pyaerocom.mathutils.calc_statistics`
-
-        Returns
-        -------
-        dict
-            dictionary containing statistical parameters
-        """
-        if aggr is None:
-            aggr = "mean"
-        if use_area_weights and not "weights" in kwargs and self.has_latlon_dims:
-            weights = self.area_weights[0]  # 3D (time, lat, lon)
-            assert self.dims[1] == "time"
-            kwargs["weights"] = np.nanmean(weights, axis=0).flatten()
-
-        nc, ncd = self.num_coords, self.num_coords_with_data
-        # ToDo: find better solution to parse aggregator without if conditions,
-        # e.g. xr.apply_ufunc or similar, with core aggregators that are
-        # supported being defined in some dictionary in some pyaerocom config
-        # module or class. Also aggregation could go into a separate method...
-        if aggr == "mean":
-            arr = self.data.mean(dim="time")
-        elif aggr == "median":
-            arr = self.data.median(dim="time")
-        else:
-            raise ValueError("So far only mean and median are supported aggregators")
-
-        obs, mod = arr[0].values.flatten(), arr[1].values.flatten()
-        stats = calc_statistics(mod, obs, **kwargs)
-        stats["num_coords_tot"] = nc
-        stats["num_coords_with_data"] = ncd
-        return stats
-
-    def plot_scatter(self, **kwargs):
-        """Create scatter plot of data
-
-        Parameters
-        ----------
-        **kwargs
-            keyword args passed to :func:`pyaerocom.plot.plotscatter.plot_scatter`
-
-        Returns
-        -------
-        Axes
-            matplotlib axes instance
-        """
-        meta = self.metadata
-        try:
-            num_points = self.num_coords_with_data
-        except DataDimensionError:
-            num_points = np.nan
-        try:
-            vars_ = meta["var_name"]
-        except KeyError:
-            vars_ = ["N/D", "N/D"]
-        try:
-            xn, yn = meta["data_source"]
-        except KeyError:
-            xn, yn = "N/D", "N/D"
-
-        if vars_[0] != vars_[1]:
-            var_ref = vars_[0]
-        else:
-            var_ref = None
-        try:
-            tst = meta["ts_type"]
-        except KeyError:
-            tst = "N/D"
-        try:
-            fn = meta["filter_name"]
-        except KeyError:
-            fn = "N/D"
-        try:
-            unit = self.unitstr
-        except KeyError:
-            unit = "N/D"
-        try:
-            start = self.start
-        except AttributeError:
-            start = "N/D"
-
-        try:
-            stop = self.stop
-        except AttributeError:
-            stop = "N/D"
-
-        # ToDo: include option to use area weighted stats in plotting
-        # routine...
-        return plot_scatter(
-            x_vals=self.data.values[0].flatten(),
-            y_vals=self.data.values[1].flatten(),
-            var_name=vars_[1],
-            var_name_ref=var_ref,
-            x_name=xn,
-            y_name=yn,
-            start=start,
-            stop=stop,
-            unit=unit,
-            ts_type=tst,
-            stations_ok=num_points,
-            filter_name=fn,
-            **kwargs,
-        )
 
     def rename_variable(self, var_name, new_var_name, data_source, inplace=True):
         """Rename a variable in this object
@@ -1678,6 +1300,78 @@ class ColocatedData:
         data.data = filtered
         return data
 
+    def flatten_latlondim_station_name(self):
+        """Stack (flatten) lat / lon dimension into new dimension station_name
+
+        Returns
+        -------
+        ColocatedData
+            new colocated data object with dimension station_name and lat lon
+            arrays as additional coordinates
+        """
+        if not self.has_latlon_dims:
+            raise DataDimensionError("Need latitude and longitude dimensions")
+
+        newdims = []
+        for dim in self.dims:
+            if dim == "latitude":
+                newdims.append("station_name")
+            elif dim == "longitude":
+                continue
+            else:
+                newdims.append(dim)
+
+        arr = self.stack(station_name=["latitude", "longitude"], inplace=False).data
+
+        arr = arr.transpose(*newdims)
+        return ColocatedData(arr)
+
+    def calc_statistics(self, use_area_weights=False, **kwargs):
+        """Calculate statistics from model and obs data
+
+        Calculate standard statistics for model assessment. This is done by
+        taking all model and obs data points in this object as input for
+        :func:`pyaerocom.mathutils.calc_statistics`. For instance, if the
+        object is 3D with dimensions `data_source` (obs, model), `time` (e.g.
+        12 monthly values) and `station_name` (e.g. 4 sites), then the input
+        arrays for model and obs into
+        :func:`pyaerocom.mathutils.calc_statistics` will be each of size
+        12x4.
+
+        See also :func:`calc_temporal_statistics` and
+        :func:`calc_spatial_statistics`.
+
+        Parameters
+        ----------
+        use_area_weights : bool
+            if True and if data is 4D (i.e. has lat and lon dimension), then
+            area weights are applied when caluclating the statistics based on
+            the coordinate cell sizes. Defaults to False.
+        **kwargs
+            additional keyword args passed to
+            :func:`pyaerocom.mathutils.calc_statistics`
+
+        Returns
+        -------
+        dict
+            dictionary containing statistical parameters
+        """
+        if use_area_weights and not "weights" in kwargs and self.has_latlon_dims:
+            kwargs["weights"] = self.area_weights[0].flatten()
+
+        nc = self.num_coords
+        try:
+            ncd = self.num_coords_with_data
+        except DataDimensionError:
+            ncd = np.nan
+        obsvals = self.data.values[0].flatten()
+        modvals = self.data.values[1].flatten()
+        stats = calc_statistics(modvals, obsvals, **kwargs)
+
+        stats["num_coords_tot"] = nc
+        stats["num_coords_with_data"] = ncd
+        return stats
+
     def apply_region_mask(self, region_id, inplace=False):
         """
         Apply a binary regions mask filter to data object. Available binary
@@ -1823,42 +1517,28 @@ class ColocatedData:
         mod, obs = _arr[1], _arr[0]
         return (mod - obs).sum("time") / obs.sum("time")
 
-    def plot_coordinates(self, marker="x", markersize=12, fontsize_base=10, **kwargs):
-        """
-        Plot station coordinates
-
-        Uses :func:`pyaerocom.plot.plotcoordinates.plot_coordinates`.
-
-        Parameters
-        ----------
-        marker : str, optional
-            matplotlib marker name used to plot site locations.
-            The default is 'x'.
-        markersize : int, optional
-            Size of site markers. The default is 12.
-        fontsize_base : int, optional
-            Basic fontsize. The default is 10.
-        **kwargs
-            additional keyword args passed to
-            :func:`pyaerocom.plot.plotcoordinates.plot_coordinates`
+    def _iter_stats(self):
+        """Create a list that can be used to iterate over station dimension
 
         Returns
         -------
-        matplotlib.axes.Axes
-
+        list
+            list containing 3-element tuples, one for each site i, comprising
+            (latitude[i], longitude[i], station_name[i]).
         """
+        if not "station_name" in self.data.dims:
+            raise AttributeError(
+                "ColocatedData object has no dimension station_name. Consider stacking..."
+            )
+        if "latitude" in self.dims and "longitude" in self.dims:
+            raise AttributeError(
+                "Cannot init station iter index since latitude and longitude are othorgonal"
+            )
+        lats = self.data.latitude.values
+        lons = self.data.longitude.values
+        stats = self.data.station_name.values
 
-        from pyaerocom.plot.plotcoordinates import plot_coordinates
-
-        lats, lons = self.get_coords_valid_obs()
-        return plot_coordinates(
-            lons=lons,
-            lats=lats,
-            marker=marker,
-            markersize=markersize,
-            fontsize_base=fontsize_base,
-            **kwargs,
-        )
+        return list(zip(lats, lons, stats))
 
     def __contains__(self, val):
         return self.data.__contains__(val)

--- a/pyaerocom/colocateddata2d.py
+++ b/pyaerocom/colocateddata2d.py
@@ -1,0 +1,494 @@
+import logging
+import os
+import warnings
+from ast import literal_eval
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import xarray
+
+from pyaerocom import const
+from pyaerocom.colocateddata import ColocatedData
+from pyaerocom.exceptions import (
+    CoordinateError,
+    DataCoverageError,
+    DataDimensionError,
+    DataSourceError,
+    MetaDataError,
+    NetcdfError,
+    UnknownRegion,
+    VarNotAvailableError,
+)
+from pyaerocom.geodesy import get_country_info_coords
+from pyaerocom.helpers import to_datestring_YYYYMMDD
+from pyaerocom.helpers_landsea_masks import get_mask_value, load_region_mask_xr
+from pyaerocom.mathutils import calc_statistics
+from pyaerocom.plot.plotscatter import plot_scatter
+from pyaerocom.region import Region
+from pyaerocom.region_defs import REGION_DEFS
+from pyaerocom.time_resampler import TimeResampler
+
+logger = logging.getLogger(__name__)
+
+
+class ColocatedData2D(ColocatedData):
+    """
+    Class derived from ColocatedData which represents 2D colcated data. Everything specific to the 2D case will be put here
+    """
+
+    def __init__(self, data=None, **kwargs):
+        super().__init__(data, **kwargs)
+
+    @property
+    def num_coords_with_data(self):
+        """Number of lat/lon coordinate pairs that contain at least one datapoint
+
+        Note
+        ----
+        Occurrence of valid data is only checked for obsdata (first index in
+        data_source dimension).
+        """
+        obj = self.flatten_latlondim_station_name() if self.has_latlon_dims else self
+        dims = obj.dims
+        if not "station_name" in dims:
+            raise DataDimensionError("Need dimension station_name")
+        obs = obj.data[0]
+        if len(dims) > 3:  # additional dimensions
+            default_dims = ("data_source", "time", "station_name")
+            add_dims = tuple(x for x in dims if not x in default_dims)
+            raise DataDimensionError(
+                f"Can only unambiguously retrieve no of coords with obs data "
+                f"for colocated data with dims {default_dims}, please reduce "
+                f"dimensionality first by selecting or aggregating additional "
+                f"dimensions: {add_dims}"
+            )
+
+        if "time" in dims:
+            val = (obs.count(dim="time") > 0).data.sum()
+        else:
+            val = (~np.isnan(obs.data)).sum()
+        return val
+
+    def flatten_latlondim_station_name(self):
+        """Stack (flatten) lat / lon dimension into new dimension station_name
+
+        Returns
+        -------
+        ColocatedData
+            new colocated data object with dimension station_name and lat lon
+            arrays as additional coordinates
+        """
+        if not self.has_latlon_dims:
+            raise DataDimensionError("Need latitude and longitude dimensions")
+
+        newdims = []
+        for dim in self.dims:
+            if dim == "latitude":
+                newdims.append("station_name")
+            elif dim == "longitude":
+                continue
+            else:
+                newdims.append(dim)
+
+        arr = self.stack(station_name=["latitude", "longitude"], inplace=False).data
+
+        arr = arr.transpose(*newdims)
+        return ColocatedData(arr)
+
+    def get_coords_valid_obs(self):
+        """
+        Get latitude / longitude coordinates where obsdata is available
+
+        Returns
+        -------
+        list
+            latitute coordinates
+        list
+            longitude coordinates
+
+        """
+
+        obs = self.data[0]
+        if self.ndim == 4:
+            stacked = obs.stack(x=["latitude", "longitude"])
+            invalid = stacked.isnull().all(dim="time")
+            coords = stacked.x[~invalid].values
+            coords = zip(*list(coords))
+        else:
+            invalid = obs.isnull().all(dim="time")
+            lats = list(obs.latitude[~invalid].values)
+            lons = list(obs.longitude[~invalid].values)
+            coords = (lats, lons)
+        return list(coords)
+
+    def _iter_stats(self):
+        """Create a list that can be used to iterate over station dimension
+
+        Returns
+        -------
+        list
+            list containing 3-element tuples, one for each site i, comprising
+            (latitude[i], longitude[i], station_name[i]).
+        """
+        if not "station_name" in self.data.dims:
+            raise AttributeError(
+                "ColocatedData object has no dimension station_name. Consider stacking..."
+            )
+        if "latitude" in self.dims and "longitude" in self.dims:
+            raise AttributeError(
+                "Cannot init station iter index since latitude and longitude are othorgonal"
+            )
+        lats = self.data.latitude.values
+        lons = self.data.longitude.values
+        stats = self.data.station_name.values
+
+        return list(zip(lats, lons, stats))
+
+    def _get_stat_coords(self):
+        """
+        Get station coordinates
+
+        Raises
+        ------
+        DataDimensionError
+            if data is 4D and does not have latitude and longitude dimension
+
+        Returns
+        -------
+        list
+            list containing 2 element tuples (latitude, longitude)
+
+        """
+        if self.ndim == 4:
+            if not self.has_latlon_dims:
+                raise DataDimensionError("Invalid dimensions in 4D ColocatedData")
+            lats, lons = self.data.latitude.data, self.data.longitude.data
+            coords = np.dstack(np.meshgrid(lats, lons))
+            coords = coords.reshape(len(lats) * len(lons), 2)
+        else:
+            coords = zip(self.latitude.data, self.longitude.data)
+        return list(coords)
+
+    def check_set_countries(self, inplace=True, assign_to_dim=None):
+        """
+        Checks if country information is available and assigns if not
+
+        If not country information is available, countries will be assigned
+        for each lat / lon coordinate using
+        :func:`pyaerocom.geodesy.get_country_info_coords`.
+
+        Parameters
+        ----------
+        inplace : bool, optional
+            If True, modify and return this object, else a copy.
+            The default is True.
+        assign_to_dim : str, optional
+            name of dimension to which the country coordinate is assigned.
+            Default is None, in which case station_name is used.
+
+        Raises
+        ------
+        DataDimensionError
+            If data is 4D (i.e. if latitude and longitude are othorgonal
+            dimensions)
+
+        Returns
+        -------
+        ColocatedData
+            data object with countries assigned
+
+        """
+        if self.has_latlon_dims:
+            raise DataDimensionError(
+                "Countries cannot be assigned to 4D"
+                "ColocatedData with othorgonal lat / lon "
+                "dimensions. Please consider stacking "
+                "the latitude and longitude dimensions-"
+            )
+        if assign_to_dim is None:
+            assign_to_dim = "station_name"
+
+        if not assign_to_dim in self.dims:
+            raise DataDimensionError("No such dimension", assign_to_dim)
+
+        coldata = self if inplace else self.copy()
+
+        if "country" in coldata.data.coords:
+            logger.info("Country information is available")
+            return coldata
+        coords = coldata._get_stat_coords()
+
+        info = get_country_info_coords(coords)
+
+        countries, codes = [], []
+        for item in info:
+            countries.append(item["country"])
+            codes.append(item["country_code"])
+
+        arr = coldata.data
+        arr = arr.assign_coords(
+            country=(assign_to_dim, countries), country_code=(assign_to_dim, codes)
+        )
+        coldata.data = arr
+        return coldata
+
+    def calc_statistics(self, use_area_weights=False, **kwargs):
+        """Calculate statistics from model and obs data
+
+        Calculate standard statistics for model assessment. This is done by
+        taking all model and obs data points in this object as input for
+        :func:`pyaerocom.mathutils.calc_statistics`. For instance, if the
+        object is 3D with dimensions `data_source` (obs, model), `time` (e.g.
+        12 monthly values) and `station_name` (e.g. 4 sites), then the input
+        arrays for model and obs into
+        :func:`pyaerocom.mathutils.calc_statistics` will be each of size
+        12x4.
+
+        See also :func:`calc_temporal_statistics` and
+        :func:`calc_spatial_statistics`.
+
+        Parameters
+        ----------
+        use_area_weights : bool
+            if True and if data is 4D (i.e. has lat and lon dimension), then
+            area weights are applied when caluclating the statistics based on
+            the coordinate cell sizes. Defaults to False.
+        **kwargs
+            additional keyword args passed to
+            :func:`pyaerocom.mathutils.calc_statistics`
+
+        Returns
+        -------
+        dict
+            dictionary containing statistical parameters
+        """
+        if use_area_weights and not "weights" in kwargs and self.has_latlon_dims:
+            kwargs["weights"] = self.area_weights[0].flatten()
+
+        nc = self.num_coords
+        try:
+            ncd = self.num_coords_with_data
+        except DataDimensionError:
+            ncd = np.nan
+        obsvals = self.data.values[0].flatten()
+        modvals = self.data.values[1].flatten()
+        stats = calc_statistics(modvals, obsvals, **kwargs)
+
+        stats["num_coords_tot"] = nc
+        stats["num_coords_with_data"] = ncd
+        return stats
+
+    def calc_temporal_statistics(self, aggr=None, **kwargs):
+        """Calculate *temporal* statistics from model and obs data
+
+        *Temporal* statistics is computed by averaging first the spatial
+        dimension(s) (that is, `station_name` for 3D data, and
+        `latitude` and `longitude` for 4D data), so that only `data_source` and
+        `time` remains as dimensions. These 2D data are then used to calculate
+        standard statistics using :func:`pyaerocom.mathutils.calc_statistics`.
+
+        See also :func:`calc_statistics` and
+        :func:`calc_spatial_statistics`.
+
+        Parameters
+        ----------
+        aggr : str, optional
+            aggreagator to be used, currently only mean and median are
+            supported. Defaults to mean.
+        **kwargs
+            additional keyword args passed to
+            :func:`pyaerocom.mathutils.calc_statistics`
+
+        Returns
+        -------
+        dict
+            dictionary containing statistical parameters
+        """
+        if aggr is None:
+            aggr = "mean"
+        nc = self.num_coords
+        try:
+            ncd = self.num_coords_with_data
+        except:
+            ncd = np.nan
+        if self.has_latlon_dims:
+            dim = ("latitude", "longitude")
+        else:
+            dim = "station_name"
+
+        if aggr == "mean":
+            arr = self.data.mean(dim=dim)
+        elif aggr == "median":
+            arr = self.data.median(dim=dim)
+        else:
+            raise ValueError("So far only mean and median are supported aggregators")
+        obs, mod = arr[0].values.flatten(), arr[1].values.flatten()
+        stats = calc_statistics(mod, obs, **kwargs)
+        stats["num_coords_tot"] = nc
+        stats["num_coords_with_data"] = ncd
+        return stats
+
+    def calc_spatial_statistics(self, aggr=None, use_area_weights=False, **kwargs):
+        """Calculate *spatial* statistics from model and obs data
+
+        *Spatial* statistics is computed by averaging first the time
+        dimension and then, if data is 4D, flattening lat / lon dimensions into
+        new station_name dimension, so that the resulting dimensions are
+        `data_source` and `station_name`. These 2D data are then used to
+        calculate standard statistics using
+        :func:`pyaerocom.mathutils.calc_statistics`.
+
+        See also :func:`calc_statistics` and
+        :func:`calc_temporal_statistics`.
+
+        Parameters
+        ----------
+        aggr : str, optional
+            aggreagator to be used, currently only mean and median are
+            supported. Defaults to mean.
+        use_area_weights : bool
+            if True and if data is 4D (i.e. has lat and lon dimension), then
+            area weights are applied when caluclating the statistics based on
+            the coordinate cell sizes. Defaults to False.
+        **kwargs
+            additional keyword args passed to
+            :func:`pyaerocom.mathutils.calc_statistics`
+
+        Returns
+        -------
+        dict
+            dictionary containing statistical parameters
+        """
+        if aggr is None:
+            aggr = "mean"
+        if use_area_weights and not "weights" in kwargs and self.has_latlon_dims:
+            weights = self.area_weights[0]  # 3D (time, lat, lon)
+            assert self.dims[1] == "time"
+            kwargs["weights"] = np.nanmean(weights, axis=0).flatten()
+
+        nc, ncd = self.num_coords, self.num_coords_with_data
+        # ToDo: find better solution to parse aggregator without if conditions,
+        # e.g. xr.apply_ufunc or similar, with core aggregators that are
+        # supported being defined in some dictionary in some pyaerocom config
+        # module or class. Also aggregation could go into a separate method...
+        if aggr == "mean":
+            arr = self.data.mean(dim="time")
+        elif aggr == "median":
+            arr = self.data.median(dim="time")
+        else:
+            raise ValueError("So far only mean and median are supported aggregators")
+
+        obs, mod = arr[0].values.flatten(), arr[1].values.flatten()
+        stats = calc_statistics(mod, obs, **kwargs)
+        stats["num_coords_tot"] = nc
+        stats["num_coords_with_data"] = ncd
+        return stats
+
+    def plot_scatter(self, **kwargs):
+        """Create scatter plot of data
+
+        Parameters
+        ----------
+        **kwargs
+            keyword args passed to :func:`pyaerocom.plot.plotscatter.plot_scatter`
+
+        Returns
+        -------
+        Axes
+            matplotlib axes instance
+        """
+        meta = self.metadata
+        try:
+            num_points = self.num_coords_with_data
+        except DataDimensionError:
+            num_points = np.nan
+        try:
+            vars_ = meta["var_name"]
+        except KeyError:
+            vars_ = ["N/D", "N/D"]
+        try:
+            xn, yn = meta["data_source"]
+        except KeyError:
+            xn, yn = "N/D", "N/D"
+
+        if vars_[0] != vars_[1]:
+            var_ref = vars_[0]
+        else:
+            var_ref = None
+        try:
+            tst = meta["ts_type"]
+        except KeyError:
+            tst = "N/D"
+        try:
+            fn = meta["filter_name"]
+        except KeyError:
+            fn = "N/D"
+        try:
+            unit = self.unitstr
+        except KeyError:
+            unit = "N/D"
+        try:
+            start = self.start
+        except AttributeError:
+            start = "N/D"
+
+        try:
+            stop = self.stop
+        except AttributeError:
+            stop = "N/D"
+
+        # ToDo: include option to use area weighted stats in plotting
+        # routine...
+        return plot_scatter(
+            x_vals=self.data.values[0].flatten(),
+            y_vals=self.data.values[1].flatten(),
+            var_name=vars_[1],
+            var_name_ref=var_ref,
+            x_name=xn,
+            y_name=yn,
+            start=start,
+            stop=stop,
+            unit=unit,
+            ts_type=tst,
+            stations_ok=num_points,
+            filter_name=fn,
+            **kwargs,
+        )
+
+    def plot_coordinates(self, marker="x", markersize=12, fontsize_base=10, **kwargs):
+        """
+        Plot station coordinates
+
+        Uses :func:`pyaerocom.plot.plotcoordinates.plot_coordinates`.
+
+        Parameters
+        ----------
+        marker : str, optional
+            matplotlib marker name used to plot site locations.
+            The default is 'x'.
+        markersize : int, optional
+            Size of site markers. The default is 12.
+        fontsize_base : int, optional
+            Basic fontsize. The default is 10.
+        **kwargs
+            additional keyword args passed to
+            :func:`pyaerocom.plot.plotcoordinates.plot_coordinates`
+
+        Returns
+        -------
+        matplotlib.axes.Axes
+
+        """
+
+        from pyaerocom.plot.plotcoordinates import plot_coordinates
+
+        lats, lons = self.get_coords_valid_obs()
+        return plot_coordinates(
+            lons=lons,
+            lats=lats,
+            marker=marker,
+            markersize=markersize,
+            fontsize_base=fontsize_base,
+            **kwargs,
+        )

--- a/pyaerocom/colocateddata3d.py
+++ b/pyaerocom/colocateddata3d.py
@@ -5,29 +5,31 @@ from ast import literal_eval
 from pathlib import Path
 
 import numpy as np
-import pandas as pd
-import xarray
 
-from pyaerocom import const
+# from pyaerocom import const
 from pyaerocom.colocateddata import ColocatedData
-from pyaerocom.exceptions import (
-    CoordinateError,
-    DataCoverageError,
-    DataDimensionError,
-    DataSourceError,
-    MetaDataError,
-    NetcdfError,
-    UnknownRegion,
-    VarNotAvailableError,
-)
-from pyaerocom.geodesy import get_country_info_coords
-from pyaerocom.helpers import to_datestring_YYYYMMDD
-from pyaerocom.helpers_landsea_masks import get_mask_value, load_region_mask_xr
-from pyaerocom.mathutils import calc_statistics
-from pyaerocom.plot.plotscatter import plot_scatter
-from pyaerocom.region import Region
-from pyaerocom.region_defs import REGION_DEFS
-from pyaerocom.time_resampler import TimeResampler
+
+# import pandas as pd
+# import xarray
+
+# from pyaerocom.exceptions import (
+#     CoordinateError,
+#     DataCoverageError,
+#     DataDimensionError,
+#     DataSourceError,
+#     MetaDataError,
+#     NetcdfError,
+#     UnknownRegion,
+#     VarNotAvailableError,
+# )
+# from pyaerocom.geodesy import get_country_info_coords
+# from pyaerocom.helpers import to_datestring_YYYYMMDD
+# from pyaerocom.helpers_landsea_masks import get_mask_value, load_region_mask_xr
+# from pyaerocom.mathutils import calc_statistics
+# from pyaerocom.plot.plotscatter import plot_scatter
+# from pyaerocom.region import Region
+# from pyaerocom.region_defs import REGION_DEFS
+# from pyaerocom.time_resampler import TimeResampler
 
 logger = logging.getLogger(__name__)
 
@@ -35,8 +37,8 @@ logger = logging.getLogger(__name__)
 class ColocatedData3D(ColocatedData):
     """Class representing 3d colocated data which will be used for vertical profiles"""
 
-    def __init__(self, data=None, **kwargs):
-        super().__init__(data, **kwargs)
+    # def __init__(self, data=None, **kwargs):
+    #     super().__init__(data, **kwargs)
 
     @property
     def altitude(self):

--- a/pyaerocom/colocateddata3d.py
+++ b/pyaerocom/colocateddata3d.py
@@ -1,0 +1,52 @@
+import logging
+import os
+import warnings
+from ast import literal_eval
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import xarray
+
+from pyaerocom import const
+from pyaerocom.colocateddata import ColocatedData
+from pyaerocom.exceptions import (
+    CoordinateError,
+    DataCoverageError,
+    DataDimensionError,
+    DataSourceError,
+    MetaDataError,
+    NetcdfError,
+    UnknownRegion,
+    VarNotAvailableError,
+)
+from pyaerocom.geodesy import get_country_info_coords
+from pyaerocom.helpers import to_datestring_YYYYMMDD
+from pyaerocom.helpers_landsea_masks import get_mask_value, load_region_mask_xr
+from pyaerocom.mathutils import calc_statistics
+from pyaerocom.plot.plotscatter import plot_scatter
+from pyaerocom.region import Region
+from pyaerocom.region_defs import REGION_DEFS
+from pyaerocom.time_resampler import TimeResampler
+
+logger = logging.getLogger(__name__)
+
+
+class ColocatedData3D(ColocatedData):
+    """Class representing 3d colocated data which will be used for vertical profiles"""
+
+    def __init__(self, data=None, **kwargs):
+        super().__init__(data, **kwargs)
+
+    @property
+    def altitude(self):
+        """Array of altitude coordinates"""
+        if not "altitude" in self.data.coords:
+            raise AttributeError("ColocatedData#D does not include altitutde coordinate")
+        return self.data.altitude
+
+    @property
+    def alt_range(self):
+        """Altitude range covered by this data object"""
+        alts = self.altitude.values
+        return (np.nanmin(alts), np.nanmax(alts))

--- a/pyaerocom/colocation.py
+++ b/pyaerocom/colocation.py
@@ -11,7 +11,7 @@ from geonum.atmosphere import pressure
 
 from pyaerocom import __version__ as pya_ver
 from pyaerocom import const
-from pyaerocom.colocateddata import ColocatedData
+from pyaerocom.colocateddata2d import ColocatedData2D
 from pyaerocom.exceptions import (
     DataUnitError,
     DimensionOrderError,
@@ -330,7 +330,7 @@ def colocate_gridded_gridded(
 
     dims = ["data_source", "time", "latitude", "longitude"]
 
-    coldata = ColocatedData(data=arr, coords=coords, dims=dims, name=data.var_name, attrs=meta)
+    coldata = ColocatedData2D(data=arr, coords=coords, dims=dims, name=data.var_name, attrs=meta)
 
     # add correct units for lat / lon dimensions
     coldata.latitude.attrs["standard_name"] = data.latitude.standard_name
@@ -889,7 +889,7 @@ def colocate_gridded_ungridded(
             # resolution of obsdata is too low
             logger.warning(
                 f"{var_ref} data from site {obs_stat.station_name} will "
-                f"not be added to ColocatedData. Reason: {e}"
+                f"not be added to ColocatedData2D. Reason: {e}"
             )
     try:
         revision = data_ref.data_revision[dataset_ref]
@@ -933,7 +933,7 @@ def colocate_gridded_ungridded(
     }
 
     dims = ["data_source", "time", "station_name"]
-    coldata = ColocatedData(data=arr, coords=coords, dims=dims, name=var, attrs=meta)
+    coldata = ColocatedData2D(data=arr, coords=coords, dims=dims, name=var, attrs=meta)
 
     # add correct units for lat / lon dimensions
     coldata.latitude.attrs["standard_name"] = data.latitude.standard_name

--- a/pyaerocom/colocation_auto.py
+++ b/pyaerocom/colocation_auto.py
@@ -18,7 +18,7 @@ import pandas as pd
 
 from pyaerocom import const
 from pyaerocom._lowlevel_helpers import BrowseDict, ListOfStrings, StrWithDefault, chk_make_subdir
-from pyaerocom.colocateddata import ColocatedData
+from pyaerocom.colocateddata2d import ColocatedData2D
 from pyaerocom.colocation import (
     colocate_gridded_gridded,
     colocate_gridded_ungridded,
@@ -852,7 +852,7 @@ class Colocator(ColocationSetup):
         all_files = self.get_nc_files_in_coldatadir()
         for file in all_files:
             try:
-                meta = ColocatedData.get_meta_from_filename(file)
+                meta = ColocatedData2D.get_meta_from_filename(file)
             except Exception:
                 continue
             candidate = check_meta_match(
@@ -1332,7 +1332,7 @@ class Colocator(ColocationSetup):
 
     def _coldata_savename(self, obs_var, mod_var, ts_type):
         """Get filename of colocated data file for saving"""
-        name = ColocatedData._aerocom_savename(
+        name = ColocatedData2D._aerocom_savename(
             obs_var=obs_var,
             obs_id=self.get_obs_name(),
             mod_var=mod_var,

--- a/tests/aeroval/test_coldatatojson_helpers2.py
+++ b/tests/aeroval/test_coldatatojson_helpers2.py
@@ -8,7 +8,7 @@ import pytest
 import xarray
 from pyexpat.errors import XML_ERROR_PARAM_ENTITY_REF
 
-from pyaerocom import ColocatedData, TsType
+from pyaerocom import ColocatedData2D, TsType
 from pyaerocom.aeroval.coldatatojson_helpers import (
     _create_diurnal_weekly_data_object,
     _get_jsdate,
@@ -59,7 +59,7 @@ def test_get_json_mapname():
     ],
 )
 @pytest.mark.parametrize("coldataset", ["tm5_aeronet"])
-def test__init_data_default_frequencies(coldata: ColocatedData, to_ts_types: str):
+def test__init_data_default_frequencies(coldata: ColocatedData2D, to_ts_types: str):
     result = _init_data_default_frequencies(coldata, to_ts_types)
     assert len(result) == len(to_ts_types)
 
@@ -68,7 +68,7 @@ def test__init_data_default_frequencies(coldata: ColocatedData, to_ts_types: str
         if TsType(freq) > tst:
             assert val is None
         else:
-            assert isinstance(val, ColocatedData)
+            assert isinstance(val, ColocatedData2D)
             assert val.ts_type == freq
 
 
@@ -165,7 +165,7 @@ def test__process_statistics_timeseries_error(
 )
 @pytest.mark.parametrize("coldataset", ["fake_3d_trends"])
 def test__make_trends(
-    coldata: ColocatedData,
+    coldata: ColocatedData2D,
     freq: str,
     season: str,
     start: int,
@@ -217,7 +217,7 @@ def test__make_trends(
 )
 @pytest.mark.parametrize("coldataset", ["fake_3d_trends"])
 def test__make_trends_error(
-    coldata: ColocatedData,
+    coldata: ColocatedData2D,
     freq: str,
     season: str,
     min_yrs: int,
@@ -233,7 +233,7 @@ def test__make_trends_error(
 
 
 @pytest.mark.parametrize("coldataset", ["fake_3d_trends"])
-def test__init_meta_glob(coldata: ColocatedData):
+def test__init_meta_glob(coldata: ColocatedData2D):
     # test the functionality of __init_meta_glob when there are KeyErrors. Other cases already covered
     no_meta_coldata = coldata.copy()
     no_meta_coldata.data.attrs = {}
@@ -251,7 +251,7 @@ def test__init_meta_glob(coldata: ColocatedData):
     ],
 )
 @pytest.mark.parametrize("coldataset", ["fake_3d_trends"])
-def test__create_diurnal_weekly_data_object(coldata: ColocatedData, resolution: str):
+def test__create_diurnal_weekly_data_object(coldata: ColocatedData2D, resolution: str):
     try:
         obj = _create_diurnal_weekly_data_object(coldata, resolution)
         assert isinstance(obj, xarray.Dataset)

--- a/tests/fixtures/collocated_data.py
+++ b/tests/fixtures/collocated_data.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from pyaerocom import ColocatedData, Filter
+from pyaerocom import ColocatedData2D, Filter
 from pyaerocom.config import ALL_REGION_NAME
 
 from .data_access import DataForTests
@@ -92,7 +92,7 @@ def _create_fake_coldata_3d():
     }
 
     dims = ["data_source", "time", "station_name"]
-    cd = ColocatedData(data=data, coords=coords, dims=dims, name=var, attrs=meta)
+    cd = ColocatedData2D(data=data, coords=coords, dims=dims, name=var, attrs=meta)
 
     return cd
 
@@ -162,7 +162,7 @@ def _create_fake_trends_coldata_3d():
     }
 
     dims = ["data_source", "time", "station_name"]
-    cd = ColocatedData(data=data, coords=coords, dims=dims, name=var, attrs=meta)
+    cd = ColocatedData2D(data=data, coords=coords, dims=dims, name=var, attrs=meta)
 
     return cd
 
@@ -217,7 +217,7 @@ def _create_fake_coldata_3d_hourly():
     }
 
     dims = ["data_source", "time", "station_name"]
-    cd = ColocatedData(data=data, coords=coords, dims=dims, name=var, attrs=meta)
+    cd = ColocatedData2D(data=data, coords=coords, dims=dims, name=var, attrs=meta)
 
     return cd
 
@@ -246,7 +246,7 @@ def _create_fake_coldata_4d():
     _data_fake[0, :, 1, 1] = np.nan
     _data_fake[0, 0, 0, 0] = np.nan
     meta = {"ts_type": "monthly"}
-    return ColocatedData(data=_data_fake, coords=coords, dims=dims, attrs=meta)
+    return ColocatedData2D(data=_data_fake, coords=coords, dims=dims, attrs=meta)
 
 
 def _create_fake_coldata_5d():
@@ -267,14 +267,14 @@ def _create_fake_coldata_5d():
     dims = ["data_source", "time", "latitude", "longitude", "wvl"]
     # set all NaN in one obs coordinate
     arr = xr.DataArray(data=_data_fake, coords=coords, dims=dims)
-    cd = ColocatedData(np.ones((2, 2, 2)))
+    cd = ColocatedData2D(np.ones((2, 2, 2)))
     cd.data = arr
     return cd
 
 
 COLDATA = dict(
-    tm5_aeronet=lambda: ColocatedData(str(EXAMPLE_FILE)),
-    fake_nodims=lambda: ColocatedData(np.ones((2, 1, 1))),
+    tm5_aeronet=lambda: ColocatedData2D(str(EXAMPLE_FILE)),
+    fake_nodims=lambda: ColocatedData2D(np.ones((2, 1, 1))),
     fake_3d=_create_fake_coldata_3d,
     fake_4d=_create_fake_coldata_4d,
     fake_5d=_create_fake_coldata_5d,
@@ -284,6 +284,6 @@ COLDATA = dict(
 
 
 @pytest.fixture
-def coldata(coldataset: str) -> ColocatedData:
-    """dispatch ColocatedData depending on coldataset"""
+def coldata(coldataset: str) -> ColocatedData2D:
+    """dispatch ColocatedData2D depending on coldataset"""
     return COLDATA[coldataset]()

--- a/tests/fixtures/tm5.py
+++ b/tests/fixtures/tm5.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import pytest
 from xarray import open_dataarray
 
-from pyaerocom import ColocatedData
+from pyaerocom import ColocatedData2D
 from pyaerocom.config import ALL_REGION_NAME
 from pyaerocom.griddeddata import GriddedData
 
@@ -30,7 +30,7 @@ def data_tm5() -> GriddedData:
     return data
 
 
-def load_coldata_tm5_aeronet_from_scratch(path: Path) -> ColocatedData:
+def load_coldata_tm5_aeronet_from_scratch(path: Path) -> ColocatedData2D:
 
     arr = open_dataarray(path)
     if "_min_num_obs" in arr.attrs:
@@ -43,18 +43,18 @@ def load_coldata_tm5_aeronet_from_scratch(path: Path) -> ColocatedData:
                 info[to][fr] = {}
             info[to][fr] = int(num)
         arr.attrs["min_num_obs"] = info
-    cd = ColocatedData()
+    cd = ColocatedData2D()
     cd.data = arr
     return cd
 
 
 @pytest.fixture(scope="session")
-def coldata_tm5_aeronet() -> ColocatedData:
+def coldata_tm5_aeronet() -> ColocatedData2D:
     path = DataForTests(CHECK_PATHS.coldata_tm5_aeronet).path
     return load_coldata_tm5_aeronet_from_scratch(path)
 
 
 @pytest.fixture(scope="session")
-def coldata_tm5_tm5() -> ColocatedData:
+def coldata_tm5_tm5() -> ColocatedData2D:
     path = DataForTests(CHECK_PATHS.tm5_tm5).path
     return load_coldata_tm5_aeronet_from_scratch(path)

--- a/tests/plot/test_mapping.py
+++ b/tests/plot/test_mapping.py
@@ -8,7 +8,7 @@ import pytest
 from matplotlib.figure import Figure
 
 from pyaerocom import GriddedData
-from pyaerocom.colocateddata import ColocatedData
+from pyaerocom.colocateddata2d import ColocatedData2D
 from pyaerocom.config import ALL_REGION_NAME
 from pyaerocom.exceptions import DataDimensionError
 from pyaerocom.plot.config import ColorTheme, get_color_theme
@@ -227,12 +227,12 @@ def test_plot_map_aerocom_error():
         plot_map_aerocom(42, ALL_REGION_NAME)
 
 
-def test_plot_nmb_map_colocateddata(coldata_tm5_aeronet: ColocatedData):
+def test_plot_nmb_map_colocateddata(coldata_tm5_aeronet: ColocatedData2D):
     val = plot_nmb_map_colocateddata(coldata_tm5_aeronet)
     assert isinstance(val, cartopy.mpl.geoaxes.GeoAxes)
 
 
-def test_plot_nmb_map_colocateddata4D(coldata_tm5_tm5: ColocatedData):
+def test_plot_nmb_map_colocateddata4D(coldata_tm5_tm5: ColocatedData2D):
     val = plot_nmb_map_colocateddata(coldata_tm5_tm5)
     assert isinstance(val, cartopy.mpl.geoaxes.GeoAxes)
 
@@ -255,7 +255,7 @@ def test_plot_nmb_map_colocateddata4D(coldata_tm5_tm5: ColocatedData):
     ],
 )
 def test_plot_nmb_map_colocateddataFAIL(
-    coldata: ColocatedData, exception: Type[Exception], error: str
+    coldata: ColocatedData2D, exception: Type[Exception], error: str
 ):
     with pytest.raises(exception) as e:
         plot_nmb_map_colocateddata(coldata)

--- a/tests/test_colocateddata.py
+++ b/tests/test_colocateddata.py
@@ -9,7 +9,7 @@ import xarray as xr
 from matplotlib.axes import Axes
 from numpy.typing import ArrayLike
 
-from pyaerocom import ColocatedData
+from pyaerocom import ColocatedData2D
 from pyaerocom.config import ALL_REGION_NAME
 from pyaerocom.exceptions import DataCoverageError, DataDimensionError, MetaDataError
 from tests.fixtures.collocated_data import EXAMPLE_FILE
@@ -17,7 +17,7 @@ from tests.fixtures.collocated_data import EXAMPLE_FILE
 
 @pytest.mark.parametrize("data", [EXAMPLE_FILE, str(EXAMPLE_FILE), np.ones((2, 3, 4))])
 def test_ColocatedData__init__(data: Path | str | ArrayLike):
-    cd = ColocatedData(data=data)
+    cd = ColocatedData2D(data=data)
     assert isinstance(cd.data, xr.DataArray)
 
 
@@ -30,80 +30,80 @@ def test_ColocatedData__init__(data: Path | str | ArrayLike):
         ({}, ValueError),
     ],
 )
-def test_ColocatedData__init___error(data, exception: Type[Exception]):
+def test_ColocatedData2D__init___error(data, exception: Type[Exception]):
     with pytest.raises(exception):
-        ColocatedData(data=data).data
+        ColocatedData2D(data=data).data
 
 
-def test_ColocatedData_data():
-    col = ColocatedData()
+def test_ColocatedData2D_data():
+    col = ColocatedData2D()
     col.data = data = xr.DataArray()
     assert col.data is data
 
 
-def test_ColocatedData_data_error():
-    col = ColocatedData()
+def test_ColocatedData2D_data_error():
+    col = ColocatedData2D()
     with pytest.raises(ValueError):
         col.data = "Blaaa"
 
 
 @pytest.mark.parametrize("coldataset", ["tm5_aeronet"])
-def test_ColocatedData_data_source(coldata: ColocatedData):
+def test_ColocatedData2D_data_source(coldata: ColocatedData2D):
     ds = coldata.data_source
     assert isinstance(ds, xr.DataArray)
     assert len(ds) == 2
 
 
 @pytest.mark.parametrize("coldataset", ["fake_nodims"])
-def test_ColocatedData_data_source_error(coldata: ColocatedData):
+def test_ColocatedData2D_data_source_error(coldata: ColocatedData2D):
     with pytest.raises(AttributeError) as e:
         coldata.data_source
     assert str(e.value).endswith("has no attribute 'data_source'")
 
 
 @pytest.mark.parametrize("coldataset", ["tm5_aeronet"])
-def test_ColocatedData_var_name(coldata: ColocatedData):
+def test_ColocatedData2D_var_name(coldata: ColocatedData2D):
     assert isinstance(coldata.var_name, list)
 
 
 @pytest.mark.parametrize("coldataset", ["fake_nodims"])
-def test_ColocatedData_var_name_error(coldata: ColocatedData):
+def test_ColocatedData2D_var_name_error(coldata: ColocatedData2D):
     with pytest.raises(AttributeError) as e:
         coldata.var_name
     assert str(e.value).endswith("has no attribute 'var_name'")
 
 
 @pytest.mark.parametrize("coldataset", ["tm5_aeronet"])
-def test_ColocatedData_latitude(coldata: ColocatedData):
+def test_ColocatedData2D_latitude(coldata: ColocatedData2D):
     assert isinstance(coldata.latitude, xr.DataArray)
 
 
 @pytest.mark.parametrize("coldataset", ["fake_nodims"])
-def test_ColocatedData_latitude_error(coldata: ColocatedData):
+def test_ColocatedData2D_latitude_error(coldata: ColocatedData2D):
     with pytest.raises(AttributeError) as e:
         coldata.latitude
     assert str(e.value).endswith("does not include latitude coordinate")
 
 
 @pytest.mark.parametrize("coldataset", ["tm5_aeronet"])
-def test_ColocatedData_longitude(coldata: ColocatedData):
+def test_ColocatedData2D_longitude(coldata: ColocatedData2D):
     assert isinstance(coldata.longitude, xr.DataArray)
 
 
 @pytest.mark.parametrize("coldataset", ["fake_nodims"])
-def test_ColocatedData_longitude_error(coldata: ColocatedData):
+def test_ColocatedData2D_longitude_error(coldata: ColocatedData2D):
     with pytest.raises(AttributeError) as e:
         coldata.longitude
     assert str(e.value).endswith("does not include longitude coordinate")
 
 
 @pytest.mark.parametrize("coldataset", ["tm5_aeronet"])
-def test_ColocatedData_time(coldata: ColocatedData):
+def test_ColocatedData2D_time(coldata: ColocatedData2D):
     assert isinstance(coldata.time, xr.DataArray)
 
 
 @pytest.mark.parametrize("coldataset", ["fake_nodims"])
-def test_ColocatedData_time_error(coldata: ColocatedData):
+def test_ColocatedData2D_time_error(coldata: ColocatedData2D):
     with pytest.raises(AttributeError) as e:
         coldata.time
     assert str(e.value).endswith("does not include time coordinate")
@@ -116,12 +116,12 @@ def test_ColocatedData_time_error(coldata: ColocatedData):
         ("fake_4d", (30, 50)),
     ],
 )
-def test_ColocatedData_lat_range(coldata: ColocatedData, lat_range: tuple[float, float]):
+def test_ColocatedData2D_lat_range(coldata: ColocatedData2D, lat_range: tuple[float, float]):
     assert coldata.lat_range == pytest.approx(lat_range, rel=1e-1)
 
 
 @pytest.mark.parametrize("coldataset", ["fake_nodims"])
-def test_ColocatedData_lat_range_error(coldata: ColocatedData):
+def test_ColocatedData2D_lat_range_error(coldata: ColocatedData2D):
     with pytest.raises(AttributeError) as e:
         coldata.lat_range
     assert str(e.value).endswith("does not include latitude coordinate")
@@ -134,38 +134,38 @@ def test_ColocatedData_lat_range_error(coldata: ColocatedData):
         ("fake_4d", (10, 20)),
     ],
 )
-def test_ColocatedData_lon_range(coldata: ColocatedData, lon_range: tuple[float, float]):
+def test_ColocatedData2D_lon_range(coldata: ColocatedData2D, lon_range: tuple[float, float]):
     assert coldata.lon_range == pytest.approx(lon_range, rel=1e-1)
 
 
 @pytest.mark.parametrize("coldataset", ["fake_nodims"])
-def test_ColocatedData_lon_range_error(coldata: ColocatedData):
+def test_ColocatedData2D_lon_range_error(coldata: ColocatedData2D):
     with pytest.raises(AttributeError) as e:
         coldata.lon_range
     assert str(e.value).endswith("does not include longitude coordinate")
 
 
 @pytest.mark.parametrize("coldataset", ["tm5_aeronet"])
-def test_ColocatedData_ts_type(coldata: ColocatedData):
+def test_ColocatedData2D_ts_type(coldata: ColocatedData2D):
     assert isinstance(coldata.ts_type, str)
 
 
 @pytest.mark.parametrize("coldataset", ["fake_nodims"])
-def test_ColocatedData_ts_type_error(coldata: ColocatedData):
+def test_ColocatedData2D_ts_type_error(coldata: ColocatedData2D):
     with pytest.raises(ValueError) as e:
         coldata.ts_type
     assert str(e.value).endswith("does not contain information about temporal resolution")
 
 
 @pytest.mark.parametrize("coldataset", ["tm5_aeronet"])
-def test_ColocatedData_units(coldata: ColocatedData):
+def test_ColocatedData2D_units(coldata: ColocatedData2D):
     units = coldata.units
     assert isinstance(units, list)
     assert bool(units) and all(isinstance(x, str) for x in units)
 
 
 @pytest.mark.parametrize("coldataset", ["fake_nodims"])
-def test_ColocatedData_units_error(coldata: ColocatedData):
+def test_ColocatedData2D_units_error(coldata: ColocatedData2D):
     with pytest.raises(KeyError) as e:
         coldata.units
     assert "units" in str(e.value)
@@ -180,12 +180,12 @@ def test_ColocatedData_units_error(coldata: ColocatedData):
         ("fake_3d", 4),
     ],
 )
-def test_ColocatedData_num_coords(coldata: ColocatedData, num_coords: int):
+def test_ColocatedData2D_num_coords(coldata: ColocatedData2D, num_coords: int):
     assert coldata.num_coords == num_coords
 
 
 @pytest.mark.parametrize("coldataset", ["fake_nodims"])
-def test_ColocatedData_num_coords_error(coldata: ColocatedData):
+def test_ColocatedData2D_num_coords_error(coldata: ColocatedData2D):
     with pytest.raises(DataDimensionError) as e:
         coldata.num_coords
     assert str(e.value).startswith("Need dimension")
@@ -199,7 +199,7 @@ def test_ColocatedData_num_coords_error(coldata: ColocatedData):
         ("fake_4d", 5),
     ],
 )
-def test_ColocatedData_num_coords_with_data(coldata: ColocatedData, num_coords_with_data: int):
+def test_ColocatedData2D_num_coords_with_data(coldata: ColocatedData2D, num_coords_with_data: int):
     assert coldata.num_coords_with_data == num_coords_with_data
 
 
@@ -210,7 +210,7 @@ def test_ColocatedData_num_coords_with_data(coldata: ColocatedData, num_coords_w
         ("fake_nodims", "Need dimension"),
     ],
 )
-def test_ColocatedData_num_coords_with_data_error(coldata: ColocatedData, error: str):
+def test_ColocatedData2D_num_coords_with_data_error(coldata: ColocatedData2D, error: str):
     with pytest.raises(DataDimensionError) as e:
         coldata.num_coords_with_data
     assert error in str(e.value)
@@ -223,7 +223,7 @@ def test_ColocatedData_num_coords_with_data_error(coldata: ColocatedData, error:
         ("fake_4d", 5),
     ],
 )
-def test_ColocatedData_get_coords_valid_obs(coldata: ColocatedData, num_coords: int):
+def test_ColocatedData2D_get_coords_valid_obs(coldata: ColocatedData2D, num_coords: int):
     coords_valid_obs = coldata.get_coords_valid_obs()
     assert isinstance(coords_valid_obs, list)
     assert len(coords_valid_obs) == 2
@@ -231,7 +231,7 @@ def test_ColocatedData_get_coords_valid_obs(coldata: ColocatedData, num_coords: 
 
 
 @pytest.mark.parametrize("coldataset", ["fake_nodims"])
-def test_ColocatedData_get_coords_valid_obs_error(coldata: ColocatedData):
+def test_ColocatedData2D_get_coords_valid_obs_error(coldata: ColocatedData2D):
     with pytest.raises(ValueError) as e:
         coldata.get_coords_valid_obs()
     assert str(e.value).startswith("'time' not found in array dimensions")
@@ -248,7 +248,9 @@ def test_ColocatedData_get_coords_valid_obs_error(coldata: ColocatedData):
         ("fake_4d", True, {"nmb": 0}),
     ],
 )
-def test_ColocatedData_calc_statistics(coldata: ColocatedData, use_area_weights: bool, chk: dict):
+def test_ColocatedData2D_calc_statistics(
+    coldata: ColocatedData2D, use_area_weights: bool, chk: dict
+):
     output = coldata.calc_statistics(use_area_weights=use_area_weights)
     assert isinstance(output, dict)
     for key, val in chk.items():
@@ -256,7 +258,7 @@ def test_ColocatedData_calc_statistics(coldata: ColocatedData, use_area_weights:
 
 
 @pytest.mark.parametrize("coldataset", ["fake_nodims"])
-def test_ColocatedData_calc_statistics_error(coldata: ColocatedData):
+def test_ColocatedData2D_calc_statistics_error(coldata: ColocatedData2D):
     with pytest.raises(DataDimensionError) as e:
         coldata.calc_statistics()
     assert str(e.value).startswith("Need dimension")
@@ -272,8 +274,8 @@ def test_ColocatedData_calc_statistics_error(coldata: ColocatedData):
         ("tm5_aeronet", "median", {"nmb": -0.0136, "R": 0.851}),
     ],
 )
-def test_ColocatedData_calc_temporal_statistics(
-    coldata: ColocatedData, aggr: str | None, statistics: dict[str, float]
+def test_ColocatedData2D_calc_temporal_statistics(
+    coldata: ColocatedData2D, aggr: str | None, statistics: dict[str, float]
 ):
     temporal_statistics = coldata.calc_temporal_statistics(aggr=aggr)
     assert isinstance(temporal_statistics, dict)
@@ -288,8 +290,8 @@ def test_ColocatedData_calc_temporal_statistics(
         ("tm5_aeronet", "max", ValueError, "So far only mean and median are supported"),
     ],
 )
-def test_ColocatedData_calc_temporal_statistics_error(
-    coldata: ColocatedData, aggr: str | None, exception: Type[Exception], error: str
+def test_ColocatedData2D_calc_temporal_statistics_error(
+    coldata: ColocatedData2D, aggr: str | None, exception: Type[Exception], error: str
 ):
     with pytest.raises(exception) as e:
         coldata.calc_temporal_statistics(aggr=aggr)
@@ -306,8 +308,8 @@ def test_ColocatedData_calc_temporal_statistics_error(
         ("tm5_aeronet", {"aggr": "median"}, {"nmb": -0.42, "R": 0.81}),
     ],
 )
-def test_ColocatedData_calc_spatial_statistics(
-    coldata: ColocatedData, args: dict, statistics: dict[str, float]
+def test_ColocatedData2D_calc_spatial_statistics(
+    coldata: ColocatedData2D, args: dict, statistics: dict[str, float]
 ):
     spatial_statistics = coldata.calc_spatial_statistics(**args)
     assert isinstance(spatial_statistics, dict)
@@ -322,8 +324,8 @@ def test_ColocatedData_calc_spatial_statistics(
         ("tm5_aeronet", "max", ValueError, "So far only mean and median are supported"),
     ],
 )
-def test_ColocatedData_calc_spatial_statistics_error(
-    coldata: ColocatedData, aggr: str | None, exception: Type[Exception], error: str
+def test_ColocatedData2D_calc_spatial_statistics_error(
+    coldata: ColocatedData2D, aggr: str | None, exception: Type[Exception], error: str
 ):
     with pytest.raises(exception) as e:
         coldata.calc_spatial_statistics(aggr=aggr)
@@ -333,7 +335,7 @@ def test_ColocatedData_calc_spatial_statistics_error(
 @pytest.mark.parametrize(
     "coldataset", ["fake_5d", "fake_nodims", "tm5_aeronet", "fake_3d", "fake_4d"]
 )
-def test_ColocatedData_plot_scatter(coldata: ColocatedData):
+def test_ColocatedData2D_plot_scatter(coldata: ColocatedData2D):
     plot = coldata.plot_scatter()
     assert isinstance(plot, Axes)
 
@@ -352,12 +354,12 @@ def test_meta_access_filename():
         "filter_name": f"{ALL_REGION_NAME}-noMOUNTAINS",
     }
 
-    _meta = ColocatedData.get_meta_from_filename(name)
+    _meta = ColocatedData2D.get_meta_from_filename(name)
     assert _meta == meta
 
 
 def test_read_colocated_data(coldata_tm5_aeronet):
-    loaded = ColocatedData(EXAMPLE_FILE)
+    loaded = ColocatedData2D(EXAMPLE_FILE)
     mean_loaded = np.nanmean(loaded.data)
     mean_fixture = np.nanmean(coldata_tm5_aeronet.data.data)
     assert mean_fixture == mean_loaded
@@ -417,8 +419,8 @@ def test_apply_latlon_filter_error(coldata_tm5_aeronet, region_id: str):
         ("tm5_aeronet", "Brazil", True, (-59.95, 66.25), (-132.55, 119.95), 1),
     ],
 )
-def test_ColocatedData_filter_region(
-    coldata: ColocatedData,
+def test_ColocatedData2D_filter_region(
+    coldata: ColocatedData2D,
     region_id: str,
     check_country_meta: bool,
     latrange: tuple[float, float],
@@ -439,7 +441,7 @@ def test_ColocatedData_filter_region(
 
 
 @pytest.mark.parametrize("coldataset", ["fake_4d"])
-def test_ColocatedData_filter_region_error(coldata: ColocatedData):
+def test_ColocatedData2D_filter_region_error(coldata: ColocatedData2D):
     with pytest.raises(DataDimensionError) as e:
         coldata.check_set_countries()
     assert str(e.value).startswith("Countries cannot be assigned")
@@ -466,7 +468,7 @@ def test_ColocatedData_filter_region_error(coldata: ColocatedData):
         ),
     ],
 )
-def test_ColocatedData_to_netcdf(coldata: ColocatedData, tmp_path: Path, filename: str):
+def test_ColocatedData2D_to_netcdf(coldata: ColocatedData2D, tmp_path: Path, filename: str):
     path = tmp_path / filename
     assert not path.exists()
     file = coldata.to_netcdf(tmp_path)
@@ -475,11 +477,11 @@ def test_ColocatedData_to_netcdf(coldata: ColocatedData, tmp_path: Path, filenam
 
 
 @pytest.mark.parametrize("coldataset", ["tm5_aeronet", "fake_3d_hr", "fake_3d"])
-def test_ColocatedData_read_netcdf(coldata: ColocatedData, tmp_path: Path):
+def test_ColocatedData2D_read_netcdf(coldata: ColocatedData2D, tmp_path: Path):
     file = coldata.to_netcdf(tmp_path)
     assert Path(file).exists()
-    cd = ColocatedData().read_netcdf(file)
-    assert isinstance(cd, ColocatedData)
+    cd = ColocatedData2D().read_netcdf(file)
+    assert isinstance(cd, ColocatedData2D)
 
 
 @pytest.mark.parametrize(
@@ -491,7 +493,7 @@ def test_ColocatedData_read_netcdf(coldata: ColocatedData, tmp_path: Path):
         ("tm5_aeronet", dict(to_ts_type="yearly", colocate_time=True), 0.363),
     ],
 )
-def test_ColocatedData_resample_time(coldata: ColocatedData, args: dict, mean):
+def test_ColocatedData2D_resample_time(coldata: ColocatedData2D, args: dict, mean):
     resampled = coldata.resample_time(**args)
     assert (resampled is coldata) == args.get("inplace", False)
 

--- a/tests/test_colocation.py
+++ b/tests/test_colocation.py
@@ -5,7 +5,7 @@ import pytest
 from cf_units import Unit
 
 from pyaerocom import GriddedData, const, helpers
-from pyaerocom.colocateddata import ColocatedData
+from pyaerocom.colocateddata2d import ColocatedData2D
 from pyaerocom.colocation import (
     _colocate_site_data_helper,
     _colocate_site_data_helper_timecol,
@@ -198,7 +198,7 @@ def test_colocate_gridded_ungridded(
 
     coldata = colocate_gridded_ungridded(data_tm5, aeronetsunv3lev2_subset, **addargs)
 
-    assert isinstance(coldata, ColocatedData)
+    assert isinstance(coldata, ColocatedData2D)
     assert coldata.ts_type == ts_type
     assert coldata.shape == shape
 
@@ -224,7 +224,7 @@ def test_colocate_gridded_ungridded_nonglobal(aeronetsunv3lev2_subset):
     gridded.units = Unit("1")
 
     coldata = colocate_gridded_ungridded(gridded, aeronetsunv3lev2_subset, colocate_time=False)
-    assert isinstance(coldata, ColocatedData)
+    assert isinstance(coldata, ColocatedData2D)
     assert coldata.shape == (2, 2, 2)
 
 
@@ -239,7 +239,7 @@ def test_colocate_gridded_gridded_same_new_var(data_tm5):
 def test_colocate_gridded_gridded_same(data_tm5):
     coldata = colocate_gridded_gridded(data_tm5, data_tm5)
 
-    assert isinstance(coldata, ColocatedData)
+    assert isinstance(coldata, ColocatedData2D)
     stats = coldata.calc_statistics()
     # check mean value
     assert stats["data_mean"] == pytest.approx(0.09825691)
@@ -262,4 +262,4 @@ def test_read_emep_colocate_emep_tm5(data_tm5, path_emep):
     data_emep.units = "1"
 
     col = colocate_gridded_gridded(data_emep, data_tm5)
-    assert isinstance(col, ColocatedData)
+    assert isinstance(col, ColocatedData2D)

--- a/tests/test_colocation_auto.py
+++ b/tests/test_colocation_auto.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from pyaerocom import ColocatedData, GriddedData, UngriddedData, const
+from pyaerocom import ColocatedData2D, GriddedData, UngriddedData, const
 from pyaerocom.colocation_auto import ColocationSetup, Colocator
 from pyaerocom.config import ALL_REGION_NAME
 from pyaerocom.exceptions import ColocationError, ColocationSetupError
@@ -227,7 +227,7 @@ def test_Colocator_run_gridded_gridded(tm5_aero_stp):
     col.run()
     var = col.obs_vars[0]
     coldata = col.data[var][var]
-    assert isinstance(coldata, ColocatedData)
+    assert isinstance(coldata, ColocatedData2D)
     assert coldata.ndim == 4
 
 
@@ -418,7 +418,7 @@ def test_colocator_with_obs_data_dir_ungridded():
     data = col.run()
     assert len(data) == 1
     cd = data["od550aer"]["od550aer"]
-    assert isinstance(cd, ColocatedData)
+    assert isinstance(cd, ColocatedData2D)
     assert cd.ts_type == "monthly"
     assert str(cd.start) == "2010-01-15T00:00:00.000000000"
     assert str(cd.stop) == "2010-12-15T00:00:00.000000000"
@@ -436,7 +436,7 @@ def test_colocator_with_model_data_dir_ungridded():
     data = col.run()
     assert len(data) == 1
     cd = data["od550aer"]["od550aer"]
-    assert isinstance(cd, ColocatedData)
+    assert isinstance(cd, ColocatedData2D)
     assert cd.ts_type == "monthly"
     assert str(cd.start) == "2010-01-15T00:00:00.000000000"
     assert str(cd.stop) == "2010-12-15T00:00:00.000000000"
@@ -455,7 +455,7 @@ def test_colocator_with_obs_data_dir_gridded():
     data = col.run()
     assert len(data) == 1
     cd = data["od550aer"]["od550aer"]
-    assert isinstance(cd, ColocatedData)
+    assert isinstance(cd, ColocatedData2D)
     assert cd.ts_type == "monthly"
     assert str(cd.start) == "2010-01-15T12:00:00.000000000"
     assert str(cd.stop) == "2010-12-15T12:00:00.000000000"


### PR DESCRIPTION
This is a (mostly failed) attempt at splitting up `ColocatedData` for the eventual inclusion of 3D spatial fields and 4D spatio-temporal fields. Hence **this is not a real draft PR**, but mostly keeping this here for posterity until we decide how to proceed. 

The goal was to make `ColocatedData` a parent class and then create derived classes `ColocatedData2D` and `ColocatedData3D`. Trying to put everything agnostic to the number of spatial dimensions into the parent class `ColocatedData` left very little in `ColcatedData2D` (about 350 lines of code).  

Daniel and I realized that this is not a trivial task, and discussed what we would want out of "an ideal colocated data class". We for the time being agreed that it would be ideal to only have colocation done on the tuple (lon, lat, alt, time), instead "dimensions" such as the station name. This is geared towards accounting for the vertical profile data and is basically the point-cloud idea Jan has brought up before. We want to discuss this in our next meeting, because creating and entirely new colocated data class is a huge overhaul. 