### PR TITLE
add Python 3.12 support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,34 +6,7 @@ on:
   - cron:  '0 12 1 * *'  # 12:00, first day of the month
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    env:
-      PYTHON: "3.10"
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python ${{ env.PYTHON }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ env.PYTHON }}
-    - name: Python info
-      run: |
-        which python
-        python --version
-    - name: Install system packages
-      run: |
-        sudo apt update
-        sudo apt install libudunits2-dev libgeos-dev libproj-dev proj-data proj-bin
-    - name: Install Tox
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox
-    - name: Check format
-      run: tox -e format
-    - name: Run linters
-      run: tox -e lint
-
-  docs:
+  lint-and-docs:
     runs-on: ubuntu-latest
     env:
       PYTHON: "3.10"
@@ -55,6 +28,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox
+    - name: Check format
+      run: tox -e format
+    - name: Run linters
+      run: tox -e lint
     - name: Build docs
       run: tox -e docs
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,13 +63,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
         experimental: [false]
         os: [ubuntu-22.04]
-        include:
-          - python-version: '3.12'
-            experimental: true
-            os: ubuntu-22.04
+        #include:
+        #  - python-version: '3.13'
+        #    experimental: true
+        #    os: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -106,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
         experimental: [false]
     defaults:
       run:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,7 +99,14 @@ jobs:
         python -m pip install tox
     - name: Run test
       continue-on-error: ${{ matrix.experimental }}
-      run: tox -e py
+      run: tox -e py -- --cov --no-cov-on-fail --cov-report xml
+    - name: Upload coverage to Codecov
+      if: ${{ success() }}
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+        flags: unittests
 
   conda:
     runs-on: ubuntu-latest
@@ -130,10 +137,3 @@ jobs:
     - name: Run pytest
       continue-on-error: ${{ matrix.experimental }}
       run: python -m pytest -ra -q --cov --no-cov-on-fail --cov-report xml
-    - name: Upload coverage to Codecov
-      if: ${{ success() }}
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
-        flags: unittests

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -110,20 +110,17 @@ jobs:
 
   conda:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.10', '3.11', '3.12']
-        experimental: [false]
+    env:
+      PYTHON: "3.11"
     defaults:
       run:
         shell: bash -l {0}
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ env.PYTHON }}
       uses: conda-incubator/setup-miniconda@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ env.PYTHON }}
         activate-environment: pya
         environment-file: pyaerocom_env.yml
     - name: Conda info
@@ -135,5 +132,4 @@ jobs:
     - name: Install pyaerocom
       run: python -m pip install . --no-deps
     - name: Run pytest
-      continue-on-error: ${{ matrix.experimental }}
       run: python -m pytest -ra -q --cov --no-cov-on-fail --cov-report xml

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ on:
   - cron:  '0 12 1 * *'  # 12:00, first day of the month
 
 jobs:
-  lint-and-docs:
+  lint-docs-package:
     runs-on: ubuntu-latest
     env:
       PYTHON: "3.10"
@@ -34,6 +34,8 @@ jobs:
       run: tox -e lint
     - name: Build docs
       run: tox -e docs
+    - name: Build package
+      run: tox -e build
 
   venv:
     runs-on: ${{ matrix.os }}

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -5,7 +5,7 @@ Helpers for conversion of ColocatedData to JSON files for web interface.
 import logging
 import os
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Literal
 
 import numpy as np
@@ -276,7 +276,7 @@ def _init_meta_glob(coldata, **kwargs):
         meta_glob["obs_revision"] = meta["revision_ref"]
     except KeyError:
         meta_glob["obs_revision"] = NDSTR
-    meta_glob["processed_utc"] = datetime.utcnow().strftime("%Y-%m-%d %H:%M")
+    meta_glob["processed_utc"] = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M")
     meta_glob.update(kwargs)
     return meta_glob
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
     "Operating System :: OS Independent",
     "Development Status :: 3 - Alpha",
@@ -30,8 +31,8 @@ dependencies = [
     "seaborn>=0.12.2",
     "dask",
     "geonum",
-    "LatLon23",             # required by geonum
-    "SRTM.py",              # required by geonum
+    "LatLon23",                       # required by geonum
+    "SRTM.py",                        # required by geonum
     "simplejson",
     "requests",
     "geocoder_reverse_natural_earth",
@@ -98,10 +99,7 @@ exclude = [
 minversion = "7.4"
 log_cli = false
 log_cli_level = "WARNING"
-addopts = [
-    "--failed-first",
-    "--import-mode=importlib",
-]
+addopts = ["--failed-first", "--import-mode=importlib"]
 xfail_strict = true
 testpaths = ["tests"]
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,7 @@ max-line-length = 99
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py310, py311, py312, format, lint, docs
+envlist = py310, py311, py312, format, lint, docs, build
 skip_missing_interpreters = True
 isolated_build = True
 requires =
@@ -226,4 +226,10 @@ commands =
     sphinx-build {posargs:-T} docs/ docs/_build/html
 extras =
     docs
+
+[testenv:build]
+commands =
+    python -m build
+deps =
+    build
 """


### PR DESCRIPTION
## Change Summary

This PR adds support for Python 3.12.
It does not addresses #1054 and #1050, those are the only tests that failing locally.

Additionally, this PR reduces the number of CI jobs by:
- testing conda install only on Python 3.11
- send code coverage to codecov from venv jobs
- combine lint and docs into a single job, and add package build step to combined job

## Related issue number

N/A

## Checklist

* [x] Start with a draft-PR
* [x] The pull request title is a good summary of the changes
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass first locally and then on CI
* [x] My PR is ready to review and I have selected a reviewer
