### PR TITLE
add dask-chunks to limit memory-consumption

### DIFF
--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -194,7 +194,9 @@ def read_dataset(paths: list[Path], *, day: int) -> xr.Dataset:
     # h5 chunk cache is 1 MB, netcdf4 chunk-cache is 64MB
     # using h5netcdf saves therefore up to 63MB/file
     # in our case only ~20MB/file, i.e. 0.5GB/month
-    ds = xr.open_mfdataset(paths, preprocess=preprocess, parallel=False, engine="h5netcdf")
+    ds = xr.open_mfdataset(
+        paths, preprocess=preprocess, parallel=False, engine="h5netcdf", chunks={"time": 1}
+    )
     return ds.pipe(fix_coord).pipe(fix_names)
 
 


### PR DESCRIPTION
## Change Summary

All cams2_83 models have the time-dimension as unlimited dimension, meaning all reading should be done one time-slice at a time. Dask-lazy reading of the data reads by default all data into memory. This PR changes the default dask chunk-strategy to match the cams2_83 model data-layout and reduces the memory consumption for one year of hourly data by a huge factor. (Tested reading for 1 month to go from 1.5G to 0.5G.)

## Related issue number

#1074 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
