### PR TITLE
Only set data dummy to mean if defined

### DIFF
--- a/pyaerocom/_lowlevel_helpers.py
+++ b/pyaerocom/_lowlevel_helpers.py
@@ -62,7 +62,7 @@ def read_json(file_path):
         content as dictionary
     """
     with open(file_path) as f:
-        data = simplejson.load(f)
+        data = simplejson.load(f, allow_nan=True)
     return data
 
 
@@ -80,7 +80,7 @@ def write_json(data_dict, file_path, **kwargs):
         indent, )
     """
     with open(file_path, "w") as f:
-        simplejson.dump(round_floats(data_dict), f, **kwargs)
+        simplejson.dump(round_floats(data_dict), f, allow_nan=True, **kwargs)
 
 
 def check_make_json(fp, indent=4):

--- a/pyaerocom/aeroval/helpers.py
+++ b/pyaerocom/aeroval/helpers.py
@@ -180,9 +180,10 @@ def make_dummy_model(obs_list: list, cfg) -> str:
 
             # Set the value to be the mean of acceptable values to prevent incorrect outlier removal
             # This needs some care though because the defaults are (currently) -inf and inf, which leads to erroneous removal
+            breakpoint()
             if not (
-                dummy_grid.var_info.minimum == Variable.VMIN_DEFAULT
-                or dummy_grid.var_info.maximum == Variable.VMAX_DEFAULT
+                dummy_grid.var_info.minimum == Variable().VMIN_DEFAULT
+                or dummy_grid.var_info.maximum == Variable().VMAX_DEFAULT
             ):
                 dummy_grid.data *= (dummy_grid.var_info.minimum + dummy_grid.var_info.maximum) / 2
 

--- a/pyaerocom/aeroval/helpers.py
+++ b/pyaerocom/aeroval/helpers.py
@@ -4,6 +4,8 @@ import os
 import shutil
 from pathlib import Path
 
+import numpy as np
+
 from pyaerocom import const
 from pyaerocom.aeroval.modelentry import ModelEntry
 from pyaerocom.aeroval.varinfo_web import VarinfoWeb
@@ -19,6 +21,7 @@ from pyaerocom.helpers import (
 )
 from pyaerocom.io import ReadGridded
 from pyaerocom.tstype import TsType
+from pyaerocom.variable import Variable
 
 logger = logging.getLogger(__name__)
 
@@ -176,7 +179,12 @@ def make_dummy_model(obs_list: list, cfg) -> str:
             dummy_grid = GriddedData(dummy_cube)
 
             # Set the value to be the mean of acceptable values to prevent incorrect outlier removal
-            dummy_grid.data *= (dummy_grid.var_info.minimum + dummy_grid.var_info.maximum) / 2
+            # This needs some care though because the defaults are (currently) -inf and inf, which leads to erroneous removal
+            if not (
+                dummy_grid.var_info.minimum == Variable.VMIN_DEFAULT
+                or dummy_grid.var_info.maximum == Variable.VMAX_DEFAULT
+            ):
+                dummy_grid.data *= (dummy_grid.var_info.minimum + dummy_grid.var_info.maximum) / 2
 
             # Loop over each year
             yr_gen = dummy_grid.split_years()

--- a/pyaerocom/aeroval/helpers.py
+++ b/pyaerocom/aeroval/helpers.py
@@ -168,6 +168,7 @@ def make_dummy_model(obs_list: list, cfg) -> str:
     (start, stop) = get_max_period_range(cfg.time_cfg.periods)
     freq = get_highest_resolution(*cfg.time_cfg.freqs)
 
+    tmp_var_obj = Variable()
     # Loops over variables in obs
     for obs in obs_list:
         for var in cfg.obs_cfg[obs]["obs_vars"]:
@@ -180,10 +181,10 @@ def make_dummy_model(obs_list: list, cfg) -> str:
 
             # Set the value to be the mean of acceptable values to prevent incorrect outlier removal
             # This needs some care though because the defaults are (currently) -inf and inf, which leads to erroneous removal
-            breakpoint()
+
             if not (
-                dummy_grid.var_info.minimum == Variable().VMIN_DEFAULT
-                or dummy_grid.var_info.maximum == Variable().VMAX_DEFAULT
+                dummy_grid.var_info.minimum == tmp_var_obj.VMIN_DEFAULT
+                or dummy_grid.var_info.maximum == tmp_var_obj.VMAX_DEFAULT
             ):
                 dummy_grid.data *= (dummy_grid.var_info.minimum + dummy_grid.var_info.maximum) / 2
 

--- a/pyaerocom/scripts/testdata-minimal/create_subset_ebas.py
+++ b/pyaerocom/scripts/testdata-minimal/create_subset_ebas.py
@@ -75,7 +75,7 @@ def check_outdated(filedir):
 
     with open(JSON_FILE, "r") as f:
 
-        data = simplejson.load(f)
+        data = simplejson.load(f, allow_nan=True)
 
     for var, stats in data.items():
         for stat, files in stats.items():
@@ -213,7 +213,7 @@ def main():
         infofile = JSON_FILE
         if os.path.exists(infofile):
             with open(infofile, "r") as f:
-                current_files = simplejson.load(f)
+                current_files = simplejson.load(f, allow_nan=True)
         else:
             current_files = {}
 
@@ -281,7 +281,7 @@ def main():
 
             print(f"re-writing {JSON_FILE}")
             with open(JSON_FILE, "w") as f:
-                simplejson.dump(all_files, f)
+                simplejson.dump(all_files, f, allow_nan=True)
 
 
 if __name__ == "__main__":

--- a/tests/fixtures/ebas.py
+++ b/tests/fixtures/ebas.py
@@ -15,7 +15,7 @@ from .data_access import DataForTests
 EBAS_FILEDIR = DataForTests("obsdata/EBASMultiColumn/data").path
 ebas_info_file = DataForTests("scripts/ebas_files.json").path
 assert ebas_info_file.exists()
-EBAS_FILES = simplejson.loads(ebas_info_file.read_text())
+EBAS_FILES = simplejson.loads(ebas_info_file.read_text(), allow_nan=True)
 for sites in EBAS_FILES.values():
     for files in sites.values():
         for file in files:

--- a/tests/fixtures/ebas.py
+++ b/tests/fixtures/ebas.py
@@ -15,7 +15,7 @@ from .data_access import DataForTests
 EBAS_FILEDIR = DataForTests("obsdata/EBASMultiColumn/data").path
 ebas_info_file = DataForTests("scripts/ebas_files.json").path
 assert ebas_info_file.exists()
-EBAS_FILES = simplejson.loads(ebas_info_file.read_text(), allow_nan=True)
+EBAS_FILES = simplejson.loads(ebas_info_file.read_text())
 for sites in EBAS_FILES.values():
     for files in sites.values():
         for file in files:


### PR DESCRIPTION
Bug fix from #827. If the min and max aren't defined in variables.ini, then the are set tho to `VMIN_DEFAULT` and `VMAX_DEFAULT` in the `Variable` class, which are currently `-inf` and `inf`. Hence, the mean is not defined, the dummy data all set to `NaN`, and erroneously filtered out.