### PR TITLE
Fix test_Config_read_config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -113,26 +113,24 @@ def test_Config_has_access_users_database():
 
 
 @pytest.mark.parametrize(
-    "cfg_id,basedir,init_obslocs_ungridded,init_data_search_dirs,data_searchdirno",
+    "cfg_id,basedir,init_obslocs_ungridded,init_data_search_dirs",
     [
-        ("metno", None, False, False, 0),
-        ("metno", None, True, False, 0),
-        ("metno", None, True, True, 0),
-        ("metno", f"/home/{USER}", True, True, 2),
-        ("users-db", None, False, False, 0),
+        ("metno", None, False, False),
+        ("metno", None, True, False),
+        ("metno", None, True, True),
+        ("metno", f"/home/{USER}", True, True),
+        ("users-db", None, False, False),
     ],
 )
-def test_Config_read_config(
-    cfg_id, basedir, init_obslocs_ungridded, init_data_search_dirs, data_searchdirno
-):
+def test_Config_read_config(cfg_id, basedir, init_obslocs_ungridded, init_data_search_dirs):
     cfg = testmod.Config(try_infer_environment=False)
     cfg_file = cfg._config_files[cfg_id]
     assert Path(cfg_file).exists()
     cfg.read_config(cfg_file, basedir, init_obslocs_ungridded, init_data_search_dirs)
     if not cfg.has_access_lustre:
         pytest.skip(f"Skipping since {cfg._LUSTRE_CHECK_PATH} directory not accessible")
-    assert len(cfg.DATA_SEARCH_DIRS) == data_searchdirno
-    assert len(cfg.OBSLOCS_UNGRIDDED) == 0
+    assert all([Path(idir).exists() for idir in cfg.DATA_SEARCH_DIRS])
+    assert cfg.OBSLOCS_UNGRIDDED
     assert Path(cfg.OUTPUTDIR).exists()
     assert Path(cfg.COLOCATEDDATADIR).exists()
     assert Path(cfg.CACHEDIR).exists()


### PR DESCRIPTION
## Change Summary

This test was checking to see that the correct number of paths existed on lustre, but the code is not responsible for whether these paths exists - they can be deleted at anytime. A commented has been shared in the chat that those responsible for these data should submit PRs updating the paths in `paths.ini`

## Related issue number

Close #1054

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
