### PR TITLE
Use dev release of Geonum instead of Github

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
     "numpy>=1.24.3",
     "seaborn>=0.12.2",
     "dask",
+    "LatLon23",
+    "SRTM.py",
     "geonum==1.5.0.dev9",  # https://github.com/jgliss/geonum/issues/26
     "simplejson",
     "requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "numpy>=1.24.3",
     "seaborn>=0.12.2",
     "dask",
-    "geonum @ git+https://github.com/jgliss/geonum.git",  # https://github.com/jgliss/geonum/issues/26
+    "geonum==1.5.0.dev9",  # https://github.com/jgliss/geonum/issues/26
     "simplejson",
     "requests",
     "geocoder_reverse_natural_earth",


### PR DESCRIPTION
## Change Summary

We previously changed the Geonum to pull from Github as a fix for a broken test (#1050). There is a dev release on Pypi which incorporates the required fix (https://pypi.org/project/geonum/#history) which I think is better to use than Github. 

## Related issue number
NA

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
