### PR TITLE
Make computed statistics configurable by allowing dropping of default statistics and specification of the number of decimals shown 

### DIFF
--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -364,6 +364,7 @@ class ColdataToJsonEngine(ProcessingEngine):
             data,
             regnames,
             use_weights,
+            drop_stats,
             use_country,
             meta_glob,
             periods,
@@ -414,6 +415,7 @@ class ColdataToJsonEngine(ProcessingEngine):
                 trends_min_yrs,
                 use_fairmode,
                 obs_var,
+                drop_stats,
             )
 
             # the files in /map and /scat will be split up according to their time period as well

--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -192,7 +192,7 @@ class ColdataToJsonEngine(ProcessingEngine):
                     main_freq=main_freq,
                     regnames=regnames,
                     use_weights=use_weights,
-                    drop_stats = drop_stats,
+                    drop_stats=drop_stats,
                     use_country=use_country,
                     obs_name=obs_name,
                     obs_var=obs_var,

--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -87,6 +87,7 @@ class ColdataToJsonEngine(ProcessingEngine):
         """
         t00 = time()
         use_weights = self.cfg.statistics_opts.weighted_stats
+        drop_stats = self.cfg.statistics_opts.drop_stats
         # redundant, but cheap and important to be correct
         self.cfg._check_time_config()
         freqs = self.cfg.time_cfg.freqs
@@ -191,6 +192,7 @@ class ColdataToJsonEngine(ProcessingEngine):
                     main_freq=main_freq,
                     regnames=regnames,
                     use_weights=use_weights,
+                    drop_stats = drop_stats,
                     use_country=use_country,
                     obs_name=obs_name,
                     obs_var=obs_var,
@@ -316,6 +318,7 @@ class ColdataToJsonEngine(ProcessingEngine):
         main_freq: str = None,
         regnames=None,
         use_weights: bool = True,
+        drop_stats: tuple = (),
         use_country: bool = False,
         obs_name: str = None,
         obs_var: str = None,
@@ -342,6 +345,7 @@ class ColdataToJsonEngine(ProcessingEngine):
                     freq=main_freq,
                     region_ids={reg: regnames[reg]},
                     use_weights=use_weights,
+                    drop_stats=drop_stats,
                     use_country=use_country,
                     data_freq=input_freq,
                 )
@@ -360,6 +364,7 @@ class ColdataToJsonEngine(ProcessingEngine):
             data,
             regnames,
             use_weights,
+            drop_stats,
             use_country,
             meta_glob,
             periods,

--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -364,7 +364,6 @@ class ColdataToJsonEngine(ProcessingEngine):
             data,
             regnames,
             use_weights,
-            drop_stats,
             use_country,
             meta_glob,
             periods,

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -836,7 +836,7 @@ def _process_map_and_scat(
     obs_var,
     drop_stats,
 ):
-    stats_dummy = _init_stats_dummy()
+    stats_dummy = _init_stats_dummy(drop_stats=drop_stats)
     scat_data = {}
     scat_dummy = [np.nan]
     for freq, cd in data.items():
@@ -1131,7 +1131,7 @@ def _process_heatmap_data(
     trends_min_yrs,
 ):
     output = {}
-    stats_dummy = _init_stats_dummy()
+    stats_dummy = _init_stats_dummy(drop_stats=drop_stats)
     for freq, coldata in data.items():
         output[freq] = hm_freq = {}
         for regid, regname in region_ids.items():

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1308,7 +1308,7 @@ def _process_statistics_timeseries(data, freq, region_ids, use_weights, drop_sta
             per = to_idx_str[i]
             try:
                 arr = ColocatedData(subset.data.sel(time=per))
-                stats = arr.calc_statistics(use_area_weights=use_weights)
+                stats = arr.calc_statistics(use_area_weights=use_weights, drop_stats=drop_stats)
                 output[regname][str(js)] = _prep_stats_json(stats)
             except DataCoverageError:
                 pass

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1236,7 +1236,9 @@ def _map_indices(outer_idx, inner_idx):
     return mapping.astype(int)
 
 
-def _process_statistics_timeseries(data, freq, region_ids, use_weights, drop_stats, use_country, data_freq):
+def _process_statistics_timeseries(
+    data, freq, region_ids, use_weights, drop_stats, use_country, data_freq
+    ):
     """
     Compute statistics timeseries for input data
 

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -700,8 +700,8 @@ def _process_sites(data, regions, regions_how, meta_glob):
     return (ts_objs, map_meta, site_indices)
 
 
-def _get_statistics(obs_vals, mod_vals, min_num):
-    stats = calc_statistics(mod_vals, obs_vals, min_num_valid=min_num)
+def _get_statistics(obs_vals, mod_vals, min_num, drop_stats):
+    stats = calc_statistics(mod_vals, obs_vals, min_num_valid=min_num, drop_stats=drop_stats)
     return _prep_stats_json(stats)
 
 
@@ -834,6 +834,7 @@ def _process_map_and_scat(
     trends_min_yrs,
     use_fairmode,
     obs_var,
+    drop_stats,
 ):
     stats_dummy = _init_stats_dummy()
     scat_data = {}
@@ -857,7 +858,7 @@ def _process_map_and_scat(
                     else:
                         obs_vals = subset.data.data[0, :, i]
                         mod_vals = subset.data.data[1, :, i]
-                        stats = _get_statistics(obs_vals, mod_vals, min_num)
+                        stats = _get_statistics(obs_vals, mod_vals, min_num=min_num, drop_stats=drop_stats)
 
                         if use_fairmode and freq != "yearly" and not np.isnan(obs_vals).all():
                             stats["mb"] = np.nanmean(mod_vals - obs_vals)
@@ -1019,8 +1020,8 @@ def _prep_stats_json(stats):
     return stats
 
 
-def _get_extended_stats(coldata, use_weights):
-    stats = coldata.calc_statistics(use_area_weights=use_weights)
+def _get_extended_stats(coldata, use_weights, drop_stats):
+    stats = coldata.calc_statistics(use_area_weights=use_weights, drop_stats=drop_stats)
 
     # Removes the spatial median and temporal mean (see mails between Hilde, Jonas, Augustin and Daniel from 27.09.21)
     # (stats['R_spatial_mean'],
@@ -1121,6 +1122,7 @@ def _process_heatmap_data(
     data,
     region_ids,
     use_weights,
+    drop_stats,
     use_country,
     meta_glob,
     periods,
@@ -1174,7 +1176,7 @@ def _process_heatmap_data(
                                 region_id=regid, check_country_meta=use_country
                             )
 
-                            stats = _get_extended_stats(subset, use_weights)
+                            stats = _get_extended_stats(subset, use_weights, drop_stats)
 
                             if add_trends and freq != "daily" and trends_successful:
                                 # The whole trends dicts are placed in the stats dict

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -858,7 +858,9 @@ def _process_map_and_scat(
                     else:
                         obs_vals = subset.data.data[0, :, i]
                         mod_vals = subset.data.data[1, :, i]
-                        stats = _get_statistics(obs_vals, mod_vals, min_num=min_num, drop_stats=drop_stats)
+                        stats = _get_statistics(
+                            obs_vals, mod_vals, min_num=min_num, drop_stats=drop_stats
+                        )
 
                         if use_fairmode and freq != "yearly" and not np.isnan(obs_vals).all():
                             stats["mb"] = np.nanmean(mod_vals - obs_vals)

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1236,7 +1236,7 @@ def _map_indices(outer_idx, inner_idx):
     return mapping.astype(int)
 
 
-def _process_statistics_timeseries(data, freq, region_ids, use_weights, use_country, data_freq):
+def _process_statistics_timeseries(data, freq, region_ids, use_weights, drop_stats, use_country, data_freq):
     """
     Compute statistics timeseries for input data
 

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1,6 +1,7 @@
 """
 Helpers for conversion of ColocatedData to JSON files for web interface.
 """
+
 import logging
 import os
 from copy import deepcopy
@@ -1238,7 +1239,7 @@ def _map_indices(outer_idx, inner_idx):
 
 def _process_statistics_timeseries(
     data, freq, region_ids, use_weights, drop_stats, use_country, data_freq
-    ):
+):
     """
     Compute statistics timeseries for input data
 

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -586,6 +586,11 @@ class ExperimentOutput(ProjectOutput):
             for stat in self.cfg.statistics_opts.drop_stats:
                 stats_info.pop(stat, None)
 
+        # configure the number of decimals shown in statistics if provided
+        if self.cfg.statistics_opts.stats_decimals:
+            for stat in stats_info:
+                stats_info[stat].update(decimals=self.cfg.statistics_opts.stats_decimals)
+
         if self.cfg.statistics_opts.add_trends:
             if self.cfg.processing_opts.obs_only:
                 obs_statistics_trend = {

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -580,6 +580,12 @@ class ExperimentOutput(ProjectOutput):
         else:
             stats_info = statistics_defaults
             stats_info.update(extended_statistics)
+
+        # configurable statistics - drop any statistics provided in drop_stats
+        if self.cfg.statistics_opts.drop_stats:
+            for stat in self.cfg.statistics_opts.drop_stats:
+                stats_info.pop(stat, None)
+
         if self.cfg.statistics_opts.add_trends:
             if self.cfg.processing_opts.obs_only:
                 obs_statistics_trend = {

--- a/pyaerocom/aeroval/setupclasses.py
+++ b/pyaerocom/aeroval/setupclasses.py
@@ -136,7 +136,12 @@ class StatisticsSetup(ConstrainedContainer):
         days, obviously).
     drop_stats: tuple, optional
         tuple of strings with names of statistics (as determined by keys in
-        aeroval.glob_defaults.py's statistics_defaults) to not compute
+        aeroval.glob_defaults.py's statistics_defaults) to not compute. For example,
+        setting drop_stats = ("mb", "mab"), results in json files in hm/ts with
+        entries which do not contain the mean bias and mean absolute bias,
+        but the other statistics are preserved.
+
+
 
     Parameters
     ----------

--- a/pyaerocom/aeroval/setupclasses.py
+++ b/pyaerocom/aeroval/setupclasses.py
@@ -157,6 +157,7 @@ class StatisticsSetup(ConstrainedContainer):
         self.obs_only_stats = False
         self.model_only_stats = False
         self.drop_stats = ()
+        self.stats_decimals = None
         self.update(**kwargs)
 
 
@@ -237,6 +238,7 @@ class EvalRunOptions(ConstrainedContainer):
         self.only_model_maps = False
         self.obs_only = False
         self.drop_stats = ()
+        self.stats_decimals = None
         self.update(**kwargs)
 
 

--- a/pyaerocom/aeroval/setupclasses.py
+++ b/pyaerocom/aeroval/setupclasses.py
@@ -156,6 +156,7 @@ class StatisticsSetup(ConstrainedContainer):
         self.use_diurnal = False
         self.obs_only_stats = False
         self.model_only_stats = False
+        self.drop_stats = ()
         self.update(**kwargs)
 
 
@@ -235,6 +236,7 @@ class EvalRunOptions(ConstrainedContainer):
         #: If True, process only maps (skip obs evaluation)
         self.only_model_maps = False
         self.obs_only = False
+        self.drop_stats = ()
         self.update(**kwargs)
 
 

--- a/pyaerocom/aeroval/setupclasses.py
+++ b/pyaerocom/aeroval/setupclasses.py
@@ -135,7 +135,7 @@ class StatisticsSetup(ConstrainedContainer):
         compute the statistics for a given month (in this case, a month with 31
         days, obviously).
     drop_stats: tuple, optional
-        tuple of strings with names of statistics (as determined by keys in 
+        tuple of strings with names of statistics (as determined by keys in
         aeroval.glob_defaults.py's statistics_defaults) to not compute
 
     Parameters

--- a/pyaerocom/aeroval/setupclasses.py
+++ b/pyaerocom/aeroval/setupclasses.py
@@ -134,7 +134,9 @@ class StatisticsSetup(ConstrainedContainer):
         the above example 310 values would be used - 31 for each site - to
         compute the statistics for a given month (in this case, a month with 31
         days, obviously).
-
+    drop_stats: tuple, optional
+        tuple of strings with names of statistics (as determined by keys in 
+        aeroval.glob_defaults.py's statistics_defaults) to not compute
 
     Parameters
     ----------

--- a/pyaerocom/colocateddata.py
+++ b/pyaerocom/colocateddata.py
@@ -788,7 +788,7 @@ class ColocatedData:
 
         return cd
 
-    def calc_statistics(self, use_area_weights=False, **kwargs):
+    def calc_statistics(self, use_area_weights=False, drop_stats = (), **kwargs):
         """Calculate statistics from model and obs data
 
         Calculate standard statistics for model assessment. This is done by

--- a/pyaerocom/colocateddata.py
+++ b/pyaerocom/colocateddata.py
@@ -788,7 +788,7 @@ class ColocatedData:
 
         return cd
 
-    def calc_statistics(self, use_area_weights=False, drop_stats = (), **kwargs):
+    def calc_statistics(self, use_area_weights=False, **kwargs):
         """Calculate statistics from model and obs data
 
         Calculate standard statistics for model assessment. This is done by

--- a/pyaerocom/mathutils.py
+++ b/pyaerocom/mathutils.py
@@ -308,9 +308,9 @@ def calc_statistics(
     if weights is not None:
         weights = weights[mask]
         weights = weights / weights.max()
-        result["NOTE"] = (
-            "Weights were not applied to FGE and kendall and spearman corr (not implemented)"
-        )
+        result[
+            "NOTE"
+        ] = "Weights were not applied to FGE and kendall and spearman corr (not implemented)"
 
     result["rms"] = np.sqrt(np.average(diffsquare, weights=weights))
 

--- a/pyaerocom/mathutils.py
+++ b/pyaerocom/mathutils.py
@@ -353,8 +353,7 @@ def calc_statistics(data, ref_data, lowlim=None, highlim=None, min_num_valid=1, 
     result["mb"] = mb
     result["mab"] = mab
     
-    breakpoint()
-    
+ 
     if drop_stats:
         for istat in drop_stats:
             result.pop(istat, None)

--- a/pyaerocom/mathutils.py
+++ b/pyaerocom/mathutils.py
@@ -189,7 +189,7 @@ def _nanmean_and_std(data):
 @ignore_warnings(
     RuntimeWarning, "An input array is constant", "invalid value encountered in .*divide"
 )
-def calc_statistics(data, ref_data, lowlim=None, highlim=None, min_num_valid=1, weights=None):
+def calc_statistics(data, ref_data, lowlim=None, highlim=None, min_num_valid=1, weights=None, drop_stats=None):
     """Calc statistical properties from two data arrays
 
     Calculates the following statistical properties based on the two provided
@@ -352,6 +352,12 @@ def calc_statistics(data, ref_data, lowlim=None, highlim=None, min_num_valid=1, 
     result["fge"] = fge
     result["mb"] = mb
     result["mab"] = mab
+    
+    breakpoint()
+    
+    if drop_stats:
+        for istat in drop_stats:
+            result.pop(istat, None)
 
     return result
 

--- a/pyaerocom/mathutils.py
+++ b/pyaerocom/mathutils.py
@@ -1,6 +1,7 @@
 """
 Mathematical low level utility methods of pyaerocom
 """
+
 import numpy as np
 from scipy.stats import kendalltau, pearsonr, spearmanr
 
@@ -229,7 +230,13 @@ def calc_statistics(
     min_num_valid : int
         minimum number of valid measurements required to compute statistical
         parameters.
-
+    weights: ndarray
+        array containing weights if computing weighted statistics
+    drop_stats: tuple
+        tuple which drops the provided statistics from computed json files.
+        For example, setting drop_stats = ("mb", "mab"), results in json files
+        in hm/ts with entries which do not contain the mean bias and mean
+        absolute bias, but the other statistics are preserved.
     Returns
     -------
     dict
@@ -301,9 +308,9 @@ def calc_statistics(
     if weights is not None:
         weights = weights[mask]
         weights = weights / weights.max()
-        result[
-            "NOTE"
-        ] = "Weights were not applied to FGE and kendall and spearman corr (not implemented)"
+        result["NOTE"] = (
+            "Weights were not applied to FGE and kendall and spearman corr (not implemented)"
+        )
 
     result["rms"] = np.sqrt(np.average(diffsquare, weights=weights))
 

--- a/pyaerocom/mathutils.py
+++ b/pyaerocom/mathutils.py
@@ -500,10 +500,10 @@ def estimate_value_range(vmin, vmax, extend_percent=0):
     return vmin, vmax
 
 
-def _init_stats_dummy():
+def _init_stats_dummy(drop_stats=None):
     # dummy for statistics dictionary for locations without data
     stats_dummy = {}
-    for k in calc_statistics([1], [1]):
+    for k in calc_statistics([1], [1], drop_stats=drop_stats):
         stats_dummy[k] = np.nan
 
     # Test to make sure these variables are defined even when yearly and season != all

--- a/pyaerocom/mathutils.py
+++ b/pyaerocom/mathutils.py
@@ -189,7 +189,9 @@ def _nanmean_and_std(data):
 @ignore_warnings(
     RuntimeWarning, "An input array is constant", "invalid value encountered in .*divide"
 )
-def calc_statistics(data, ref_data, lowlim=None, highlim=None, min_num_valid=1, weights=None, drop_stats=None):
+def calc_statistics(
+    data, ref_data, lowlim=None, highlim=None, min_num_valid=1, weights=None, drop_stats=None
+):
     """Calc statistical properties from two data arrays
 
     Calculates the following statistical properties based on the two provided
@@ -352,8 +354,7 @@ def calc_statistics(data, ref_data, lowlim=None, highlim=None, min_num_valid=1, 
     result["fge"] = fge
     result["mb"] = mb
     result["mab"] = mab
-    
- 
+
     if drop_stats:
         for istat in drop_stats:
             result.pop(istat, None)

--- a/tests/aeroval/test_coldatatojson_helpers2.py
+++ b/tests/aeroval/test_coldatatojson_helpers2.py
@@ -97,7 +97,7 @@ def test__process_statistics_timeseries(
     example_coldata, freq: str, region_ids: dict[str, str], data_freq: str, nmb_avg
 ):
     result = _process_statistics_timeseries(
-        example_coldata, freq, region_ids, False, False, data_freq
+        data=example_coldata, freq=freq, region_ids=region_ids, use_weights=False, drop_stats=(), use_country=False, data_freq=data_freq
     )
     assert len(result) == len(region_ids)
     biases = [np.nan]
@@ -106,7 +106,24 @@ def test__process_statistics_timeseries(
             biases.append(stats["nmb"])
     mean_bias = np.nanmean(biases)
     assert mean_bias == pytest.approx(nmb_avg, abs=0.001, nan_ok=True)
+    
+    
+@pytest.mark.parametrize(
+    "freq,region_ids,data_freq,nmb_avg,drop_stats",
+    [
+        ("yearly", {"EUROPE": "Europe"}, "monthly", 0.168, ("mb", "mab")),
+        ("yearly", {"EUROPE": "Europe"}, None, 0.122, ("nmb")),
 
+    ],
+)
+@pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning")
+def test__process_statistics_timeseries_drop_stats(
+    example_coldata, freq: str, region_ids: dict[str, str], data_freq: str, nmb_avg, drop_stats
+):
+    result = _process_statistics_timeseries(
+        data=example_coldata, freq=freq, region_ids=region_ids, use_weights=False, drop_stats=drop_stats, use_country=False, data_freq=data_freq
+    )
+    assert all([stat not in result for stat in drop_stats])
 
 @pytest.mark.parametrize(
     "freq,region_ids,data_freq,exception,error",
@@ -146,7 +163,7 @@ def test__process_statistics_timeseries_error(
     error: str,
 ):
     with pytest.raises(exception) as e:
-        _process_statistics_timeseries(example_coldata, freq, region_ids, False, False, data_freq)
+        _process_statistics_timeseries(data=example_coldata, freq=freq, region_ids=region_ids, use_weights=False, drop_stats=(), use_country=False, data_freq=data_freq)
     assert str(e.value) == error
 
 

--- a/tests/aeroval/test_coldatatojson_helpers2.py
+++ b/tests/aeroval/test_coldatatojson_helpers2.py
@@ -97,7 +97,13 @@ def test__process_statistics_timeseries(
     example_coldata, freq: str, region_ids: dict[str, str], data_freq: str, nmb_avg
 ):
     result = _process_statistics_timeseries(
-        data=example_coldata, freq=freq, region_ids=region_ids, use_weights=False, drop_stats=(), use_country=False, data_freq=data_freq
+        data=example_coldata,
+        freq=freq,
+        region_ids=region_ids,
+        use_weights=False,
+        drop_stats=(),
+        use_country=False,
+        data_freq=data_freq,
     )
     assert len(result) == len(region_ids)
     biases = [np.nan]
@@ -106,14 +112,13 @@ def test__process_statistics_timeseries(
             biases.append(stats["nmb"])
     mean_bias = np.nanmean(biases)
     assert mean_bias == pytest.approx(nmb_avg, abs=0.001, nan_ok=True)
-    
-    
+
+
 @pytest.mark.parametrize(
     "freq,region_ids,data_freq,nmb_avg,drop_stats",
     [
         ("yearly", {"EUROPE": "Europe"}, "monthly", 0.168, ("mb", "mab")),
         ("yearly", {"EUROPE": "Europe"}, None, 0.122, ("nmb")),
-
     ],
 )
 @pytest.mark.filterwarnings("ignore:Mean of empty slice:RuntimeWarning")
@@ -121,9 +126,16 @@ def test__process_statistics_timeseries_drop_stats(
     example_coldata, freq: str, region_ids: dict[str, str], data_freq: str, nmb_avg, drop_stats
 ):
     result = _process_statistics_timeseries(
-        data=example_coldata, freq=freq, region_ids=region_ids, use_weights=False, drop_stats=drop_stats, use_country=False, data_freq=data_freq
+        data=example_coldata,
+        freq=freq,
+        region_ids=region_ids,
+        use_weights=False,
+        drop_stats=drop_stats,
+        use_country=False,
+        data_freq=data_freq,
     )
     assert all([stat not in result for stat in drop_stats])
+
 
 @pytest.mark.parametrize(
     "freq,region_ids,data_freq,exception,error",
@@ -163,7 +175,15 @@ def test__process_statistics_timeseries_error(
     error: str,
 ):
     with pytest.raises(exception) as e:
-        _process_statistics_timeseries(data=example_coldata, freq=freq, region_ids=region_ids, use_weights=False, drop_stats=(), use_country=False, data_freq=data_freq)
+        _process_statistics_timeseries(
+            data=example_coldata,
+            freq=freq,
+            region_ids=region_ids,
+            use_weights=False,
+            drop_stats=(),
+            use_country=False,
+            data_freq=data_freq,
+        )
     assert str(e.value) == error
 
 

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -328,3 +328,21 @@ def test_ExperimentOutput_reorder_experiments_error(dummy_expout: ExperimentOutp
     with pytest.raises(ValueError) as e:
         dummy_expout.reorder_experiments("b")
     assert str(e.value) == "need list as input"
+
+
+
+@geojson_unavail
+@pytest.mark.parametrize("cfg,drop_stats,stats_decimals", [("cfgexp1", ("mab", "R_spearman"), 2)])
+def test_Experiment_Output_drop_stats_and_decimals(eval_config: dict, drop_stats, stats_decimals: int):
+    cfg = EvalSetup(**eval_config)
+    cfg.model_cfg["mod1"] = cfg.model_cfg["TM5-AP3-CTRL"]
+    cfg["statistics_opts"]["drop_stats"] = drop_stats
+    cfg["statistics_opts"]["stats_decimals"] = stats_decimals
+    proc = ExperimentProcessor(cfg)
+    proc.run()
+    path = Path(proc.exp_output.exp_dir)
+    files = [f for f in path.iterdir() if f.is_file()]
+    assert any(["statistics.json" in f.name for f in files])
+    statistics_json = read_json(path / "statistics.json")
+    assert all([stat not in statistics_json for stat in drop_stats])
+    assert all([statistics_json[stat]["decimals"] == stats_decimals for stat in statistics_json])

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -330,10 +330,11 @@ def test_ExperimentOutput_reorder_experiments_error(dummy_expout: ExperimentOutp
     assert str(e.value) == "need list as input"
 
 
-
 @geojson_unavail
 @pytest.mark.parametrize("cfg,drop_stats,stats_decimals", [("cfgexp1", ("mab", "R_spearman"), 2)])
-def test_Experiment_Output_drop_stats_and_decimals(eval_config: dict, drop_stats, stats_decimals: int):
+def test_Experiment_Output_drop_stats_and_decimals(
+    eval_config: dict, drop_stats, stats_decimals: int
+):
     cfg = EvalSetup(**eval_config)
     cfg.model_cfg["mod1"] = cfg.model_cfg["TM5-AP3-CTRL"]
     cfg["statistics_opts"]["drop_stats"] = drop_stats


### PR DESCRIPTION
Designed to close #885 

Similar to what we do for obs-only or model-only experiments, `statistics.json` will be configurable to only show statistics in [`statistics_default`](https://github.com/metno/pyaerocom/blob/f8596b2cca36bf53226d1f224c95a01564888b2b/pyaerocom/aeroval/glob_defaults.py#L329) which are **not** included in the `drop_stats` tuple in the configuration file. This means that if a project does not require Mean Bias or Mean Absolute Bias, for example, then setting `drop_stats = ("mb", "mab")` will result in an experiment which does not show these statistics. The strings provided in `drop_stats` must match the keys in `statistics_default`. `drop_stats` is implemented as a tuple of strings to imply to programmers that this object is immutable at runtime.