### PR TITLE
missing temporary path to unpack testdata-minimal.tar.gz

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -100,7 +100,11 @@ jobs:
         python -m pip install tox
     - name: Run test
       continue-on-error: ${{ matrix.experimental }}
-      run: tox -e py
+      run: |
+        tox -e py -- -vvx tests/aeroval/test_helpers.py::test_make_dummy_model[cfgexp1]
+        tox -e py -- -vvx tests/aeroval/test_helpers.py
+        tox -e py -- -vvx tests/aeroval
+        tox -e py
 
   conda:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -100,11 +100,7 @@ jobs:
         python -m pip install tox
     - name: Run test
       continue-on-error: ${{ matrix.experimental }}
-      run: |
-        tox -e py -- -vvx tests/aeroval/test_helpers.py::test_make_dummy_model[cfgexp1]
-        tox -e py -- -vvx tests/aeroval/test_helpers.py
-        tox -e py -- -vvx tests/aeroval
-        tox -e py
+      run: tox -e py
 
   conda:
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ exclude_lines = [
 
 [tool.black]
 target-version = ['py39']
-extend_skip = ["pyaerocom-tutorials"]
+extend-exclude = "pyaerocom-tutorials"
 line-length = 99
 
 [tool.isort]

--- a/tests/fixtures/data_access.py
+++ b/tests/fixtures/data_access.py
@@ -37,8 +37,9 @@ minimal_dataset = pooch.create(
 
 
 def download(file_name: str = TESTATA_FILE):
-    """download tar file to ~/MyPyaerocom/ unpack cointents into ~/MyPyaerocom/testdata-minimal/"""
+    """download tar file to ~/MyPyaerocom/ unpack contents into ~/MyPyaerocom/testdata-minimal/"""
     logger.debug(f"fetch {file_name} to {minimal_dataset.path}")
+    minimal_dataset.path.joinpath("tmp").mkdir(parents=True, exist_ok=True)
     minimal_dataset.fetch(file_name, processor=pooch.Untar(["testdata-minimal"], extract_dir="./"))
 
 


### PR DESCRIPTION
This is likely an error on the underlying library ([pooch]).
There I create the temporary path before retrieving the test dataset.

close #996

[pooch]: https://www.fatiando.org/pooch/latest/