### PR TITLE
fix Pydantic DeprecationWarning

### DIFF
--- a/pyaerocom/io/pyaro/pyaro_config.py
+++ b/pyaerocom/io/pyaro/pyaro_config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import ClassVar, Optional
 
 import yaml
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 import pyaerocom as pya
 
@@ -14,12 +14,11 @@ logger = logging.getLogger(__name__)
 
 
 class PyaroConfig(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     _DEFAULT_CATALOG: ClassVar[Path] = resources.files(pya) / Path(
         "data/pyaro_catalogs/default.yaml"
     )
-
-    class Config:
-        arbitrary_types_allowed = True
 
     ##########################
     #   Model fields


### PR DESCRIPTION
## Change Summary

fix pydanting deprecation warning
```
PydanticDeprecatedSince20: Support for class-based `config` is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.6/migration/
```

as described on the [docs](https://docs.pydantic.dev/2.6/api/config/#pydantic.config.ConfigDict.arbitrary_types_allowed)

## Related issue number

None

## Checklist

* [X] Start with a draft-PR
* [X] The pull request title is a good summary of the changes
* [X] Documentation reflects the changes where applicable
* [X] Tests for the changes exist where applicable
* [x] Tests pass first locally and then on CI
* [x] My PR is ready to review and I have selected a reviewer