### PR TITLE
conda-forge compatibility

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -116,8 +116,10 @@ jobs:
     - name: Install pyaerocom
       run: python -m pip install . --no-deps
     - name: Run pytest
+      continue-on-error: ${{ startsWith(matrix.python-version, '3.11') }}
       run: pytest --cov=pyaerocom/ --cov-report xml
     - name: Upload coverage to Codecov
+      if: ${{ ! startsWith(matrix.python-version, '3.11') }}
       uses: codecov/codecov-action@v2
       with:
           file: ./coverage.xml

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,7 +95,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, '3.10']
+        python-version: [3.8, 3.9, '3.10', '3.11']
     defaults:
       run:
         shell: bash -l {0}

--- a/pyaerocom/_logging.py
+++ b/pyaerocom/_logging.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 
 import logging
 import os
-from importlib import resources
 from logging.config import fileConfig
+
+from pyaerocom.data import resources
 
 LOGGING_CONFIG = dict(
     # root logger

--- a/pyaerocom/config.py
+++ b/pyaerocom/config.py
@@ -2,7 +2,6 @@ import getpass
 import logging
 import os
 from configparser import ConfigParser
-from importlib import resources
 from pathlib import Path
 
 import numpy as np
@@ -14,6 +13,7 @@ from pyaerocom._lowlevel_helpers import (
     chk_make_subdir,
     list_to_shortstr,
 )
+from pyaerocom.data import resources
 from pyaerocom.exceptions import DataIdError, DataSourceError
 from pyaerocom.grid_io import GridIO
 from pyaerocom.region_defs import ALL_REGION_NAME, HTAP_REGIONS, OLD_AEROCOM_REGIONS

--- a/pyaerocom/data/resources.py
+++ b/pyaerocom/data/resources.py
@@ -1,0 +1,41 @@
+"""
+Compatibility layer between importlib.resources for Python 3.11 and older versions
+"""
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import ContextManager
+
+if sys.version_info >= (3, 11):
+    from importlib import resources
+else:
+    import importlib_resources as resources
+
+
+def path(package: str, resource: str) -> ContextManager[Path]:
+    """A context manager providing a file path object to the resource.
+    If the resource does not already exist on its own on the file system,
+    a temporary file will be created. If the file was created, the file
+    will be deleted upon exiting the context manager (no exception is
+    raised if the file was deleted prior to the context manager
+    exiting).
+    """
+    return resources.as_file(resources.files(package) / resource)
+
+
+def is_resource(package: str, name: str) -> bool:
+    """True if `name` is a resource inside `package`.
+
+    Directories are *not* resources.
+    """
+    with path(package, name) as p:
+        return p.exists()
+
+
+def read_text(package: str, resource: str, encoding: str = "utf-8", errors: str = "strict") -> str:
+    """Return the decoded string of the resource.
+
+    The decoding-related arguments have the same semantics as those of `pathlib.Path.read_text`.
+    """
+    with path(package, resource) as p:
+        return p.read_text(encoding, errors)

--- a/pyaerocom/io/ebas_varinfo.py
+++ b/pyaerocom/io/ebas_varinfo.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from configparser import ConfigParser
-from importlib import resources
 
 from pyaerocom import const
 from pyaerocom._lowlevel_helpers import BrowseDict
+from pyaerocom.data import resources
 from pyaerocom.exceptions import VarNotAvailableError
 from pyaerocom.io import EbasSQLRequest
 

--- a/pyaerocom/io/fileconventions.py
+++ b/pyaerocom/io/fileconventions.py
@@ -1,8 +1,8 @@
 from configparser import ConfigParser
-from importlib import resources
 from os.path import basename, splitext
 
 from pyaerocom import const
+from pyaerocom.data import resources
 from pyaerocom.exceptions import FileConventionError
 from pyaerocom.tstype import TsType
 

--- a/pyaerocom/io/helpers.py
+++ b/pyaerocom/io/helpers.py
@@ -7,13 +7,13 @@ import logging
 import os
 import shutil
 from datetime import datetime
-from importlib import resources
 from pathlib import Path
 from time import time
 
 import simplejson as json
 
 from pyaerocom import const
+from pyaerocom.data import resources
 from pyaerocom.exceptions import VariableDefinitionError, VarNotAvailableError
 from pyaerocom.io import AerocomBrowser
 

--- a/pyaerocom/metastandards.py
+++ b/pyaerocom/metastandards.py
@@ -1,10 +1,10 @@
 import logging
 from configparser import ConfigParser
-from importlib import resources
 
 import numpy as np
 
 from pyaerocom._lowlevel_helpers import BrowseDict
+from pyaerocom.data import resources
 
 logger = logging.getLogger(__name__)
 

--- a/pyaerocom/plugins/ghost/meta_keys.py
+++ b/pyaerocom/plugins/ghost/meta_keys.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import sys
-from importlib import resources
+
+from pyaerocom.data import resources
 
 if sys.version_info >= (3, 11):  # pragma: no cover
     import tomllib

--- a/pyaerocom/plugins/mscw_ctm/model_variables.py
+++ b/pyaerocom/plugins/mscw_ctm/model_variables.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import sys
-from importlib import resources
+
+from pyaerocom.data import resources
 
 if sys.version_info >= (3, 11):  # pragma: no cover
     import tomllib

--- a/pyaerocom/variable_helpers.py
+++ b/pyaerocom/variable_helpers.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from configparser import ConfigParser
-from importlib import resources
 from pathlib import Path
 
+from pyaerocom.data import resources
 from pyaerocom.exceptions import VariableDefinitionError
 
 

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -22,8 +22,9 @@ dependencies:
   - typer >=0.4.0
 ## python < 3.10
   - importlib-metadata >=3.6
-## python 3.11
+## python < 3.11
   - tomli >=2.0.1
+  - importlib-resources >=5.10
 ## testing
   - pytest >=6.0
   - pytest-dependency

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - iris >=3.2.0
-  - xarray >=0.16.0
+  - xarray >=0.16.0,!=2022.11.0
   - cartopy >=0.20.0
   - matplotlib-base >=3.0.1
   - scipy >=1.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,14 +22,15 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     'importlib-metadata>=3.6; python_version < "3.10"',
+    'importlib-resources>=5.10; python_version < "3.11"',
     'tomli>=2.0.1; python_version < "3.11"',
     "xarray>=0.16.0,!=2022.11.0",
     "scipy>=1.1.0",
     "pandas>=0.23.0",
     "seaborn>=0.8.0",
     "geonum",
-    "LatLon23",                                          # required by geonum
-    "SRTM.py",                                           # required by geonum
+    "LatLon23",                                           # required by geonum
+    "SRTM.py",                                            # required by geonum
     "numpy>=0.12.0",
     "simplejson",
     "requests",
@@ -37,7 +38,7 @@ dependencies = [
     "tqdm",
     "openpyxl",
     "geojsoncontour",
-    'cf-units!=3.0.1.post0; python_version == "3.10.*"', # https://github.com/SciTools/cf-units/issues/218
+    'cf-units!=3.0.1.post0; python_version == "3.10.*"',  # https://github.com/SciTools/cf-units/issues/218
     "typer>=0.4.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     'importlib-metadata>=3.6; python_version < "3.10"',
     'importlib-resources>=5.10; python_version < "3.11"',
     'tomli>=2.0.1; python_version < "3.11"',
-    "xarray>=0.16.0,!=2022.11.0",
+    "xarray>=0.16.0",
     "scipy>=1.1.0",
     "pandas>=0.23.0",
     "seaborn>=0.8.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ requires-python = ">=3.8"
 dependencies = [
     'importlib-metadata>=3.6; python_version < "3.10"',
     'tomli>=2.0.1; python_version < "3.11"',
-    "xarray>=0.16.0",
+    "xarray>=0.16.0,!=2022.11.0",
     "scipy>=1.1.0",
     "pandas>=0.23.0",
     "seaborn>=0.8.0",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import getpass
 import tempfile
-from importlib import resources
 from pathlib import Path
 from typing import Type
 
@@ -11,6 +10,7 @@ import pytest
 import pyaerocom.config as testmod
 from pyaerocom import const
 from pyaerocom.config import ALL_REGION_NAME, Config
+from pyaerocom.data import resources
 from pyaerocom.grid_io import GridIO
 from pyaerocom.varcollection import VarCollection
 from tests.conftest import lustre_avail

--- a/tests/test_varcollection.py
+++ b/tests/test_varcollection.py
@@ -1,8 +1,7 @@
-from importlib import resources
-
 import pytest
 
 from pyaerocom import const
+from pyaerocom.data import resources
 from pyaerocom.exceptions import VariableDefinitionError
 from pyaerocom.varcollection import VarCollection
 from pyaerocom.variable import Variable


### PR DESCRIPTION
- [X] exclude xarray 2022.11.0 from dependencies
seems that xarray 2022.11.0 crashes tests for the conda-forge package creation https://github.com/metno/pyaerocom/discussions/782#discussioncomment-4076584
- [x] address deprecation warnings from `importlib.resources` on Python 3.11 https://github.com/metno/pyaerocom/discussions/782#discussioncomment-4077214
- [x] add Python 3.11 conda env, let test fail without failing CI