### PR TITLE
Matplotlib 3.6.0

### DIFF
--- a/pyaerocom/plot/plotscatter.py
+++ b/pyaerocom/plot/plotscatter.py
@@ -164,11 +164,15 @@ def plot_scatter_aerocom(
         xlim[0] = low
         ylim[0] = low
     with ignore_warnings(
-        UserWarning, "Attempted to set non-positive left xlim on a log-scaled axis"
+        UserWarning,
+        "Attempted to set non-positive left xlim on a log-scaled axis",
+        "Attempt to set non-positive xlim on a log-scaled axis will be ignored.",
     ):
         ax.set_xlim(xlim)
     with ignore_warnings(
-        UserWarning, "Attempted to set non-positive bottom ylim on a log-scaled axis"
+        UserWarning,
+        "Attempted to set non-positive bottom ylim on a log-scaled axis",
+        "Attempt to set non-positive ylim on a log-scaled axis will be ignored.",
     ):
         ax.set_ylim(ylim)
     xlbl = f"{x_name}"

--- a/pyaerocom/trends_engine.py
+++ b/pyaerocom/trends_engine.py
@@ -1,6 +1,6 @@
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.cm import get_cmap
 from matplotlib.colors import Normalize
 from scipy.stats import kendalltau
 from scipy.stats.mstats import theilslopes
@@ -18,7 +18,7 @@ from pyaerocom.trends_helpers import (
 class TrendsEngine:
     """Trend computation engine (does not need to be instantiated)"""
 
-    CMAP = get_cmap("bwr")
+    CMAP = matplotlib.colormaps["bwr"]
     NORM = Normalize(-10, 10)
 
     @staticmethod

--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -1109,7 +1109,7 @@ class UngriddedData:
             altitude = subset[:, self._DATAHEIGHTINDEX]
 
             data = pd.Series(vals, dtime)
-            if not data.index.is_monotonic:
+            if not data.index.is_monotonic_increasing:
                 data = data.sort_index()
             if any(~np.isnan(vals_err)):
                 sd.data_err[var] = vals_err

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ filterwarnings = [
     "error",
     "ignore::pytest.PytestUnraisableExceptionWarning",
     # except deprecation and future warnings ouside this packege
+    'ignore::PendingDeprecationWarning:^(?!pyaerocom|tests).*:',
     'ignore::DeprecationWarning:^(?!pyaerocom|tests).*:',
     'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
     # and not on this list

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     'importlib-metadata>=3.6; python_version < "3.10"',
     'tomli>=2.0.1; python_version < "3.11"',
     "xarray>=0.16.0",
-    "matplotlib>=3.0.1",
     "scipy>=1.1.0",
     "pandas>=0.23.0",
     "seaborn>=0.8.0",
@@ -55,10 +54,12 @@ Documentation = "https://pyaerocom.readthedocs.io"
 [project.optional-dependencies]
 proj-legacy = [
     # proj<8, e.g CI
-    "cartopy>=0.16.0,!=0.20.*",
-    "scitools-iris>=3.1.0,!=3.2.*",
+    "cartopy>=0.16.0,<0.20",
+    "scitools-iris>=3.1.0,<3.2",
+    # cartopy 0.19 incompatible with matplotlib 3.6
+    "matplotlib>=3.0.1,<3.6",
 ]
-proj8 = ["cartopy>=0.20", "scitools-iris>=3.2"]
+proj8 = ["cartopy>=0.20", "scitools-iris>=3.2", "matplotlib>=3.6.0"]
 docs = [
     "sphinx>=4.2.0",
     "sphinxcontrib-napoleon",


### PR DESCRIPTION
matplotlib 3.6 introduces a number of deprecation warnings and changes some of its internal methods that were used by cartopy 0.19 (used on CI and Ubuntu Bionic machines).