### PR TITLE
fix test for 3.11

### DIFF
--- a/tests/io/test_ebas_nasa_ames.py
+++ b/tests/io/test_ebas_nasa_ames.py
@@ -80,7 +80,7 @@ def test_EbasNasaAmesFile_head_fix(filedata):
 def test_EbasNasaAmesFile_head_fix_error(filedata):
     with pytest.raises(AttributeError) as e:
         filedata.head_fix = "Blaaaaaaaaaaaaaaa"
-    assert str(e.value).startswith("can't set attribute")
+    assert str(e.value).startswith("can't set attribute") or "object has no setter" in str(e.value)
 
 
 def test_EbasNasaAmesFile_data(filedata):


### PR DESCRIPTION
this is to account for new error message in python 3.11 when attribute cannot be set 