### PR TITLE
Put other inputs from EvalSetup in ExperimentInfo

### DIFF
--- a/pyaerocom/aeroval/setupclasses.py
+++ b/pyaerocom/aeroval/setupclasses.py
@@ -300,12 +300,19 @@ class EvalSetup(BaseModel):
     @computed_field
     @cached_property
     def proj_info(self) -> ProjectInfo:
-        return ProjectInfo(proj_id=self.proj_id)
+        return ProjectInfo(
+            proj_id=self.proj_id
+        )  # special case because ProjectInfo only has one attrbibute proj_id which is required by EvalSetup
 
     @computed_field
     @cached_property
     def exp_info(self) -> ExperimentInfo:
-        return ExperimentInfo(exp_id=self.exp_id)
+        if not hasattr(self, "model_extra"):
+            return ExperimentInfo(exp_id=self.exp_id)
+        model_args = {
+            key: val for key, val in self.model_extra.items() if key in ExperimentInfo.model_fields
+        }
+        return ExperimentInfo(**model_args)
 
     @cached_property
     def json_filename(self) -> str:
@@ -330,9 +337,9 @@ class EvalSetup(BaseModel):
         }
         return OutputPaths(proj_id=self.proj_id, exp_id=self.exp_id, **model_args)
 
-    # This is a hack to get keys from a general CFG into their appropriate respective classes
+    # Many computed_fields here have this hack to get keys from a general CFG into their appropriate respective classes
     # TODO: all these computed fields could be more easily defined if the config were
-    # rigid enough to have they explicitly defined (e.g., in a TOML file), rather than dumping everything
+    # rigid enough to have them explicitly defined (e.g., in a TOML file), rather than dumping everything
     # into one large config dict and then dishing out the relevant parts to each class.
     @computed_field
     @cached_property

--- a/pyaerocom/aeroval/setupclasses.py
+++ b/pyaerocom/aeroval/setupclasses.py
@@ -312,6 +312,7 @@ class EvalSetup(BaseModel):
         model_args = {
             key: val for key, val in self.model_extra.items() if key in ExperimentInfo.model_fields
         }
+        model_args["exp_id"] = self.exp_id
         return ExperimentInfo(**model_args)
 
     @cached_property


### PR DESCRIPTION
## Change Summary

`ExperimentInfo` now has the same "hack" as the other `computed_field`s to get keys from a general config dict into this class. Previously was just returning the default values. 

## Related issue number

NA. Personal communication with @charlienegri in the pyaerocom chat.

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
