### PR TITLE
Adds option for kwargs in PyaroConfig

### DIFF
--- a/pyaerocom/io/pyaro/pyaro_config.py
+++ b/pyaerocom/io/pyaro/pyaro_config.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class PyaroConfig(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")
 
     _DEFAULT_CATALOG: ClassVar[Path] = resources.files(pya) / Path(
         "data/pyaro_catalogs/default.yaml"

--- a/pyaerocom/io/pyaro/pyaro_config.py
+++ b/pyaerocom/io/pyaro/pyaro_config.py
@@ -12,6 +12,8 @@ import pyaerocom as pya
 
 logger = logging.getLogger(__name__)
 
+# TODO Check a validator if extra/kwarg is serializable. Either in json_repr or as a @field_validator on extra
+
 
 class PyaroConfig(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True, extra="allow")

--- a/pyaerocom/io/pyaro/read_pyaro.py
+++ b/pyaerocom/io/pyaro/read_pyaro.py
@@ -105,15 +105,16 @@ class PyaroToUngriddedData:
 
     def _open_reader(self) -> Reader:
         data_id = self.config.data_id
+        kwargs = self.config.model_extra
 
         if self.config.name_map is None:
             return open_timeseries(
-                data_id, self.config.filename_or_obj_or_url, filters=self.config.filters
+                data_id, self.config.filename_or_obj_or_url, filters=self.config.filters, **kwargs,
             )
         else:
             return VariableNameChangingReader(
                 open_timeseries(
-                    data_id, self.config.filename_or_obj_or_url, filters=self.config.filters
+                    data_id, self.config.filename_or_obj_or_url, filters=self.config.filters, **kwargs,
                 ),
                 self.config.name_map,
             )

--- a/pyaerocom/io/pyaro/read_pyaro.py
+++ b/pyaerocom/io/pyaro/read_pyaro.py
@@ -109,12 +109,18 @@ class PyaroToUngriddedData:
 
         if self.config.name_map is None:
             return open_timeseries(
-                data_id, self.config.filename_or_obj_or_url, filters=self.config.filters, **kwargs,
+                data_id,
+                self.config.filename_or_obj_or_url,
+                filters=self.config.filters,
+                **kwargs,
             )
         else:
             return VariableNameChangingReader(
                 open_timeseries(
-                    data_id, self.config.filename_or_obj_or_url, filters=self.config.filters, **kwargs,
+                    data_id,
+                    self.config.filename_or_obj_or_url,
+                    filters=self.config.filters,
+                    **kwargs,
                 ),
                 self.config.name_map,
             )

--- a/tests/fixtures/pyaro.py
+++ b/tests/fixtures/pyaro.py
@@ -22,6 +22,7 @@ def make_csv_test_file(tmp_path: Path) -> Path:
     end = pd.to_datetime("31.12.2015", dayfirst=True)
     dates = pd.date_range(start, end, freq="D")
     stations = ["NO0002", "GB0881"]
+    countries = ["NO", "GB"]
     coords = [(58, 8), (60, -1)]
     species = ["NOx", "SOx"]
 
@@ -30,7 +31,7 @@ def make_csv_test_file(tmp_path: Path) -> Path:
             for i, station in enumerate(stations):
                 for date in dates:
                     f.write(
-                        f"{s}, {station}, {coords[i][1]}, {coords[i][0]}, {np.random.normal(10, 5)}, Gg, {date}, {date+pd.Timedelta('1D')} \n"
+                        f"{s}, {station}, {coords[i][1]}, {coords[i][0]}, {np.random.normal(10, 5)}, Gg, {date}, {date+pd.Timedelta('1D')}, {countries[i]} \n"
                     )
 
     return file
@@ -57,6 +58,54 @@ def testconfig(tmp_path: Path) -> PyaroConfig:
     return [config1, config2]
 
 
+def testconfig_kwargs(tmp_path: Path) -> PyaroConfig:
+    data_id = "csv_timeseries"
+    columns = {
+        "variable": 0,
+        "station": 1,
+        "longitude": 2,
+        "latitude": 3,
+        "value": 4,
+        "units": 5,
+        "start_time": 6,
+        "end_time": 7,
+        "altitude": "0",
+        "country": 8,
+        "standard_deviation": "NaN",
+        "flag": "0",
+    }
+
+    config = PyaroConfig(
+        name="test",
+        data_id=data_id,
+        filename_or_obj_or_url=str(make_csv_test_file(tmp_path)),
+        filters={},
+        name_map={"SOx": "concso4"},
+        columns=columns,
+    )
+
+    return config
+
+
+@pytest.fixture
+def pyaro_kwargs() -> dict:
+    columns = {
+        "variable": 0,
+        "station": 1,
+        "longitude": 2,
+        "latitude": 3,
+        "value": 4,
+        "units": 5,
+        "start_time": 6,
+        "end_time": 7,
+        "altitude": "0",
+        "country": 8,
+        "standard_deviation": "NaN",
+        "flag": "0",
+    }
+    return columns
+
+
 @pytest.fixture
 def pyaro_test_data_file(tmp_path) -> Path:
     return make_csv_test_file(tmp_path)
@@ -68,8 +117,21 @@ def pyaro_testconfig(tmp_path) -> PyaroConfig:
 
 
 @pytest.fixture
+def pyaro_testconfig_kwargs(tmp_path) -> PyaroConfig:
+    return testconfig_kwargs(tmp_path=tmp_path)
+
+
+@pytest.fixture
 def pyaro_testdata(tmp_path) -> ReadPyaro:
     config = testconfig(tmp_path=tmp_path)[0]
+    rp = ReadPyaro(config=config)
+
+    return rp
+
+
+@pytest.fixture
+def pyaro_testdata_kwargs(tmp_path) -> ReadPyaro:
+    config = testconfig_kwargs(tmp_path=tmp_path)
     rp = ReadPyaro(config=config)
 
     return rp

--- a/tests/io/pyaro/test_pyaro_config.py
+++ b/tests/io/pyaro/test_pyaro_config.py
@@ -33,6 +33,11 @@ def test_default_path_exist():
     assert PyaroConfig._DEFAULT_CATALOG.exists()
 
 
+def test_kwargs(pyaro_testconfig_kwargs, pyaro_kwargs):
+    kwargs = pyaro_testconfig_kwargs.model_extra["columns"]
+    assert kwargs == pyaro_kwargs
+
+
 def test_save(tmp_path):
     config = get_test_config()
     config.save(path=Path(tmp_path))

--- a/tests/io/pyaro/test_read_pyaro.py
+++ b/tests/io/pyaro/test_read_pyaro.py
@@ -51,6 +51,18 @@ def test_pyarotoungriddeddata_reading(pyaro_testdata):
     assert (all_stations["stats"][0].dtime == dates).all()
 
 
+def test_pyarotoungriddeddata_reading_kwargs(pyaro_testdata_kwargs):
+    obj = pyaro_testdata_kwargs.converter
+    data = obj.read()
+    assert isinstance(data, UngriddedData)
+
+    # Checks if stations have correct countries
+    all_stations = data.to_station_data_all("concso4")
+    countries = ["NO", "GB"]
+    assert all_stations["stats"][1]["country"].strip() == countries[0]
+    assert all_stations["stats"][0]["country"].strip() == countries[1]
+
+
 def test_pyarotoungriddeddata_stations(pyaro_testdata):
     obj = pyaro_testdata.converter
 


### PR DESCRIPTION
## Change Summary

Adds option for adding kwargs to PyaroConfig. Means that the config might not be serializable. Needs some testing before merging

## Related issue number
fix #1108

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [x] At least 1 reviewer is selected
* [ ] Make PR ready to review
