### PR TITLE
save memory by using hdf5-reader; avoid double reading during file-ch…

### DIFF
--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -205,7 +205,6 @@ def check_files(paths: list[Path]) -> list[Path]:
     new_paths: list[Path] = []
 
     for p in tqdm(paths, disable=const.QUIET):
-
         try:
             with xr.open_dataset(p) as ds:
                 if len(ds.time.data) < 2:

--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -191,7 +191,10 @@ def read_dataset(paths: list[Path], *, day: int) -> xr.Dataset:
     def preprocess(ds: xr.Dataset) -> xr.Dataset:
         return ds.pipe(forecast_day, day=day).pipe(fix_missing_vars)
 
-    ds = xr.open_mfdataset(paths, preprocess=preprocess, parallel=False)
+    # h5 chunk cache is 1 MB, netcdf4 chunk-cache is 64MB
+    # using h5netcdf saves therefore up to 63MB/file
+    # in our case only ~20MB/file, i.e. 0.5GB/month
+    ds = xr.open_mfdataset(paths, preprocess=preprocess, parallel=False, engine="h5netcdf")
     return ds.pipe(fix_coord).pipe(fix_names)
 
 
@@ -202,40 +205,22 @@ def check_files(paths: list[Path]) -> list[Path]:
     new_paths: list[Path] = []
 
     for p in tqdm(paths, disable=const.QUIET):
-        import signal
-
-        command = ["python", "-c", f"from netCDF4 import Dataset; Dataset('{p}')"]
-        # command = ["python", "-c", f"import xarray as xr; xr.open_dataset('{p}')"]
-        # command = ["python", "-c", f"import signal; import os; signal.raise_signal(signal.SIGSEGV) "]
-        # command = ["python", "--version"]
-
-        output = subprocess.run(command, capture_output=True)
-        # print(str(output))
-        if output.returncode == -signal.SIGSEGV or "NetCDF: HDF error" in str(output.stderr):
-            logger.warning(f"Error when opening {p}. Skipping file")
-            continue
 
         try:
-            ds = xr.open_dataset(p)
-            if len(ds.time.data) < 2:
-                logger.warning(f"To few timestamps in {p}. Skipping file")
-                continue
-            # nb_vars = len([i for i in ds.data_vars])
-            # if nb_vars < 6:
-            #     logger.warning(f"Found only {nb_vars} variables for {p}. Skipping file")
-            #     continue
-
-            if len(set(np.array(ds.time))) != len(np.array(ds.time)):
-                if len(np.array(ds.time)) != 24:
-                    logger.warning(
-                        f"Ambiguous time dimension: Duplicate timestamps in {p}, with less that 24 step. Skipping file"
-                    )
+            with xr.open_dataset(p) as ds:
+                if len(ds.time.data) < 2:
+                    logger.warning(f"To few timestamps in {p}. Skipping file")
                     continue
+                if len(set(np.array(ds.time))) != len(np.array(ds.time)):
+                    if len(np.array(ds.time)) != 24:
+                        logger.warning(
+                            f"Ambiguous time dimension: Duplicate timestamps in {p}, with less that 24 step. Skipping file"
+                        )
+                        continue
 
             new_paths.append(p)
-            ds.close()
-        except OSError:
-            logger.warning(f"Error when opening {p}. Skipping file")
+        except Exception as ex:
+            logger.warning(f"Error when opening {p}: {ex}. Skipping file")
 
     return new_paths
 

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - iris >=3.6.0, <3.8.0
   - xarray <=2022.10.0
+  - h5netcdf >1.0.0
   - cartopy >=0.21.1
   - matplotlib-base >=3.7.1
   - scipy >=1.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ requires-python = ">=3.10"
 dependencies = [
     "scitools-iris>=3.6.0, <3.8",
     "xarray<=2022.10.0",
+    "h5netcdf>=1.0.0",               # xarray backend, no chunk-cache
     "cartopy>=0.21.1",
     "matplotlib>=3.7.1",
     "scipy>=1.10.1",


### PR DESCRIPTION
## Change Summary

Use h5netcdf to remove memory consumption. The underlying netcdf4 library uses a 64MB hdf5-chunk-cache per opened file, while the hdf5 library only uses a chunk-cache 1MB. We don't re-read data, so the hdf5-chunk-cache is not needed. This saves e.g. about 0.5G on 31 files with daily hourly data (a complete variable is cached with netcdf4).

Remove double checks of corrupt files. This test is only needed with corrupt hdf5-libraries - and those should be addressed elsewhere. Most likely the tests where included to avoid to much memory usage causing hdf5-errors (and thus gave the wrong result.) Opening a small netcdf-file in an external process takes about as long as reading one variable, so this decreases the read-time to about 1/3.

## Related issue number

#1074 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
