### PR TITLE
Update GH actions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -114,7 +114,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
         activate-environment: pya

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ env.PYTHON }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON }}
     - name: Python info
@@ -40,7 +40,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ env.PYTHON }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ env.PYTHON }}
     - name: Python info
@@ -73,7 +73,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Python info

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -134,5 +134,6 @@ jobs:
       if: ${{ success() }}
       uses: codecov/codecov-action@v4
       with:
-          file: ./coverage.xml
-          flags: unittests
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        flags: unittests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       PYTHON: "3.10"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ env.PYTHON }}
       uses: actions/setup-python@v4
       with:
@@ -38,7 +38,7 @@ jobs:
     env:
       PYTHON: "3.10"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ env.PYTHON }}
       uses: actions/setup-python@v4
       with:
@@ -71,7 +71,7 @@ jobs:
             experimental: true        
             os: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -112,7 +112,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: conda-incubator/setup-miniconda@v2
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,7 +85,7 @@ jobs:
         sudo apt update
         sudo apt install libudunits2-dev libgeos-dev libproj-dev proj-data proj-bin
     - name: Cache pip and tox
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       if: ${{ ! matrix.experimental }}
       with:
         path: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -132,7 +132,7 @@ jobs:
       run: pytest -ra -q --cov --no-cov-on-fail --cov-report xml
     - name: Upload coverage to Codecov
       if: ${{ success() }}
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
           file: ./coverage.xml
           flags: unittests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install pypa/build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Release
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
avoid CI warnings like
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20
```