### PR TITLE
let Python 3.11 tests crash on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,6 +78,7 @@ jobs:
       run: sudo apt install libhdf5-mpich-dev libnetcdf-dev
     - name: Cache pip and tox
       uses: actions/cache@v3
+      if: ${{ ! startsWith(matrix.python-version, '3.11') }}
       with:
         path: |
           ~/.cache/pip

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -82,6 +82,7 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install tox
     - name: Run test
+      continue-on-error: ${{ startsWith(matrix.python-version, '3.11') }}
       run: tox -e py
 
   conda:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+  - cron:  '0 12 1 * *'  # 12:00, first day of the month
 
 jobs:
   lint:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,9 +12,9 @@ jobs:
     env:
       PYTHON: 3.8
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ env.PYTHON }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ env.PYTHON }}
     - name: Python info
@@ -37,9 +37,9 @@ jobs:
     env:
       PYTHON: 3.8
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ env.PYTHON }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ env.PYTHON }}
     - name: Python info
@@ -62,9 +62,9 @@ jobs:
       matrix:
         python-version: [3.8, 3.9, '3.10', '3.11']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Python info
@@ -103,7 +103,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: conda-incubator/setup-miniconda@v2
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -73,9 +73,6 @@ jobs:
         python --version
     - name: Install system pacakges
       run: sudo apt install libudunits2-dev libgeos-dev libproj-dev proj-data proj-bin
-    - name: Install netCDF dependencies
-      if: ${{ startsWith(matrix.python-version, '3.11') }}
-      run: sudo apt install libhdf5-mpich-dev libnetcdf-dev
     - name: Cache pip and tox
       uses: actions/cache@v3
       if: ${{ ! startsWith(matrix.python-version, '3.11') }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -69,6 +69,9 @@ jobs:
         python --version
     - name: Install system pacakges
       run: sudo apt install libudunits2-dev libgeos-dev libproj-dev proj-data proj-bin
+    - name: Install netCDF dependencies
+      if: ${{ startsWith(matrix.python-version, '3.11') }}
+      run: sudo apt install libhdf5-mpich-dev libnetcdf-dev
     - name: Cache pip and tox
       uses: actions/cache@v3
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,9 +8,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.x"
       - name: Install pypa/build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,7 +190,7 @@ max-line-length = 99
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py38, py39, py310, format, lint, docs
+envlist = py38, py39, py310, py311, format, lint, docs
 skip_missing_interpreters = True
 isolated_build = True
 requires =


### PR DESCRIPTION
- builds netCDF4 package on CI, as there is no wheel for Python 3.11
- fails to build cartopy on CI
- CI won't fail if/when tests for Python 3.11 fail