### PR TITLE
Implement tests for EvalSetup component classes.

### DIFF
--- a/pyaerocom/aeroval/setupclasses.py
+++ b/pyaerocom/aeroval/setupclasses.py
@@ -307,7 +307,7 @@ class EvalSetup(BaseModel):
     @computed_field
     @cached_property
     def exp_info(self) -> ExperimentInfo:
-        if not hasattr(self, "model_extra"):
+        if not hasattr(self, "model_extra") or self.model_extra is None:
             return ExperimentInfo(exp_id=self.exp_id)
         model_args = {
             key: val for key, val in self.model_extra.items() if key in ExperimentInfo.model_fields
@@ -331,7 +331,7 @@ class EvalSetup(BaseModel):
     @computed_field
     @cached_property
     def path_manager(self) -> OutputPaths:
-        if not hasattr(self, "model_extra"):
+        if not hasattr(self, "model_extra") or self.model_extra is None:
             return OutputPaths(proj_id=self.proj_id, exp_id=self.exp_id)
         model_args = {
             key: val for key, val in self.model_extra.items() if key in OutputPaths.model_fields
@@ -345,7 +345,7 @@ class EvalSetup(BaseModel):
     @computed_field
     @cached_property
     def time_cfg(self) -> TimeSetup:
-        if not hasattr(self, "model_extra"):
+        if not hasattr(self, "model_extra") or self.model_extra is None:
             return TimeSetup()
         model_args = {
             key: val for key, val in self.model_extra.items() if key in TimeSetup.model_fields
@@ -355,7 +355,7 @@ class EvalSetup(BaseModel):
     @computed_field
     @cached_property
     def modelmaps_opts(self) -> ModelMapsSetup:
-        if not hasattr(self, "model_extra"):
+        if not hasattr(self, "model_extra") or self.model_extra is None:
             return ModelMapsSetup()
         model_args = {
             key: val for key, val in self.model_extra.items() if key in ModelMapsSetup.model_fields
@@ -365,7 +365,7 @@ class EvalSetup(BaseModel):
     @computed_field
     @cached_property
     def webdisp_opts(self) -> WebDisplaySetup:
-        if not hasattr(self, "model_extra"):
+        if not hasattr(self, "model_extra") or self.model_extra is None:
             return WebDisplaySetup()
         model_args = {
             key: val
@@ -377,7 +377,7 @@ class EvalSetup(BaseModel):
     @computed_field
     @cached_property
     def processing_opts(self) -> EvalRunOptions:
-        if not hasattr(self, "model_extra"):
+        if not hasattr(self, "model_extra") or self.model_extra is None:
             return EvalRunOptions()
         model_args = {
             key: val for key, val in self.model_extra.items() if key in EvalRunOptions.model_fields
@@ -387,7 +387,7 @@ class EvalSetup(BaseModel):
     @computed_field
     @cached_property
     def statistics_opts(self) -> StatisticsSetup:
-        if not hasattr(self, "model_extra"):
+        if not hasattr(self, "model_extra") or self.model_extra is None:
             return StatisticsSetup(weighted_stats=True, annual_stats_constrained=False)
         model_args = {
             key: val
@@ -406,7 +406,7 @@ class EvalSetup(BaseModel):
     @computed_field
     @cached_property
     def colocation_opts(self) -> ColocationSetup:
-        if not hasattr(self, "model_extra"):
+        if not hasattr(self, "model_extra") or self.model_extra is None:
             return ColocationSetup(save_coldata=True, keep_data=False, resample_how="mean")
 
         model_args = {

--- a/tests/aeroval/test_setupclasses.py
+++ b/tests/aeroval/test_setupclasses.py
@@ -59,12 +59,29 @@ def test_EvalSetup_INVALID_ENTRY_NAMES(cfg_exp1: dict, error: str):
     assert error in str(e.value)
 
 
-@default_config
+@pytest.mark.parametrize(
+    "update", (pytest.param(None, id="defaults"), pytest.param(dict(proj_id="blah"), id="custom"))
+)
 def test_EvalSetup_ProjectInfo(eval_setup: EvalSetup, cfg_exp1: dict):
     assert eval_setup.proj_info.proj_id == cfg_exp1["proj_id"]
 
 
-@default_config
+@pytest.mark.parametrize(
+    "update",
+    (
+        pytest.param(None, id="defaults"),
+        pytest.param(
+            dict(exp_id="exp42", exp_descr="Hello world!", exp_name="Lorem Ipsum...", public=True),
+            id="custom1",
+        ),
+        pytest.param(
+            dict(
+                exp_id="exp54", exp_descr="Hello world!", exp_name="Lorem Ipsum...", public=False
+            ),
+            id="custom2",
+        ),
+    ),
+)
 def test_EvalSetup_ExperimentInfo(eval_setup: EvalSetup, cfg_exp1: dict):
     exp_info = eval_setup.exp_info
     assert exp_info.exp_id == cfg_exp1["exp_id"]
@@ -73,7 +90,19 @@ def test_EvalSetup_ExperimentInfo(eval_setup: EvalSetup, cfg_exp1: dict):
     assert exp_info.public == cfg_exp1["public"]
 
 
-@default_config
+@pytest.mark.parametrize(
+    "update",
+    (
+        pytest.param(None, id="defaults"),
+        pytest.param(
+            dict(freqs=["yearly", "monthly"], main_freq="yearly", periods=[]), id="custom1"
+        ),
+        pytest.param(
+            dict(freqs=["monthly"], main_freq="monthly", periods=["2010", "2011", "2016"]),
+            id="custom2",
+        ),
+    ),
+)
 def test_EvalSetup_TimeSetup(eval_setup: EvalSetup, cfg_exp1: dict):
     time_cfg = eval_setup.time_cfg
     assert time_cfg.freqs == cfg_exp1["freqs"]

--- a/tests/aeroval/test_setupclasses.py
+++ b/tests/aeroval/test_setupclasses.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 from pyaerocom.aeroval.setupclasses import EvalSetup
@@ -42,3 +44,119 @@ def test_EvalSetup___init__INVALID_ENTRY_NAMES(eval_config: dict, update: dict, 
     with pytest.raises(EvalEntryNameError) as e:
         EvalSetup(**eval_config)
     assert error in str(e.value)
+
+
+def test_EvalSetup_ProjectInfo():
+    eval_setup = EvalSetup.model_validate(CFG)
+
+    for k in ["proj_id"]:
+        assert getattr(eval_setup.proj_info, k, None) == CFG[k]
+
+
+@pytest.mark.parametrize(
+    "update",
+    [
+        ({}),
+    ],
+)
+def test_EvalSetup_ExperimentInfo(update):
+    cfg = CFG
+    cfg.update(update)
+
+    eval_setup = EvalSetup.model_validate(cfg)
+
+    for k in ["exp_id", "exp_descr", "exp_name", "public"]:
+        assert getattr(eval_setup.exp_info, k, None) == cfg[k]
+
+
+@pytest.mark.parametrize(
+    "update",
+    [
+        ({}),
+    ],
+)
+def test_EvalSetup_TimeSetup(update):
+    cfg = CFG
+    cfg.update(update)
+    eval_setup = EvalSetup.model_validate(cfg)
+
+    assert eval_setup.time_cfg.freqs == cfg["freqs"]
+    assert eval_setup.time_cfg.main_freq == cfg["main_freq"]
+    assert eval_setup.time_cfg.periods == cfg["periods"]
+
+
+@pytest.mark.parametrize("update", [({}), ({"maps_freq": "yearly", "maps_res_deg": 10})])
+def test_EvalSetup_ModelMapsSetup(update):
+    cfg = CFG
+    cfg.update(update)
+    eval_setup = EvalSetup.model_validate(cfg)
+
+    assert eval_setup.modelmaps_opts.maps_freq == cfg.get("maps_freq", "monthly")
+    assert eval_setup.modelmaps_opts.maps_res_deg == cfg.get("maps_res_deg", 5)
+
+
+@pytest.mark.parametrize("update", [({}), ({"obs_only": True, "only_colocation": True})])
+def test_EvalSetup_EvalRunOptions(update):
+    cfg = CFG
+    if update:
+        cfg.update(update)
+    cfg.update(update)
+    eval_setup = EvalSetup.model_validate(cfg)
+
+    assert eval_setup.processing_opts.clear_existing_json == cfg["clear_existing_json"]
+    assert eval_setup.processing_opts.obs_only == cfg.get("obs_only", False)
+    assert eval_setup.processing_opts.only_colocation == cfg.get("only_colocation", False)
+    assert eval_setup.processing_opts.only_json == cfg["only_json"]
+    assert eval_setup.processing_opts.only_model_maps == cfg["only_model_maps"]
+
+
+@pytest.mark.parametrize(
+    "update",
+    [
+        ({}),
+        (
+            {
+                "trends_min_yrs": 10,
+                "use_diurnal": True,
+                "use_fairmode": True,
+                "weighted_stats": False,
+                "model_only_stats": True,
+                "obs_only_stats": True,
+                "add_trends": True,
+                "annual_stats_constrained": True,
+            }
+        ),
+    ],
+)
+def test_EvalSetup_StatisticsSetup(update):
+    cfg = CFG
+    cfg.update(update)
+
+    eval_setup = EvalSetup.model_validate(cfg)
+
+    assert eval_setup.statistics_opts.trends_min_yrs == cfg.get("trends_min_yrs", 7)
+    assert eval_setup.statistics_opts.use_diurnal == cfg.get("use_diurnal", False)
+    assert eval_setup.statistics_opts.use_fairmode == cfg.get("use_fairmode", False)
+    assert eval_setup.statistics_opts.weighted_stats == cfg.get("weighted_stats", True)
+    assert eval_setup.statistics_opts.model_only_stats == cfg.get("model_only_stats", False)
+    assert eval_setup.statistics_opts.obs_only_stats == cfg.get("obs_only_stats", False)
+    assert eval_setup.statistics_opts.add_trends == cfg.get("add_trends", False)
+    assert eval_setup.statistics_opts.annual_stats_constrained == cfg.get(
+        "annual_stats_constrained", True
+    )
+
+
+@pytest.mark.parametrize("update", [({})])
+def test_EvalSetup_WebDisplaySetup(update):
+    cfg = CFG
+    cfg.update(update)
+
+    eval_setup = EvalSetup.model_validate(cfg)
+
+    assert eval_setup.webdisp_opts.add_model_maps == cfg.get("add_model_maps", False)
+    assert eval_setup.webdisp_opts.map_zoom == cfg.get("map_zoom", "World")
+    assert eval_setup.webdisp_opts.modelorder_from_config == cfg.get(
+        "modelorder_from_config", True
+    )
+    assert eval_setup.webdisp_opts.obsorder_from_config == cfg.get("obsorder_from_config", True)
+    assert eval_setup.webdisp_opts.add_model_maps == cfg.get("add_model_maps", False)

--- a/tests/aeroval/test_setupclasses.py
+++ b/tests/aeroval/test_setupclasses.py
@@ -60,11 +60,9 @@ def test_EvalSetup___init__INVALID_ENTRY_NAMES(eval_config: dict, update: dict, 
     assert error in str(e.value)
 
 
-def test_EvalSetup_ProjectInfo():
-    eval_setup = EvalSetup.model_validate(CFG)
-
-    for k in ["proj_id"]:
-        assert getattr(eval_setup.proj_info, k, None) == CFG[k]
+@pytest.mark.parametrize("update", ((None),))
+def test_EvalSetup_ProjectInfo(eval_setup: EvalSetup, cfg_exp1: dict):
+    assert eval_setup.proj_info.proj_id == cfg_exp1["proj_id"]
 
 
 @pytest.mark.parametrize("update", ((None),))


### PR DESCRIPTION
## Change Summary

Implements tests for the component classes of EvalSetup, checking that values are assigned as expected.

## Related issue number

fix #1096 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
