### PR TITLE
Use PyPis Trusted Publisher Management for releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -21,6 +24,4 @@ jobs:
         run: python -m build
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
+


### PR DESCRIPTION
Designed to close #972 

https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/

- [x] Update `publish-yml`
- [x] In github:
     - [x] remove secret PYPI_API_TOKEN
     - [x] add release environment 
- [x] In pypi:
     - [x] remove api-tokens under Account Settings
     - [x] under Projects -> pyaercom -> Publishing: Add new publisher (the github-repo, release env, and publish.yml)