### PR TITLE
fixing entry-point imports under pytest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,7 +68,7 @@ jobs:
         os: [ubuntu-22.04]
         include:
           - python-version: '3.12'
-            experimental: true        
+            experimental: true
             os: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
@@ -129,7 +129,7 @@ jobs:
       run: python -m pip install . --no-deps
     - name: Run pytest
       continue-on-error: ${{ matrix.experimental }}
-      run: pytest -ra -q --cov --no-cov-on-fail --cov-report xml
+      run: python -m pytest -ra -q --cov --no-cov-on-fail --cov-report xml
     - name: Upload coverage to Codecov
       if: ${{ success() }}
       uses: codecov/codecov-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,7 @@ requires =
 commands_pre =
     python --version
 commands =
-    pytest -ra -q {posargs:--cov --no-cov-on-fail}
+    python -m pytest -ra -q {posargs:--cov --no-cov-on-fail}
 extras =
     test
 setenv =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,10 @@ exclude = [
 minversion = "7.4"
 log_cli = false
 log_cli_level = "WARNING"
-addopts = "--failed-first"
+addopts = [
+    "--failed-first",
+    "--import-mode=importlib",
+]
 xfail_strict = true
 testpaths = ["tests"]
 filterwarnings = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -112,7 +112,6 @@ def test_Config_has_access_users_database():
     assert not cfg.has_access_users_database
 
 
-@lustre_avail
 @pytest.mark.parametrize(
     "cfg_id,basedir,init_obslocs_ungridded,init_data_search_dirs,data_searchdirno",
     [
@@ -130,6 +129,8 @@ def test_Config_read_config(
     cfg_file = cfg._config_files[cfg_id]
     assert Path(cfg_file).exists()
     cfg.read_config(cfg_file, basedir, init_obslocs_ungridded, init_data_search_dirs)
+    if not cfg.has_access_lustre:
+        pytest.skip(f"Skipping since {cfg._LUSTRE_CHECK_PATH} directory not accessible")
     assert len(cfg.DATA_SEARCH_DIRS) == data_searchdirno
     assert len(cfg.OBSLOCS_UNGRIDDED) == 0
     assert Path(cfg.OUTPUTDIR).exists()


### PR DESCRIPTION
Under some environments, the entry-point import under pytest failed while they in general worked under pure python.

Solving using the recommended pytest setup: https://docs.pytest.org/en/latest/explanation/goodpractices.html#choosing-an-import-mode