### PR TITLE
Manually load data in AirNow reader to avoid pandas error

### DIFF
--- a/pyaerocom/io/read_airnow.py
+++ b/pyaerocom/io/read_airnow.py
@@ -26,7 +26,7 @@ class ReadAirNow(ReadUngriddedBase):
     _FILEMASK = f"/**/*{_FILETYPE}"
 
     #: Version log of this class (for caching)
-    __version__ = "0.07"
+    __version__ = "0.08"
 
     #: Column delimiter
     FILE_COL_DELIM = "|"
@@ -285,10 +285,13 @@ class ReadAirNow(ReadUngriddedBase):
                 file,
                 sep=self.FILE_COL_DELIM,
                 names=self.FILE_COL_NAMES,
-                # encoding="unicode_escape",
-                on_bad_lines="skip",
+                encoding="cp863",
+                # on_bad_lines="skip",
             )
         except:
+            breakpoint()
+            with open(file) as f:
+                data = f.read()
             breakpoint()
         return df
 
@@ -336,9 +339,7 @@ class ReadAirNow(ReadUngriddedBase):
                 vardata = arr[mask]
                 arrs.append(vardata)
         if len(arrs) == 0:
-            raise DataRetrievalError(
-                "None of the input variables could be found in input list"
-            )
+            raise DataRetrievalError("None of the input variables could be found in input list")
         return self._filedata_to_statlist(arrs, vars_to_retrieve)
 
     def _filedata_to_statlist(self, arrs, vars_to_retrieve):
@@ -378,7 +379,6 @@ class ReadAirNow(ReadUngriddedBase):
             mask = data[:, varcol] == var_in_file
             subset = data[mask]
             dtime_subset = dtime[mask]
-            breakpoint()
             statlist = np.unique(subset[:, statcol])
             for stat_id in tqdm(statlist, desc=var):
                 if not stat_id in stat_ids:
@@ -415,9 +415,7 @@ class ReadAirNow(ReadUngriddedBase):
         ------
         NotImplementedError
         """
-        raise NotImplementedError(
-            "Not needed for these data since the format is unsuitable..."
-        )
+        raise NotImplementedError("Not needed for these data since the format is unsuitable...")
 
     def read(self, vars_to_retrieve=None, first_file=None, last_file=None):
         """

--- a/pyaerocom/io/read_airnow.py
+++ b/pyaerocom/io/read_airnow.py
@@ -280,7 +280,16 @@ class ReadAirNow(ReadUngriddedBase):
             DataFrame containing the file data
 
         """
-        df = pd.read_csv(file, sep=self.FILE_COL_DELIM, names=self.FILE_COL_NAMES)
+        try:
+            df = pd.read_csv(
+                file,
+                sep=self.FILE_COL_DELIM,
+                names=self.FILE_COL_NAMES,
+                # encoding="unicode_escape",
+                on_bad_lines="skip",
+            )
+        except:
+            breakpoint()
         return df
 
     def _read_files(self, files, vars_to_retrieve):
@@ -327,7 +336,9 @@ class ReadAirNow(ReadUngriddedBase):
                 vardata = arr[mask]
                 arrs.append(vardata)
         if len(arrs) == 0:
-            raise DataRetrievalError("None of the input variables could be found in input list")
+            raise DataRetrievalError(
+                "None of the input variables could be found in input list"
+            )
         return self._filedata_to_statlist(arrs, vars_to_retrieve)
 
     def _filedata_to_statlist(self, arrs, vars_to_retrieve):
@@ -362,12 +373,12 @@ class ReadAirNow(ReadUngriddedBase):
         dtime = self.make_datetime64_array(data[:, 0], data[:, 1])
         stats = []
         for var in vars_to_retrieve:
-
             # extract only variable data (should speed things up)
             var_in_file = self.VAR_MAP[var]
             mask = data[:, varcol] == var_in_file
             subset = data[mask]
             dtime_subset = dtime[mask]
+            breakpoint()
             statlist = np.unique(subset[:, statcol])
             for stat_id in tqdm(statlist, desc=var):
                 if not stat_id in stat_ids:
@@ -404,7 +415,9 @@ class ReadAirNow(ReadUngriddedBase):
         ------
         NotImplementedError
         """
-        raise NotImplementedError("Not needed for these data since the format is unsuitable...")
+        raise NotImplementedError(
+            "Not needed for these data since the format is unsuitable..."
+        )
 
     def read(self, vars_to_retrieve=None, first_file=None, last_file=None):
         """
@@ -442,7 +455,8 @@ class ReadAirNow(ReadUngriddedBase):
         stats = self._read_files(files, vars_to_retrieve)
 
         data = UngriddedData.from_station_data(
-            stats, add_meta_keys=["timezone", "area_classification", "station_classification"]
+            stats,
+            add_meta_keys=["timezone", "area_classification", "station_classification"],
         )
 
         return data

--- a/tests/io/test_read_airnow.py
+++ b/tests/io/test_read_airnow.py
@@ -26,7 +26,7 @@ def test__FILEMASK(reader: ReadAirNow):
 
 
 def test__version__(reader: ReadAirNow):
-    assert reader.__version__ == "0.07"
+    assert reader.__version__ == "0.08"
 
 
 def test_FILE_COL_DELIM(reader: ReadAirNow):
@@ -336,7 +336,6 @@ def test__read_files_single_var(
     first_vals: list[float],
     unit: str,
 ):
-
     files = reader.get_file_list()
     data = reader._read_files(files, [var_name])
     assert isinstance(data, list)
@@ -361,7 +360,6 @@ def test__read_files_single_var(
 
 
 def test__read_files_single_var_error(reader: ReadAirNow):
-
     files = reader.get_file_list()
     # NH3 not available in selected 3 test files
     with pytest.raises(DataRetrievalError) as e:


### PR DESCRIPTION
Designed to close #890

I can't imagine this is the most elegant solution, but it will take care of the new encoding issues in with `pandas.read_csv()`. It would be worth investigating the performance benefit of putting this in a try-except block where we try pandas, but if that fails, we use this method instead. 