### PR TITLE
obs_only_stats flag in config

### DIFF
--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -16,6 +16,7 @@ from pyaerocom._lowlevel_helpers import (
 from pyaerocom.aeroval.glob_defaults import (
     extended_statistics,
     statistics_defaults,
+    statistics_obs_only,
     statistics_trend,
     var_ranges_defaults,
     var_web_info,
@@ -572,8 +573,11 @@ class ExperimentOutput(ProjectOutput):
         write_json(ranges, self.var_ranges_file, indent=4)
 
     def _create_statistics_json(self):
-        stats_info = statistics_defaults
-        stats_info.update(extended_statistics)
+        if self.cfg.statistics_opts.obs_only_stats:
+            stats_info = statistics_obs_only
+        else:
+            stats_info = statistics_defaults
+            stats_info.update(extended_statistics)
         if self.cfg.statistics_opts.add_trends:
             if self.cfg.processing_opts.obs_only:
                 obs_statistics_trend = {

--- a/pyaerocom/aeroval/glob_defaults.py
+++ b/pyaerocom/aeroval/glob_defaults.py
@@ -185,6 +185,17 @@ statistics_trend = {
         "decimals": 1,
     },
 }
+# If doing an obs_only experiement, the only statistics which make sense relate just to the observations
+statistics_obs_only = {
+    "refdata_mean": {
+        "name": "Mean-Obs",
+        "longname": "Observation Mean",
+        "scale": None,
+        "colmap": "coolwarm",
+        "unit": "1",
+        "decimals": 2,
+    },
+}
 
 #: Mapping of pyaerocom variable names to web naming conventions
 var_web_info = dict(

--- a/pyaerocom/aeroval/setupclasses.py
+++ b/pyaerocom/aeroval/setupclasses.py
@@ -154,6 +154,7 @@ class StatisticsSetup(ConstrainedContainer):
         self.stats_tseries_base_freq = None
         self.use_fairmode = False
         self.use_diurnal = False
+        self.obs_only_stats = False
         self.update(**kwargs)
 
 


### PR DESCRIPTION
In obs-only experiments, the statistics which make sense only related to the observations (i.e., refdata), and we only want to display these on the web. To avoid having to manually edit `statistics.json` each time remove the meaningless statisics, this proposes adding a flag, `obs_only_stats`, which can be set in the config if the Obs-Mean stats are the only things wanted from an obs-only run.