### PR TITLE
Move AerovalConfigError and AerovalTrendsError to aeroval/exceptions.py

### DIFF
--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -30,8 +30,9 @@ from pyaerocom.aeroval.coldatatojson_helpers import (
     process_profile_data_for_stations,
     update_regions_json,
 )
+from pyaerocom.aeroval.exceptions import ConfigError
 from pyaerocom.aeroval.json_utils import write_json
-from pyaerocom.exceptions import AeroValConfigError, TemporalResolutionError
+from pyaerocom.exceptions import TemporalResolutionError
 
 logger = logging.getLogger(__name__)
 

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -13,17 +13,13 @@ import pandas as pd
 import xarray as xr
 
 from pyaerocom._warnings import ignore_warnings
+from pyaerocom.aeroval.exceptions import ConfigError, TrendsError
 from pyaerocom.aeroval.fairmode_stats import fairmode_stats
 from pyaerocom.aeroval.helpers import _get_min_max_year_periods, _period_str_to_timeslice
 from pyaerocom.aeroval.json_utils import read_json, round_floats, write_json
 from pyaerocom.colocateddata import ColocatedData
 from pyaerocom.config import ALL_REGION_NAME
-from pyaerocom.exceptions import (
-    AeroValConfigError,
-    AeroValTrendsError,
-    DataCoverageError,
-    TemporalResolutionError,
-)
+from pyaerocom.exceptions import DataCoverageError, TemporalResolutionError
 from pyaerocom.helpers import start_stop
 from pyaerocom.mathutils import _init_stats_dummy, calc_statistics
 from pyaerocom.region import Region, find_closest_region_coord, get_all_default_region_ids
@@ -732,7 +728,7 @@ def _make_trends_from_timeseries(obs, mod, freq, season, start, stop, min_yrs):
 
     Raises
     ------
-    AeroValTrendsError
+    TrendsError
         If stop - start is smaller than min_yrs
 
     AeroValError
@@ -745,7 +741,7 @@ def _make_trends_from_timeseries(obs, mod, freq, season, start, stop, min_yrs):
     """
 
     if stop - start < min_yrs:
-        raise AeroValTrendsError(f"min_yrs ({min_yrs}) larger than time between start and stop")
+        raise TrendsError(f"min_yrs ({min_yrs}) larger than time between start and stop")
 
     te = TrendsEngine
 
@@ -762,7 +758,7 @@ def _make_trends_from_timeseries(obs, mod, freq, season, start, stop, min_yrs):
 
     # Makes pd.Series serializable
     if obs_trend["data"] is None or mod_trend["data"] is None:
-        raise AeroValTrendsError("Trends came back as None", obs_trend["data"], mod_trend["data"])
+        raise TrendsError("Trends came back as None", obs_trend["data"], mod_trend["data"])
 
     obs_trend["data"] = obs_trend["data"].to_json()
     mod_trend["data"] = mod_trend["data"].to_json()
@@ -799,7 +795,7 @@ def _make_trends(obs_vals, mod_vals, time, freq, season, start, stop, min_yrs):
 
     Raises
     ------
-    AeroValTrendsError
+    TrendsError
         If stop - start is smaller than min_yrs
 
     AeroValError
@@ -889,7 +885,7 @@ def _process_map_and_scat(
                                     stats["obs_trend"] = obs_trend
                                     stats["mod_trend"] = mod_trend
 
-                                except AeroValTrendsError as e:
+                                except TrendsError as e:
                                     msg = f"Failed to calculate trends, and will skip. This was due to {e}"
                                     logger.warning(msg)
 
@@ -986,7 +982,7 @@ def _apply_annual_constraint(data):
 
     Raises
     ------
-    AeroValConfigError
+    ConfigError
         If colocated data in yearly resolution is not available in input data
 
     Returns
@@ -997,7 +993,7 @@ def _apply_annual_constraint(data):
     """
     output = {}
     if not "yearly" in data or data["yearly"] is None:
-        raise AeroValConfigError(
+        raise ConfigError(
             "Cannot apply annual_stats_constrained option. "
             'Please add "yearly" in your setup (see attribute '
             '"statistics_json" in AerocomEvaluation class)'
@@ -1170,7 +1166,7 @@ def _process_heatmap_data(
                                         )
 
                                         trends_successful = True
-                                    except AeroValTrendsError as e:
+                                    except TrendsError as e:
                                         msg = f"Failed to calculate trends, and will skip. This was due to {e}"
                                         logger.warning(msg)
 

--- a/pyaerocom/aeroval/exceptions.py
+++ b/pyaerocom/aeroval/exceptions.py
@@ -1,0 +1,6 @@
+class ConfigError(ValueError):
+    pass
+
+
+class TrendsError(ValueError):
+    pass

--- a/pyaerocom/aeroval/setupclasses.py
+++ b/pyaerocom/aeroval/setupclasses.py
@@ -23,10 +23,10 @@ from pydantic import (
 from pyaerocom import __version__, const
 from pyaerocom.aeroval.aux_io_helpers import ReadAuxHandler
 from pyaerocom.aeroval.collections import ModelCollection, ObsCollection
+from pyaerocom.aeroval.exceptions import ConfigError
 from pyaerocom.aeroval.helpers import _check_statistics_periods, _get_min_max_year_periods
 from pyaerocom.aeroval.json_utils import read_json, set_float_serialization_precision, write_json
 from pyaerocom.colocation_auto import ColocationSetup
-from pyaerocom.exceptions import AeroValConfigError
 
 logger = logging.getLogger(__name__)
 
@@ -518,7 +518,7 @@ class EvalSetup(BaseModel):
 
         if len(periods) == 0:
             if colstart is None:
-                raise AeroValConfigError("Either periods or start must be set...")
+                raise ConfigError("Either periods or start must be set...")
             per = self.colocation_opts._period_from_start_stop()
             periods = [per]
             logger.info(

--- a/pyaerocom/exceptions.py
+++ b/pyaerocom/exceptions.py
@@ -8,14 +8,6 @@ class AeronetReadError(IOError):
     pass
 
 
-class AeroValConfigError(ValueError):
-    pass
-
-
-class AeroValTrendsError(ValueError):
-    pass
-
-
 class CachingError(IOError):
     pass
 

--- a/tests/aeroval/test_coldatatojson_helpers2.py
+++ b/tests/aeroval/test_coldatatojson_helpers2.py
@@ -244,7 +244,7 @@ def test__make_trends(
             "yearly",
             "all",
             7,
-            AeroValTrendsError,
+            TrendsError,
             "min_yrs (7) larger than time between start and stop",
             id="wrong min_yrs",
         ),

--- a/tests/aeroval/test_coldatatojson_helpers2.py
+++ b/tests/aeroval/test_coldatatojson_helpers2.py
@@ -21,7 +21,8 @@ from pyaerocom.aeroval.coldatatojson_helpers import (
     get_stationfile_name,
     get_timeseries_file_name,
 )
-from pyaerocom.exceptions import AeroValTrendsError, TemporalResolutionError, UnknownRegion
+from pyaerocom.aeroval.exceptions import TrendsError
+from pyaerocom.exceptions import TemporalResolutionError, UnknownRegion
 from tests.fixtures.collocated_data import COLDATA
 
 


### PR DESCRIPTION
## Change Summary

Moves AerovalConfigError and AerovalTrendsError to aeroval/exceptions.py

## Related issue number

#1084 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally (see #1091)
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
