### PR TITLE
documentation fixes: re-adding installations to conda-envs and updating contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ The following are some guidelines for contributing to pyaerocom, a Python packag
 
 ## Setting up a development environment
 
-If you want to do changes to your pyaerocom code you should follow the [installation guide in the documentation](https://pyaerocom.readthedocs.io/en/latest/install.html) for "Installing from source into a conda environment" after setting up your environment in accordance with the requirements in the [pyaerocom_env.yml](https://github.com/metno/pyaerocom/blob/main-dev/pyaerocom_env.yml) file. Use the following installation command after cloning the repository
+If you want to do changes to your pyaerocom code you should follow the [installation guide in the documentation](https://pyaerocom.readthedocs.io/en/latest/install.html) for "Installing from source ..." after setting up your environment in accordance with the requirements in the [pyaerocom_env.yml](https://github.com/metno/pyaerocom/blob/main-dev/pyaerocom_env.yml) file. Use the following installation command after cloning the repository
 
 ``` bash
 pip install --no-deps -e .
@@ -38,7 +38,9 @@ You are welcome to contribute code to implement new features, fix bugs or contri
 
 ### Tests
 
-Any new functions/methods you add must be covered by tests. Tests are wirtten and run using pytest and are found under pyaerocom/tests. Missing test coverage will trigger a warning in the GitHub CI.
+Any new functions/methods you add must be covered by tests. Tests are wirtten and run using `pytest` and/or `tox` and are found under pyaerocom/tests. Please run tests before locally (and if working at MET also on PPI) before making a PR.
+
+Missing test coverage will trigger a warning in the GitHub CI.
 
 ### Documentation
 
@@ -50,10 +52,12 @@ We are in the process of moving to the code style enforced by [black](https://gi
 
 ## Pyaerocom team
 
-* [Jan Griesfeller](https://github.com/jgriesfeller)
-* [Alvaro Valdebenito](https://github.com/avaldebe)
-* [Daniel Heinesen](https://github.com/dulte)
-* [Augustin Mortier](https://github.com/AugustinMortier)
 * [Lewis Blake](https://github.com/lewisblake)
+* [Jan Griesfeller](https://github.com/jgriesfeller)
+* [Daniel Heinesen](https://github.com/dulte)
+* [Heiko Klein](https://github.com/heikoklein)
+* [Augustin Mortier](https://github.com/AugustinMortier)
+* [Alvaro Valdebenito](https://github.com/avaldebe)
+
 * [Jonas Gliß](https://github.com/jgliss) - former member
 * [Hans Brenna](https://github.com/hansbrenna) - former member

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -3,14 +3,11 @@ Installation
 
 You can install PyAerocom via pip
 
-If you want PyAerocom in your default installation of python, then you install the latest released version of pyaerocom and its depencencies:
-::
+Install from source into a new virtual environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-	# install pyaerocom on machines with Proj8 or newer
-	# e.g. Ubuntu 22.04 LTS (Jammy Jellyfish)
-	python3 -m pip install pyaerocom
-
-Or into a new virtual environment (recommended) named *.venv* via::
+Installation into a new virtual environment (recommended for machines with newer python version and
+binary libraries) named *.venv* via::
 
 	# create and activate new virtual environment
 	python3 -m venv --prompt pya .venv
@@ -24,3 +21,46 @@ Or into a new virtual environment (recommended) named *.venv* via::
 	pip install pyaerocom
 
 
+Install from source into a conda environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you use the *conda* package manager, please make sure to
+`activate the environment <https://conda.io/docs/user-guide/tasks/manage-environments.html#activating-an-environment>`__
+you want to install pyaerocom into. For more information about conda environments,
+`see here <https://conda.io/docs/user-guide/tasks/manage-environments.html>`__.
+
+Please make sure to install all requirements (see below) before installing pyaerocom from source.
+You can do that with the provided file pyaerocom_env.yml.
+
+To install pyaerocom from source, please download and extract the
+`latest release <https://github.com/metno/pyaerocom/releases>`__
+(or clone the `repo <https://github.com/metno/pyaerocom/>`__) and install from the top-level
+directory (that contains a file *pyproject.toml*) using::
+
+	pip install --no-deps .
+
+The `--no-deps` option will ensure that only the pyearocom package is installed, preserving the conda environment.
+
+Alternatively, if you plan to apply local changes to the pyaerocom source code, you may install in
+editable mode (i.e. setuptools "develop mode") including the test dependencies::
+
+	pip install --no-deps -e .
+
+You may also download and extract (or clone) the `GitHub repo <https://github.com/metno/pyaerocom>`__
+to install the very latest (not yet released) version of pyaerocom. Note, if you install in develop
+mode, make sure you do not have pyaerocom installed already in the site packages directory,
+check e.g. `conda list pyaerocom`__ .
+
+
+Install from source into a default environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you want PyAerocom in your default installation of python, then you install the latest released version of pyaerocom and its depencencies:
+::
+
+	# install pyaerocom on machines with Proj8 or newer
+	# e.g. Ubuntu 22.04 LTS (Jammy Jellyfish)
+	python3 -m pip install pyaerocom
+
+This type of installation is no longer allowed on newer OS-installations, i.e. Ubuntu 24.04. Use the
+installation into a new virtual environment instead.


### PR DESCRIPTION
Added back installation to conda environments as needed for work on PPI and since it is linked from Contributions.
Updated list of pyaerocom-team, made alphabetic.
Highlighted tests, tox and pytest and on PPI.
