### PR TITLE
run CI for Python 3.11 on Ubuntu 22.04

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,15 +56,17 @@ jobs:
       run: tox -e docs
 
   venv:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9, '3.10']
         experimental: [false]
+        os: [ubuntu-latest]
         include:
           - python-version: '3.11'
             experimental: true        
+            os: 'ubuntu-22.04'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,8 @@ extras =
     py{,38,38,39,10}: proj-legacy
     py311: proj8
     test
+setenv =
+    UDUNITS2_XML_PATH=/usr/share/xml/udunits/udunits2-common.xml
 
 [testenv:format]
 commands =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,8 @@ commands_pre =
 commands =
     pytest -ra -q {posargs:--cov}
 extras = 
-    proj-legacy
+    py{,38,38,39,10}: proj-legacy
+    py311: proj8
     test
 
 [testenv:format]


### PR DESCRIPTION
There is no Cartopy wheel for Python 3.11. Creating the wheel requires Proj8, which is only available on Ubuntu 22.04.