### PR TITLE
Better default ranges for bsc532aer and ec532aer visualization on Aeroval

### DIFF
--- a/pyaerocom/aeroval/glob_defaults.py
+++ b/pyaerocom/aeroval/glob_defaults.py
@@ -323,6 +323,14 @@ var_ranges_defaults = {
         "scale": [0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 5, 10, 20, 50, 100, 200],
         "colmap": "coolwarm",
     },
+    "bsc532aer": {
+        "scale": [0.0, 0.0005, 0.001, 0.0015, 0.002, 0.0025, 0.003, 0.0035, 0.004],
+        "colmap": "coolwarm",
+    },
+    "ec532aer": {
+        "scale": [0, 0.004, 0.008, 0.012, 0.016, 0.02, 0.04, 0.06, 0.08, 0.1, 0.2, 0.3, 0.4],
+        "colmap": "coolwarm",
+    },
 }
 
 #: Default information for statistical parameters


### PR DESCRIPTION
## Change Summary

New default ranges for bsc532aer and ec532aer for visualization on Aeroval.

## Related issue number

NA

## Checklist

* [x] Start with a draft-PR
* [x] The pull request title is a good summary of the changes
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass first locally and then on CI
* [ ] My PR is ready to review and I have selected a reviewer