### PR TITLE
Change the name of the statistic Mean Bias to MB on Aeroval

### DIFF
--- a/pyaerocom/aeroval/glob_defaults.py
+++ b/pyaerocom/aeroval/glob_defaults.py
@@ -354,7 +354,7 @@ statistics_defaults = {
         "forecast": True,
     },
     "mb": {
-        "name": "Mean Bias",
+        "name": "MB",
         "longname": "Mean Bias",
         "scale": [
             -0.15,


### PR DESCRIPTION
## Change Summary

For consistency reasons, Mean Bias should be named MB (Normalized Mean Bias is called NMB).

## Related issue number

close https://github.com/metno/AeroToolsIssues/issues/31

## Checklist

* [x] Start with a draft-PR
* [x] The pull request title is a good summary of the changes
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass first locally and then on CI
* [x] My PR is ready to review and I have selected a reviewer