### PR TITLE
Json write speedup by avoiding multiple float-conversions

### DIFF
--- a/pyaerocom/_lowlevel_helpers.py
+++ b/pyaerocom/_lowlevel_helpers.py
@@ -8,7 +8,6 @@ from collections.abc import MutableMapping
 from pathlib import Path
 
 import numpy as np
-import simplejson
 
 from pyaerocom._warnings import ignore_warnings
 

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -15,7 +15,7 @@ import xarray as xr
 from pyaerocom._warnings import ignore_warnings
 from pyaerocom.aeroval.fairmode_stats import fairmode_stats
 from pyaerocom.aeroval.helpers import _get_min_max_year_periods, _period_str_to_timeslice
-from pyaerocom.aeroval.json_utils import read_json, write_json
+from pyaerocom.aeroval.json_utils import read_json, round_floats, write_json
 from pyaerocom.colocateddata import ColocatedData
 from pyaerocom.config import ALL_REGION_NAME
 from pyaerocom.exceptions import (
@@ -78,8 +78,8 @@ def _write_stationdata_json(ts_data, out_dir):
         current = read_json(fp)
     else:
         current = {}
-    current[ts_data["model_name"]] = ts_data
-    write_json(current, fp, ignore_nan=True)
+    current[ts_data["model_name"]] = round_floats(ts_data)
+    write_json(current, fp, round_floats=False)
 
 
 def _write_site_data(ts_objs, dirloc):
@@ -120,8 +120,8 @@ def _write_diurnal_week_stationdata_json(ts_data, out_dirs):
         current = read_json(fp)
     else:
         current = {}
-    current[ts_data["model_name"]] = ts_data
-    write_json(current, fp, ignore_nan=True)
+    current[ts_data["model_name"]] = round_floats(ts_data)
+    write_json(current, fp, round_floats=False)
 
 
 def _add_heatmap_entry_json(
@@ -143,8 +143,8 @@ def _add_heatmap_entry_json(
     if not model_name in ovc:
         ovc[model_name] = {}
     mn = ovc[model_name]
-    mn[model_var] = result
-    write_json(current, heatmap_file, ignore_nan=True)
+    mn[model_var] = round_floats(result)
+    write_json(current, heatmap_file, round_floats=False)
 
 
 def _prepare_regions_json_helper(region_ids):
@@ -239,8 +239,8 @@ def update_regions_json(region_defs, regions_json):
 
     for region_name, region_info in region_defs.items():
         if not region_name in current:
-            current[region_name] = region_info
-    write_json(current, regions_json)
+            current[region_name] = round_floats(region_info)
+    write_json(current, regions_json, round_floats=False)
     return current
 
 
@@ -1587,5 +1587,5 @@ def add_profile_entry_json(
                 "z_long_description": "Altitude Above Sea Level",
                 "unit": coldata.unitstr,
             }
-
-    write_json(current, profile_file, ignore_nan=True)
+        current[model_name] = round_floats(current[model_name])
+    write_json(current, profile_file, round_floats=False)

--- a/pyaerocom/aeroval/json_utils.py
+++ b/pyaerocom/aeroval/json_utils.py
@@ -82,10 +82,13 @@ def write_json(data_dict, file_path, **kwargs):
         additional keyword args, e.g.
         indent=int
         (ignore_nan, forced to True)
+        round_floats=True/False round floating numbers, default True
     """
     kwargs.update(ignore_nan=True)
+    if kwargs.pop("round_floats", True):
+        data_dict = round_floats(in_data=data_dict)
     with open(file_path, "w") as f:
-        simplejson.dump(round_floats(in_data=data_dict), f, allow_nan=True, **kwargs)
+        simplejson.dump(data_dict, f, allow_nan=True, **kwargs)
 
 
 def check_make_json(fp, indent=4):

--- a/pyaerocom/aeroval/json_utils.py
+++ b/pyaerocom/aeroval/json_utils.py
@@ -79,8 +79,9 @@ def write_json(data_dict, file_path, **kwargs):
     file_path : str
         output file path
     **kwargs
-        additional keyword args passed to :func:`simplejson.dumps` (e.g.
-        indent, )
+        additional keyword args, e.g.
+        indent=int
+        (ignore_nan, forced to True)
     """
     kwargs.update(ignore_nan=True)
     with open(file_path, "w") as f:


### PR DESCRIPTION
## Change Summary

Avoid rounding floats on previously written and rounded data. This speeds up CAMS2_83 daily evaluation by ~20%.
Tests on using different json-libraries didn't gave any huge change (5%). This is a short term fix.

Long-term plans could be handling all writes by a database-class, avoiding re-reading of json files.
Long-term plans should also be dropping of rounding on write - rounding should be done at the data-level where accuracy is known, not at write-level.

## Related issue number

#959 is related, performance of json writing
#1074 This is also related to the CAMS2_83 code merging, which is currently blocked by performance issues


## Checklist

* [x] Start with a draft-PR
* [x] The pull request title is a good summary of the changes
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass first locally
* [x]  Tests pass on CI
* [x] My PR is ready to review and I have selected a reviewer