### PR TITLE
fixes wrongly assigned var_name when using use keyword closes #1027

### DIFF
--- a/pyaerocom/data/variables.ini
+++ b/pyaerocom/data/variables.ini
@@ -21,170 +21,202 @@ comments_and_purpose = For comparison with AERONET and satellite measurements
 [od550lt1aer]
 description = AOD due to fine aerosol at 550 nm (particle smaller than D=1 um)
 use = od550aer
+var_name = od550lt1aer
 
 [od550gt1aer]
 description = AOD due to fine aerosol at 550 nm (particle greater than D=1 um)
 use=od550aer
+var_name = od550gt1aer
 
 [od550lt1ang]
 description = AOD filtred by Angstrom exponent less than 1
 use = od550aer
-
+var_name = od550lt1ang
 
 [od440aer]
 description = Aerosol optical depth (AOD) at 440 nm
 wavelength_nm = 440
 use = od550aer
+var_name = od440aer
 
 [od865aer]
 description = Aerosol optical depth (AOD) at 865 nm
 use = od550aer
+var_name = od865aer
 
 [od870aer]
 description = Aerosol optical depth (AOD) at 870 nm
 use = od550aer
+var_name = od870aer
 
 [od500aer]
 use=od550aer
 description = Aerosol optical depth (AOD) at 500 nm
+var_name = od500aer
 
 [od500pm10]
 use=od550aer
 description = Aerosol optical depth (AOD) at 500 nm due to PM10
 standard_name = atmosphere_optical_thickness_due_to_pm10_ambient_aerosol_particles
+var_name = od500pm10
 
 [od500pm2p5]
 use=od550aer
 description = Aerosol optical depth (AOD) at 500 nm due to PM2.5
 standard_name = atmosphere_optical_thickness_due_to_pm2p5_ambient_aerosol_particles
+var_name = od500pm2p5
 
 [od550aerh2o]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to water
 standard_name = atmosphere_optical_thickness_due_to_water_in_ambient_aerosol_particles
+var_name = od550aerh2o
 
 [proxyod550aerh2o]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to water
 standard_name = atmosphere_optical_thickness_due_to_water_in_ambient_aerosol_particles
 only_use_in = maps.php
+var_name = proxyod550aerh2o
 
 [od550bc]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to elemental carbon
 standard_name = atmosphere_optical_thickness_due_to_elemental_carbon_ambient_aerosol_particles
+var_name = od550bc
 
 [proxyod550bc]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to elemental carbon
 standard_name = atmosphere_optical_thickness_due_to_elemental_carbon_ambient_aerosol_particles
 only_use_in = maps.php
+var_name = proxyod550bc
 
 [od550dust]
-use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to dust
 standard_name = atmosphere_optical_thickness_due_to_dust_ambient_aerosol_particles
+use = od550aer
+var_name = od550dust
 
 [proxyod550dust]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to dust
 standard_name = atmosphere_optical_thickness_due_to_dust_ambient_aerosol_particles
 only_use_in = maps.php
+var_name = proxyod550dust
 
 [od550nh4]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to Ammonium
 standard_name = atmosphere_optical_thickness_due_to_ammonium_ambient_aerosol_particles
+var_name = od550nh4
 
 [proxyod550nh4]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to Ammonium
 standard_name = atmosphere_optical_thickness_due_to_ammonium_ambient_aerosol_particles
 only_use_in = maps.php
+var_name = proxyod550nh4
 
 [od550no3]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to nitrate
 standard_name = atmosphere_optical_thickness_due_to_nitrate_ambient_aerosol_particles
+var_name = od550no3
 
 [proxyod550no3]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to Nitrate
 standard_name = atmosphere_optical_thickness_due_to_nitrate_ambient_aerosol_particles
 only_use_in = maps.php
+var_name = proxyod550no3
 
 [od550oa]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to organic matter
 standard_name = atmosphere_optical_thickness_due_to_particulate_organic_matter_ambient_aerosol_particles
+var_name = od550oa
 
 [proxyod550oa]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to organic matter
 standard_name = atmosphere_optical_thickness_due_to_particulate_organic_matter_ambient_aerosol_particles
 only_use_in = maps.php
+var_name = proxyod550oa
 
 [od550pm1]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to PM1
 standard_name = atmosphere_optical_thickness_due_to_pm1_ambient_aerosol_particles
+var_name = od550pm1
 
 [od550pm1no3]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to PM1 nitrate
 standard_name = atmosphere_optical_thickness_due_to_pm1_nitrate_ambient_aerosol_particles
+var_name = od550pm1no3
 
 [od550pm10]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to PM10
 standard_name = atmosphere_optical_thickness_due_to_pm10_ambient_aerosol_particles
+var_name = od550pm10
 
 [od550pm10no3]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to PM10 nitrate
 standard_name = atmosphere_optical_thickness_due_to_pm10_nitrate_ambient_aerosol_particles
+var_name = od550pm10no3
 
 [od550pm2p5]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to PM2.5
 standard_name = atmosphere_optical_thickness_due_to_pm2p5_ambient_aerosol_particles
+var_name = od550pm2p5
 
 [od550pm2p5no3]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to PM2.5 nitrate
 standard_name = atmosphere_optical_thickness_due_to_pm2p5_nitrate_ambient_aerosol_particles
+var_name = od550pm2p5no3
 
 [od550so4]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to SO4
 standard_name = atmosphere_optical_thickness_due_to_sulfate_ambient_aerosol_particles
+var_name = od550so4
 
 [proxyod550so4]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to SO4
 standard_name = atmosphere_optical_thickness_due_to_sulfate_ambient_aerosol_particles
 only_use_in = maps.php
+var_name = proxyod550so4
 
 [od550ss]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to sea salt
 standard_name = atmosphere_optical_thickness_due_to_seasalt_ambient_aerosol_particles
+var_name = od550ss
 
 [proxyod550ss]
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to sea salt
 standard_name = atmosphere_optical_thickness_due_to_seasalt_ambient_aerosol_particles
 only_use_in  = maps.php
+var_name = proxyod550ss
 
 [od550lt1ss]
 use = od550ss
 standard_name = None
 description = Aerosol optical depth (AOD) at 550 nm due to fine sea salt (D>1um)
+var_name = od550lt1ss
 
 [od550lt1dust]
 use = od550dust
 standard_name = None
 description = Aerosol optical depth (AOD) at 550 nm due to fine dust (D>1um)
+var_name = od550lt1dust
 
 [abs550aer]
 description = Absorption aerosol optical depth (AAOD) at 550nm
@@ -209,36 +241,42 @@ dimensions = time,lat,lon
 description = Absorption aerosol optical depth (AAOD) at 440 nm
 wavelength_nm = 440
 use = abs550aer
+var_name = abs440aer
 
 [abs870aer]
 description = Absorption aerosol optical depth (AAOD) at 870 nm
 wavelength_nm = 440
 use = abs550aer
+var_name = abs870aer
 
 [abs550bc]
-description = Absorption aerosol optical depth (AAOD) at 870 nm due to elemental carbon
+description = Absorption aerosol optical depth (AAOD) at 550 nm due to elemental carbon
 standard_name = atmosphere_absorption_optical_thickness_due_to_elemental_carbon_ambient_aerosol_particles
 use = abs550aer
+var_name = abs550bc
 
 [abs550dust]
-description = Absorption aerosol optical depth (AAOD) at 870 nm due to dust
+description = Absorption aerosol optical depth (AAOD) at 550 nm due to dust
 standard_name = atmosphere_absorption_optical_thickness_due_to_dust_ambient_aerosol_particles
 use = abs550aer
+var_name = abs550dust
 
 [abs550pm1]
-description = Absorption aerosol optical depth (AAOD) at 870 nm due to dust due to PM1
+description = Absorption aerosol optical depth (AAOD) at 550 nm due to dust due to PM1
 standard_name = atmosphere_absorption_optical_thickness_due_to_pm1_ambient_aerosol_particles
 use = abs550aer
 
 [abs550pm10]
-description = Absorption aerosol optical depth (AAOD) at 870 nm due to dust due to PM10
+description = Absorption aerosol optical depth (AAOD) at 550 nm due to dust due to PM10
 standard_name = atmosphere_absorption_optical_thickness_due_to_pm10_ambient_aerosol_particles
 use = abs550aer
+var_name = abs550pm10
 
 [abs550pm2p5]
-description = Absorption aerosol optical depth (AAOD) at 870 nm due to dust due to PM2.5
+description = Absorption aerosol optical depth (AAOD) at 550 nm due to dust due to PM2.5
 standard_name = atmosphere_absorption_optical_thickness_due_to_pm2p5_ambient_aerosol_particles
 use = abs550aer
+var_name = abs550pm2p5
 
 [ec550aer]
 description = Aerosol Extinction coefficient at 550nm
@@ -290,14 +328,17 @@ map_cbar_levels = [0, 4, 8, 12, 16, 20, 40, 60, 80, 100, 200, 300, 400]
 [sc550dryaer]
 description = Dry aerosol light scattering coefficient at 550 nm (RH<40)
 use = sc550aer
+var_name = sc550dryaer
 
 [ec550dryaer]
 description = Dry aerosol light extinction coefficient at 550 nm (RH<40)
 use = ec550aer
+var_name = ec550dryaer
 
 [ac550dryaer]
 description = Dry aerosol light absorption coefficient at 550 nm (RH<40)
 use = ac550aer
+var_name = ac550dryaer
 
 [sc440aer]
 description = Aerosol light scattering coefficient at 440 nm
@@ -313,6 +354,7 @@ map_cbar_levels = [0, 4, 8, 12, 16, 20, 40, 60, 80, 100, 200, 300, 400]
 [sc440dryaer]
 description = Dry aerosol light scattering coefficient at 440 nm (RH<40)
 use = sc440aer
+var_name = sc440dryaer
 
 [sc700aer]
 description = Aerosol light scattering coefficient at 700 nm
@@ -328,6 +370,7 @@ map_cbar_levels = [0, 4, 8, 12, 16, 20, 40, 60, 80, 100, 200, 300, 400]
 [sc700dryaer]
 description = Dry aerosol light scattering coefficient at 700 nm (RH<40)
 use = sc700aer
+var_name = sc700dryaer
 
 [sc550lt1aer]
 description = Aerosol light scattering coefficient at 550 nm (fine mode)
@@ -449,6 +492,7 @@ description = Dry Angstrom exponent between 440-870 nm
 [ang5587aer]
 description = Angstrom exponent between 550-870 nm
 use=ang4487aer
+
 
 [ang4470aer]
 description = Angstrom exponent between 440-700 nm
@@ -5272,10 +5316,12 @@ comments_and_purpose = For diagnosing aerosol particle hygroscopic growth
 [scrh]
 use = rh
 comments_and_purpose = For diagnosing aerosol particle hygroscopic growth for light scattering measurement
+var_name = scrh
 
 [acrh]
 use = rh
 comments_and_purpose = For diagnosing aerosol particle hygroscopic growth for light absorption measurement
+var_name = acrh
 
 [vmrcodirect50d]
 var_name = vmrcodirect50d


### PR DESCRIPTION
The use keyword lead to variable getting assigned wrong var_name and thus leading to pyaerocom looking for aliases of the wrong variable