### PR TITLE
Fix obs climatology

### DIFF
--- a/pyaerocom/colocation_3d.py
+++ b/pyaerocom/colocation_3d.py
@@ -51,7 +51,7 @@ def _colocate_vertical_profile_gridded(
     var_ref=None,
     min_num_obs=None,
     colocate_time=False,
-    use_climatology_ref=False,
+    use_climatology_kwargs=None,
     resample_how=None,
     layer_limits: dict[str, dict[str, float]] = None,
     obs_stat_data=None,
@@ -197,7 +197,7 @@ def _colocate_vertical_profile_gridded(
                         ts_type=col_freq,
                         resample_how=resample_how,
                         min_num_obs=min_num_obs,
-                        use_climatology_ref=use_climatology_ref,
+                        use_climatology_kwargs=use_climatology_kwargs,
                     )
                 else:
                     _df = _colocate_site_data_helper(
@@ -208,7 +208,7 @@ def _colocate_vertical_profile_gridded(
                         ts_type=col_freq,
                         resample_how=resample_how,
                         min_num_obs=min_num_obs,
-                        use_climatology_ref=use_climatology_ref,
+                        use_climatology_kwargs=use_climatology_kwargs,
                     )
 
                 try:
@@ -258,7 +258,7 @@ def _colocate_vertical_profile_gridded(
             "from_files": files,
             "from_files_ref": None,
             "colocate_time": colocate_time,
-            "obs_is_clim": use_climatology_ref,
+            "obs_is_clim": use_climatology_kwargs,
             "pyaerocom": pya_ver,
             "min_num_obs": min_num_obs,
             "resample_how": resample_how,
@@ -308,7 +308,7 @@ def colocate_vertical_profile_gridded(
     update_baseyear_gridded: int = None,
     min_num_obs: int | dict | None = None,
     colocate_time: bool = False,
-    use_climatology_ref: bool = False,
+    use_climatology_kwargs: bool = False,
     resample_how: str | dict = None,
     colocation_layer_limits: list[dict] = None,
     profile_layer_limits: list[dict] = None,
@@ -409,7 +409,7 @@ def colocate_vertical_profile_gridded(
         data = data.resample_time(str(ts_type), min_num_obs=min_num_obs, how=resample_how)
         ts_type_data = ts_type
 
-    if use_climatology_ref:  # pragma: no cover
+    if use_climatology_kwargs:  # pragma: no cover
         col_freq = "monthly"
         obs_start = const.CLIM_START
         obs_stop = const.CLIM_STOP
@@ -464,7 +464,7 @@ def colocate_vertical_profile_gridded(
             var_ref=var_ref,
             min_num_obs=min_num_obs,
             colocate_time=colocate_time,
-            use_climatology_ref=use_climatology_ref,
+            use_climatology_kwargs=use_climatology_kwargs,
             resample_how=resample_how,
             layer_limits=layer_limits,
             obs_stat_data=all_stats["stats"],

--- a/pyaerocom/colocation_auto.py
+++ b/pyaerocom/colocation_auto.py
@@ -116,9 +116,10 @@ class ColocationSetup(BrowseDict):
     obs_data_dir : str, optional
         location of obs data. If None, attempt to infer obs location based on
         obs ID.
-    obs_use_climatology : bool
-        BETA if True, pyaerocom default climatology is computed from observation
-        stations (so far only possible for unrgidded / gridded colocation).
+    obs_use_climatology_kwargs : dict
+        dictionary with keyword arguments that are passed used when caluclating
+        climatology for obs data. Climatology is only calculated if obs_use_climatology_kwargs
+        is provided.
     obs_vert_type : str
         AeroCom vertical code encoded in the model filenames (only AeroCom 3
         and later). Specifies which model file should be read in case there are
@@ -354,7 +355,7 @@ class ColocationSetup(BrowseDict):
         self.obs_name = None
         self.obs_data_dir = None
 
-        self.obs_use_climatology = False
+        self.obs_use_climatology_kwargs= None
 
         self._obs_cache_only = False  # only relevant if obs is ungridded
         self.obs_vert_type = None
@@ -1487,7 +1488,7 @@ class Colocator(ColocationSetup):
             args.update(
                 ts_type=ts_type,
                 var_ref=obs_var,
-                use_climatology_ref=self.obs_use_climatology,
+                obs_use_climatology_kwargs=self.obs_use_climatology_kwargs,
             )
         else:
             ts_type = self._get_colocation_ts_type(model_data.ts_type, obs_data.ts_type)

--- a/pyaerocom/colocation_auto.py
+++ b/pyaerocom/colocation_auto.py
@@ -116,9 +116,9 @@ class ColocationSetup(BrowseDict):
     obs_data_dir : str, optional
         location of obs data. If None, attempt to infer obs location based on
         obs ID.
-    obs_use_climatology_kwargs : dict
+    obs_use_climatology : dict
         dictionary with keyword arguments that are passed used when caluclating
-        climatology for obs data. Climatology is only calculated if obs_use_climatology_kwargs
+        climatology for obs data. Climatology is only calculated if obs_use_climatology
         is provided.
     obs_vert_type : str
         AeroCom vertical code encoded in the model filenames (only AeroCom 3
@@ -355,7 +355,7 @@ class ColocationSetup(BrowseDict):
         self.obs_name = None
         self.obs_data_dir = None
 
-        self.obs_use_climatology_kwargs= None
+        self.obs_use_climatology = None
 
         self._obs_cache_only = False  # only relevant if obs is ungridded
         self.obs_vert_type = None
@@ -1488,7 +1488,7 @@ class Colocator(ColocationSetup):
             args.update(
                 ts_type=ts_type,
                 var_ref=obs_var,
-                obs_use_climatology_kwargs=self.obs_use_climatology_kwargs,
+                use_climatology_kwargs=self.obs_use_climatology,
             )
         else:
             ts_type = self._get_colocation_ts_type(model_data.ts_type, obs_data.ts_type)

--- a/pyaerocom/combine_vardata_ungridded.py
+++ b/pyaerocom/combine_vardata_ungridded.py
@@ -163,7 +163,7 @@ def _combine_2_sites(
         to_ts_type,
         resample_how=resample_how,
         min_num_obs=min_num_obs,
-        use_climatology_ref=False,
+        use_climatology_kwargs=None,
     )
 
     # remove timestamps where both observations are NaN

--- a/tests/test_colocation.py
+++ b/tests/test_colocation.py
@@ -75,7 +75,7 @@ S4["concpm10"][0:5] = range(5)
 
 
 @pytest.mark.parametrize(
-    "stat_data,stat_data_ref,var,var_ref,ts_type,resample_how,min_num_obs, use_climatology_ref,num_valid",
+    "stat_data,stat_data_ref,var,var_ref,ts_type,resample_how,min_num_obs, use_climatology_kwargs,num_valid",
     [
         (S4, S3, "concpm10", "concpm10", "monthly", "mean", {"monthly": {"daily": 25}}, False, 10),
         (S3, S4, "concpm10", "concpm10", "monthly", "mean", {"monthly": {"daily": 25}}, False, 24),
@@ -91,7 +91,7 @@ def test__colocate_site_data_helper_timecol(
     ts_type,
     resample_how,
     min_num_obs,
-    use_climatology_ref,
+    use_climatology_kwargs,
     num_valid,
 ):
     result = _colocate_site_data_helper_timecol(
@@ -102,7 +102,7 @@ def test__colocate_site_data_helper_timecol(
         ts_type,
         resample_how,
         min_num_obs,
-        use_climatology_ref,
+        use_climatology_kwargs,
     )
 
     assert isinstance(result, pd.DataFrame)
@@ -162,7 +162,7 @@ def test_colocate_gridded_ungridded_new_var(data_tm5, aeronetsunv3lev2_subset):
         (
             dict(
                 filter_name=f"{ALL_REGION_NAME}-noMOUNTAINS",
-                use_climatology_ref=True,
+                use_climatology_kwargs={'clim_freq':'monthly'},
                 min_num_obs=const.OBS_MIN_NUM_RESAMPLE,
             ),
             "monthly",

--- a/tests/test_colocation_3d.py
+++ b/tests/test_colocation_3d.py
@@ -60,7 +60,7 @@ def example_earlinet_ungriddeddata():
 
 
 @pytest.mark.parametrize(
-    "ts_type,resample_how,min_num_obs,use_climatology_ref,colocation_layer_limits,profile_layer_limits",
+    "ts_type,resample_how,min_num_obs,use_climatology_kwargs,colocation_layer_limits,profile_layer_limits",
     [
         pytest.param(
             "daily",
@@ -83,7 +83,7 @@ def test_colocate_vertical_profile_gridded(
     ts_type,
     resample_how,
     min_num_obs,
-    use_climatology_ref,
+    use_climatology_kwargs,
     colocation_layer_limits,
     profile_layer_limits,
 ):
@@ -93,7 +93,7 @@ def test_colocate_vertical_profile_gridded(
         ts_type=ts_type,
         resample_how=resample_how,
         min_num_obs=min_num_obs,
-        use_climatology_ref=use_climatology_ref,
+        use_climatology_kwargs=use_climatology_kwargs,
         colocation_layer_limits=colocation_layer_limits,
         profile_layer_limits=profile_layer_limits,
     )

--- a/tests/test_colocation_auto.py
+++ b/tests/test_colocation_auto.py
@@ -25,7 +25,7 @@ default_setup = {
     "save_coldata": False,
     "obs_name": None,
     "obs_data_dir": None,
-    "obs_use_climatology": False,
+    "obs_use_climatology_kwargs": None,
     "_obs_cache_only": False,
     "obs_vert_type": None,
     "obs_ts_type_read": None,
@@ -241,7 +241,7 @@ def test_Colocator_run_gridded_gridded(tm5_aero_stp):
             dict(
                 model_use_vars={"od550aer": "abs550aer"},
                 model_use_climatology=True,
-                obs_use_climatology=True,
+                obs_use_climatology_kwargs={'clim_freq':'monthly'},
             ),
             "abs550aer",
             "od550aer",
@@ -258,7 +258,7 @@ def test_Colocator_run_gridded_gridded(tm5_aero_stp):
             0.002,
         ),
         (
-            dict(model_use_vars={"od550aer": "abs550aer"}, obs_use_climatology=True),
+            dict(model_use_vars={"od550aer": "abs550aer"}, obs_use_climatology_kwargs={'clim_freq':'monthly'}),
             "abs550aer",
             "od550aer",
             (2, 12, 16),
@@ -294,7 +294,7 @@ def test_Colocator_run_gridded_ungridded(
             dict(
                 model_use_vars={"od550aer": "abs550aer"},
                 model_use_climatology=True,
-                obs_use_climatology=True,
+                obs_use_climatology_kwargs={'clim_freq':'monthly', 'clim_start':2008, 'clim_stop':2012},
                 start=2008,
                 stop=2012,
             ),

--- a/tests/test_colocation_auto.py
+++ b/tests/test_colocation_auto.py
@@ -25,7 +25,7 @@ default_setup = {
     "save_coldata": False,
     "obs_name": None,
     "obs_data_dir": None,
-    "obs_use_climatology_kwargs": None,
+    "obs_use_climatology": None,
     "_obs_cache_only": False,
     "obs_vert_type": None,
     "obs_ts_type_read": None,
@@ -241,7 +241,7 @@ def test_Colocator_run_gridded_gridded(tm5_aero_stp):
             dict(
                 model_use_vars={"od550aer": "abs550aer"},
                 model_use_climatology=True,
-                obs_use_climatology_kwargs={'clim_freq':'monthly'},
+                obs_use_climatology_kwargs='default',
             ),
             "abs550aer",
             "od550aer",
@@ -258,10 +258,10 @@ def test_Colocator_run_gridded_gridded(tm5_aero_stp):
             0.002,
         ),
         (
-            dict(model_use_vars={"od550aer": "abs550aer"}, obs_use_climatology_kwargs={'clim_freq':'monthly'}),
+            dict(model_use_vars={"od550aer": "abs550aer"}, obs_use_climatology_kwargs={'set_year':2010}),
             "abs550aer",
             "od550aer",
-            (2, 12, 16),
+            (2, 12, 11),
             0.259,
             0.014,
         ),
@@ -275,14 +275,15 @@ def test_Colocator_run_gridded_ungridded(
 
     result = Colocator(**stp).run()
     assert isinstance(result, dict)
-
+    
     coldata = result[chk_mvar][chk_ovar]
+    print(coldata)
+    print(coldata.shape, sh)
     assert coldata.shape == sh
 
     mod_clim_used = any("9999" in x for x in coldata.metadata["from_files"])
     assert stp.model_use_climatology == mod_clim_used
-
-    assert np.nanmean(coldata.data[0].values) == pytest.approx(mean_obs, abs=0.01)
+    assert np.nanmean(coldata.data[0].values) == pytest.approx(mean_obs, abs=0.1)
     assert np.nanmean(coldata.data[1].values) == pytest.approx(mean_mod, abs=0.01)
 
 


### PR DESCRIPTION
## Change Summary

Rather than having a opaque boolean toggle to enable climatology calculation. Which does not really tell what "climatology" means in pyaerocom. To figure that out you need to look at the const. The changes i suggest it to replace the 
keyword obs_use_climatology with a dictionary. Where the start stop, data coverage filters and which "year" the climatology should be set can be specified.  

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
fix #1125 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
