### PR TITLE
Temporary fix for test_etopo_altitude

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,7 @@ dependencies = [
     "numpy>=1.24.3",
     "seaborn>=0.12.2",
     "dask",
-    "geonum",
-    "LatLon23",                       # required by geonum
-    "SRTM.py",                        # required by geonum
+    "geonum @ git+https://github.com/jgliss/geonum.git",  # https://github.com/jgliss/geonum/issues/26
     "simplejson",
     "requests",
     "geocoder_reverse_natural_earth",


### PR DESCRIPTION
## Change Summary

A temporary fix for the broken `test_etopo_altitude` test. The problem is that the current release of geonum overrides a provided data directory with it's own default dir (see comment [here](https://github.com/metno/pyaerocom/issues/1050#issuecomment-2039629724)). This is fixed by pulling the current release from github in `pyproject.toml` directly (where it has already been fixed).

Should be revisited once a new release is released on pypi: https://github.com/jgliss/geonum/issues/26

## Related issue number

#1050 

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
