### PR TITLE
Fix pytest 8 warning

### DIFF
--- a/tests/plugins/mep/test_reader.py
+++ b/tests/plugins/mep/test_reader.py
@@ -6,7 +6,6 @@ import pytest
 
 from pyaerocom import const
 from pyaerocom.plugins.mep.reader import ReadMEP
-from tests.conftest import lustre_unavail
 
 STATION_NAMES = ("1478A", "2706A", "3377A")
 VARS_DEFAULT = {"concco", "concno2", "conco3", "concpm10", "concpm25", "concso2"}
@@ -38,47 +37,39 @@ def station_files(mep_path: Path, station: str) -> list[Path]:
     return files
 
 
-@lustre_unavail
 def test_DATASET_NAME(reader: ReadMEP):
     assert reader.DATASET_NAME == "MEP"
 
 
-@lustre_unavail
 def test_DEFAULT_VARS(reader: ReadMEP):
     assert set(reader.DEFAULT_VARS) >= VARS_DEFAULT
 
 
-@lustre_unavail
 def test_files(reader: ReadMEP):
     assert reader.files, "no stations files found"
     assert len(reader.files) >= 3, "found less files than expected"
 
 
-@lustre_unavail
 def test_FOUND_FILES(reader: ReadMEP):
     assert reader.FOUND_FILES, "no stations files found"
     assert len(reader.FOUND_FILES) >= 3, "found less files than expected"
 
 
-@lustre_unavail
 @pytest.mark.parametrize("station", STATION_NAMES)
 def test_stations(reader: ReadMEP, station: str):
     assert reader.stations()[station], f"no {station} station files"
 
 
-@lustre_unavail
 def test_PROVIDES_VARIABLES(reader: ReadMEP):
     assert set(reader.PROVIDES_VARIABLES) >= VARS_PROVIDED
 
 
-@lustre_unavail
 @pytest.mark.parametrize("station", STATION_NAMES)
 def test_read_file(reader: ReadMEP, station_files: list[str]):
     data = reader.read_file(station_files[-1])
     assert set(data.contains_vars) == VARS_DEFAULT
 
 
-@lustre_unavail
 def test_read_file_error(reader: ReadMEP):
     bad_station_file = "not-a-file.nc"
     with pytest.raises(ValueError) as e:
@@ -86,14 +77,12 @@ def test_read_file_error(reader: ReadMEP):
     assert str(e.value) == f"missing {bad_station_file}"
 
 
-@lustre_unavail
 @pytest.mark.parametrize("station", STATION_NAMES)
 def test_read(reader: ReadMEP, station_files: list[str]):
     data = reader.read(VARS_PROVIDED, station_files, first_file=0, last_file=5)
     assert set(data.contains_vars) == VARS_PROVIDED
 
 
-@lustre_unavail
 def test_read_error(reader: ReadMEP):
     bad_variable_name = "not-a-variable"
     with pytest.raises(ValueError) as e:


### PR DESCRIPTION
with pytest 8.1+, CI fails with this error
```
@lustre_unavail
@pytest.fixture(scope="module")constructs are deprecated: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function.
```

this PR fixes it