### PR TITLE
Update api.rst

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -59,7 +59,7 @@ provided here:
    handlers=file
    qualname=pyaerocom.io.readungriddedbase
    level=DEBUG
-   propagate=1
+   propagate=0
 
 
 


### PR DESCRIPTION
propage=1 gives double log-entries in file for this class, suppressing propagation.

## Change Summary

Fix example in docs.
