### PR TITLE
Fix pip cache on CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,7 +71,7 @@ jobs:
           ~/.cache/pip
           ~/.cache/srtm
           .tox
-        key: ${{ matrix.os }}-tox-${{ matrix.python-version }}-${{ hashFiles('setup.cfg', 'pyproject.toml') }}
+        key: ${{ matrix.os }}-tox-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
     - name: Install Tox
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,31 +55,18 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Python info
-      run: |
-        which python
-        python --version
+        cache: 'pip' # caching pip dependencies
     - name: Install system packages
       run: |
         sudo apt update
         sudo apt install libudunits2-dev libgeos-dev libproj-dev proj-data proj-bin
-    - name: Cache pip and tox
-      uses: actions/cache@v4
-      if: ${{ ! matrix.experimental }}
-      with:
-        path: |
-          ~/.cache/pip
-          ~/.cache/srtm
-          .tox
-        key: ${{ matrix.os }}-tox-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
     - name: Install Tox
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox
     - name: Tox environment
-      continue-on-error: ${{ matrix.experimental }}
-      run: tox -e py --notest 
-    - name: Run test
+      run: tox -e py --notest
+    - name: Run tests
       continue-on-error: ${{ matrix.experimental }}
       run: tox -e py -- --cov --no-cov-on-fail --cov-report xml
     - name: Upload coverage to Codecov

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,12 +60,11 @@ jobs:
       run: |
         sudo apt update
         sudo apt install libudunits2-dev libgeos-dev libproj-dev proj-data proj-bin
-    - name: Install Tox
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install tox
     - name: Tox environment
-      run: tox -e py --notest
+      run: |
+        pip install --upgrade pip
+        pip install tox
+        tox -e py --notest
     - name: Run tests
       continue-on-error: ${{ matrix.experimental }}
       run: tox -e py -- --cov --no-cov-on-fail --cov-report xml

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,6 +76,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install tox
+    - name: Tox environment
+      continue-on-error: ${{ matrix.experimental }}
+      run: tox -e py --notest 
     - name: Run test
       continue-on-error: ${{ matrix.experimental }}
       run: tox -e py -- --cov --no-cov-on-fail --cov-report xml

--- a/pyaerocom/io/readungridded.py
+++ b/pyaerocom/io/readungridded.py
@@ -885,14 +885,3 @@ class ReadUngridded:
 
     def __str__(self):
         return "\n".join(str(self.get_lowlevel_reader(ds)) for ds in self.data_ids)
-
-    def __str__(self):
-        return "\n".join(str(self.get_lowlevel_reader(ds)) for ds in self.data_ids)
-        return "\n".join(str(self.get_lowlevel_reader(ds)) for ds in self.data_ids)
-
-    def __str__(self):
-        return "\n".join(str(self.get_lowlevel_reader(ds)) for ds in self.data_ids)
-        return "\n".join(str(self.get_lowlevel_reader(ds)) for ds in self.data_ids)
-
-    def __str__(self):
-        return "\n".join(str(self.get_lowlevel_reader(ds)) for ds in self.data_ids)


### PR DESCRIPTION
## Change Summary

cache `pip` packages so CI tests for Python 3.12 take the same time as other versions of Python

## Related issue number

close #1076

## Checklist

* [X] Start with a draft-PR
* [X] The pull request title is a good summary of the changes
* [X] Documentation reflects the changes where applicable
* [X] Tests for the changes exist where applicable
* [x] Tests pass first locally and then on CI
* [x] My PR is ready to review and I have selected a reviewer