### PR TITLE
force pydantic>2

### DIFF
--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -18,7 +18,7 @@ dependencies:
   - tqdm
   - openpyxl
   - typer >=0.7.0
-  - pydantic
+  - pydantic > 2.0.0
 ## python < 3.11
   - tomli >=2.0.1
   - importlib-resources >=5.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     # https://github.com/SciTools/cf-units/issues/218
     'cf-units>=3.1',
     "pyaro",
-    "pydantic",
+    "pydantic>2",
 
 ]
 


### PR DESCRIPTION
Testing in a conda-environment with pre-installed pydantic 1.X raised errors on missing model_dump.
Raising version to > 2.x solves the issue. Current pydantic is 2.6.4, so maybe it should even be moved to that version, not sure what was tested.