### PR TITLE
Read colocated files made outside of pyaerocom

### DIFF
--- a/pyaerocom/aeroval/experiment_processor.py
+++ b/pyaerocom/aeroval/experiment_processor.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import glob
 import logging
 
 from pyaerocom.aeroval._processing_base import HasColocator, ProcessingEngine
@@ -52,6 +53,18 @@ class ExperimentProcessor(ProcessingEngine, HasColocator):
                 f"marked to be used only as part of a superobs "
                 f"network"
             )
+        elif ocfg["only_json"]:
+            if not ocfg["coldata_dir"]:
+                raise Exception(
+                    f"No coldata_dir provided for an obs network for whcih only_json=True. The assumption of setting only_json=True is that colocated files already exist, and so a directory colcoation for these files must be provided."
+                )
+            else:
+                preprocessed_coldata_dir = ocfg["coldata_dir"]
+                mask = f"{preprocessed_coldata_dir}/*.nc"
+                files_to_convert = glob.glob(mask)
+                engine = ColdataToJsonEngine(self.cfg)
+                engine.run(files_to_convert)
+
         else:
             col = self.get_colocator(model_name, obs_name)
             if self.cfg.processing_opts.only_json:

--- a/pyaerocom/aeroval/experiment_processor.py
+++ b/pyaerocom/aeroval/experiment_processor.py
@@ -56,7 +56,7 @@ class ExperimentProcessor(ProcessingEngine, HasColocator):
         elif ocfg["only_json"]:
             if not ocfg["coldata_dir"]:
                 raise Exception(
-                    f"No coldata_dir provided for an obs network for whcih only_json=True. The assumption of setting only_json=True is that colocated files already exist, and so a directory colcoation for these files must be provided."
+                    f"No coldata_dir provided for an obs network for which only_json=True. The assumption of setting only_json=True is that colocated files already exist, and so a directory for these files must be provided."
                 )
             else:
                 preprocessed_coldata_dir = ocfg["coldata_dir"]

--- a/pyaerocom/aeroval/obsentry.py
+++ b/pyaerocom/aeroval/obsentry.py
@@ -49,6 +49,15 @@ class ObsEntry(BrowseDict):
     read_opts_ungridded : :obj:`dict`, optional
         dictionary that specifies reading constraints for ungridded reading
         (c.g. :class:`pyaerocom.io.ReadUngridded`).
+    only_json : bool
+        Only to be set if the obs entry already has colocated data files which were
+        preprocessed outside of pyaerocom. Setting to True will skip the colcoation
+        and just create the JSON output.
+    coldata_dir : str
+        Only to be set if the obs entry already has colocated data files which were
+        preprocessed outside of pyaerocom. This is the directory in which the
+        colocated data files are located.
+
     """
 
     SUPPORTED_VERT_CODES = ["Column", "Profile", "Surface"]  # , "2D"]
@@ -74,6 +83,9 @@ class ObsEntry(BrowseDict):
         self.profile_layer_limits = None
 
         self.read_opts_ungridded = {}
+        # attributes for reading colocated data files made outside of pyaerocom
+        self.only_json = False
+        self.coldata_dir = None
 
         self.update(**kwargs)
         self.check_cfg()


### PR DESCRIPTION
Close #857

The idea here this that while an entire experiment can be set up to only produce json files by setting `only_json=True`, a specific obs-network can not. In this approach, we define `only_json` and `coldata_dir` as keys in a obs config, and assuming both are provided, proceed with the standard `ColdataToJsonEngine` processing. Outside of pyaerocom, work will need to be done to take colocated data objects that partners provide, and convert them into a format (i.e., with appropriate metadata) that pyaerocom expects.