### PR TITLE
Fix Pydantic namespace conflict in StatisticSetup

### DIFF
--- a/pyaerocom/aeroval/setupclasses.py
+++ b/pyaerocom/aeroval/setupclasses.py
@@ -163,6 +163,10 @@ class StatisticsSetup(BaseModel, extra="allow"):
 
     """
 
+    # Pydantic ConfigDict
+    model_config = ConfigDict()
+    model_config["protected_namespaces"] = ()
+    # StatisticsSetup attributes
     MIN_NUM: PositiveInt = 1
     weighted_stats: bool = True
     annual_stats_constrained: bool = False

--- a/pyaerocom/aeroval/setupclasses.py
+++ b/pyaerocom/aeroval/setupclasses.py
@@ -164,8 +164,7 @@ class StatisticsSetup(BaseModel, extra="allow"):
     """
 
     # Pydantic ConfigDict
-    model_config = ConfigDict()
-    model_config["protected_namespaces"] = ()
+    model_config = ConfigDict(protected_namespaces=())
     # StatisticsSetup attributes
     MIN_NUM: PositiveInt = 1
     weighted_stats: bool = True
@@ -229,8 +228,7 @@ class TimeSetup(BaseModel):
 
 class WebDisplaySetup(BaseModel):
     # Pydantic ConfigDict
-    model_config = ConfigDict()
-    model_config["protected_namespaces"] = ()
+    model_config = ConfigDict(protected_namespaces=())
     # WebDisplaySetup attributes
     map_zoom: Literal["World", "Europe", "xEMEP"] = "World"
     regions_how: Literal["default", "aerocom", "htap", "country"] = "default"


### PR DESCRIPTION
## Change Summary

`StatisticsSetup` had a namespace conflict which was giving a warning on the command line. This PR implements Pydantic's suggested fix.

```console
(pya) lewisb@pc5654:~/Projects/pyaerocom$ pya --version
/home/lewisb/miniconda3/envs/pya/lib/python3.11/site-packages/pydantic/_internal/_fields.py:151: UserWarning: Field "model_only_stats" has conflict with protected namespace "model_".

You may be able to resolve this warning by setting `model_config['protected_namespaces'] = ()`.
  warnings.warn(
🦄 pyaerocom 0.16.0
```

## Related issue number

NA

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
