### PR TITLE
3.12 tests moved to ubuntu 24.04 and disabled; PR-checklist updated

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,9 +9,12 @@
 
 ## Checklist
 
+* [ ] Tests pass locally
+* [ ] Tests for the changes exist where applicable
 * [ ] Start with a draft-PR
 * [ ] The pull request title is a good summary of the changes
+* [ ] PR is set to AeroTools and milestone
 * [ ] Documentation reflects the changes where applicable
-* [ ] Tests for the changes exist where applicable
-* [ ] Tests pass first locally and then on CI
-* [ ] My PR is ready to review and I have selected a reviewer
+* [ ] Tests pass on CI
+* [ ] At least 1 reviewer is selected
+* [ ] My PR is ready to review

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,9 +42,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11']
         experimental: [false]
         os: [ubuntu-22.04]
+        include:
+          - python-version: '3.12'
+            experimental: false
+            os: ubuntu-24.04
         #include:
         #  - python-version: '3.13'
         #    experimental: true

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,10 +45,10 @@ jobs:
         python-version: ['3.10', '3.11']
         experimental: [false]
         os: [ubuntu-22.04]
-        include:
-          - python-version: '3.12'
-            experimental: false
-            os: ubuntu-24.04
+        # include:
+        #   - python-version: '3.12'
+        #     experimental: false
+        #     os: ubuntu-24.04
         #include:
         #  - python-version: '3.13'
         #    experimental: true


### PR DESCRIPTION
## Change Summary

3.12 tests on ubuntu 22.04 are twice as slow as others. Moving therefore 3.12 tests to ubuntu 24.04 and disabling 24.04 since those tests are queued too long.

## Related issue number

closes #1076 

## Checklist

* [x] Start with a draft-PR
* [x] The pull request title is a good summary of the changes
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass first locally and then on CI
* [x] My PR is ready to review and I have selected a reviewer