### PR TITLE
pin shapely version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,8 @@ proj-legacy = [
     "scitools-iris>=3.1.0,<3.2",
     # cartopy 0.19 incompatible with matplotlib 3.6
     "matplotlib>=3.0.1,<3.6",
+    # cartopy 0.19 incompatible with matplotlib 2.0
+    "shapely<2.0.0",
 ]
 proj8 = ["cartopy>=0.20", "scitools-iris>=3.2", "matplotlib>=3.6.0"]
 docs = [


### PR DESCRIPTION
CI is failing with the following error:
```
ImportError: cannot import name lgeos
```

As far as I can tell the error message comes from SciTools/cartopy#2076, and the solution is to add a requirement for `shapely<2`.