### PR TITLE
Remove drop_stats and stat_decimals duplication

### DIFF
--- a/pyaerocom/aeroval/setupclasses.py
+++ b/pyaerocom/aeroval/setupclasses.py
@@ -139,6 +139,9 @@ class StatisticsSetup(ConstrainedContainer):
         setting drop_stats = ("mb", "mab"), results in json files in hm/ts with
         entries which do not contain the mean bias and mean absolute bias,
         but the other statistics are preserved.
+    stats_decimals: int, optional
+        If provided, overwrites the decimals key in glod_defaults for the statistics, which has a deault of 3.
+        Setting this higher of lower changes the number of decimals shown on the Aeroval webpage.
     round_floats_precision: int, optional
         Sets the precision argument for the function `pyaerocom.aaeroval.json_utils:set_float_serialization_precision`
 
@@ -249,8 +252,6 @@ class EvalRunOptions(ConstrainedContainer):
         #: If True, process only maps (skip obs evaluation)
         self.only_model_maps = False
         self.obs_only = False
-        self.drop_stats = ()
-        self.stats_decimals = None
         self.update(**kwargs)
 
 


### PR DESCRIPTION
## Change Summary

`drop_stats` and `stats_decimals` had incorrectly been placed in to `EvalRunOptions`. This PR removed them so that they only exist in `StatisticsSetup`

## Related issue number
NA

## Checklist

* [x] Start with a draft-PR
* [x] The pull request title is a good summary of the changes
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass first locally and then on CI
* [x] My PR is ready to review and I have selected a reviewer