### PR TITLE
Custom statistics

### DIFF
--- a/pyaerocom/stats/stats.py
+++ b/pyaerocom/stats/stats.py
@@ -120,24 +120,24 @@ def _get_default_statistic_config() -> dict[str, StatisticsCalculator]:
     which calculates all implemented statistics. Can be used as a starting
     point for adding additional stats using `dict.update()`
     """
-    return {
-        "refdata_mean": lambda x, y, w: np.nanmean(y),
-        "refdata_std": lambda x, y, w: np.nanstd(y),
-        "data_mean": lambda x, y, w: np.nanmean(x),
-        "data_std": lambda x, y, w: np.nanstd(x),
-        "rms": stat_rms,
-        "nmb": stat_nmb,
-        "mnmb": stat_mnmb,
-        "mb": stat_mb,
-        "mab": stat_mab,
-        "fge": stat_fge,
-        "R": stat_R,
-        "R_spearman": stat_R_spearman,
-        "R_kendall": stat_R_kendall,
-    }
+    return dict(
+        refdata_mean=lambda x, y, w: np.nanmean(y),
+        refdata_std=lambda x, y, w: np.nanstd(y),
+        data_mean=lambda x, y, w: np.nanmean(x),
+        data_std=lambda x, y, w: np.nanstd(x),
+        rms=stat_rms,
+        nmb=stat_nmb,
+        mnmb=stat_mnmb,
+        mb=stat_mb,
+        mab=stat_mab,
+        fge=stat_fge,
+        R=stat_R,
+        R_spearman=stat_R_spearman,
+        R_kendall=stat_R_kendall,
+    )
 
 
-_stats_configuration = _get_default_statistic_config()
+stats_configuration = _get_default_statistic_config()
 
 
 def register_custom_statistic(name: str, fun: StatisticsCalculator) -> None:
@@ -155,10 +155,10 @@ def register_custom_statistic(name: str, fun: StatisticsCalculator) -> None:
     ValueError:
         if name has already been registered, or is otherwise invalid.
     """
-    if (name in _stats_configuration) or (name in ["totnum", "weighted"]):
-        raise ValueError(f"Name {name} is already registered in _stats_configuration.")
+    if (name in stats_configuration) or (name in ["totnum", "weighted"]):
+        raise ValueError(f"Name {name} is already registered in stats_configuration.")
 
-    _stats_configuration[name] = fun
+    stats_configuration[name] = fun
 
 
 def calculate_statistics(
@@ -246,7 +246,7 @@ def calculate_statistics(
         if len(weights) != len(data):
             raise ValueError("Invalid input. Length of weights must match length of data.")
 
-    statistics = _stats_configuration
+    statistics = stats_configuration
 
     # Set defaults
     data_filters = [FilterNaN()]

--- a/pyaerocom/stats/stats.py
+++ b/pyaerocom/stats/stats.py
@@ -164,7 +164,6 @@ def register_custom_statistic(name: str, fun: StatisticsCalculator) -> None:
 def calculate_statistics(
     data,
     ref_data,
-    # statistics: Mapping[str, StatisticsCalculator] | None = None,
     min_num_valid=1,
     weights: list | None = None,
     drop_stats=None,
@@ -201,9 +200,6 @@ def calculate_statistics(
         data
     ref_data : ndarray
         array containing data, that is used to compare `data` array with
-    statistics : dict[str, StatisticsCalculator]
-        mapping between statistics name and Callable to calculate that statistics. If None,
-        the dictionary provided by `_get_default_statistic_config()` is used.
     lowlim : float
         lower end of considered value range (e.g. if set 0, then all datapoints
         where either ``data`` or ``ref_data`` is smaller than 0 are removed).
@@ -250,10 +246,9 @@ def calculate_statistics(
         if len(weights) != len(data):
             raise ValueError("Invalid input. Length of weights must match length of data.")
 
-    # Set defaults
-    if statistics is None:
-        statistics = _get_default_statistic_config()
+    statistics = _stats_configuration
 
+    # Set defaults
     data_filters = [FilterNaN()]
     if (lowlim is not None) or (highlim is not None):
         data_filters.append(FilterByLimit(lowlim=lowlim, highlim=highlim))

--- a/pyaerocom/stats/stats.py
+++ b/pyaerocom/stats/stats.py
@@ -137,10 +137,34 @@ def _get_default_statistic_config() -> dict[str, StatisticsCalculator]:
     }
 
 
+_stats_configuration = _get_default_statistic_config()
+
+
+def register_custom_statistic(name: str, fun: StatisticsCalculator) -> None:
+    """Registers a new custom statistic
+
+    Parameters
+    ----------
+    name:
+        The name as which the custom statistic will be registered.
+    fun:
+        A function which implements the calculation of the statistics.
+
+    Raises
+    ------
+    ValueError:
+        if name has already been registered, or is otherwise invalid.
+    """
+    if (name in _stats_configuration) or (name in ["totnum", "weighted"]):
+        raise ValueError(f"Name {name} is already registered in _stats_configuration.")
+
+    _stats_configuration[name] = fun
+
+
 def calculate_statistics(
     data,
     ref_data,
-    statistics: Mapping[str, StatisticsCalculator] | None = None,
+    # statistics: Mapping[str, StatisticsCalculator] | None = None,
     min_num_valid=1,
     weights: list | None = None,
     drop_stats=None,

--- a/pyaerocom/stats/stats.py
+++ b/pyaerocom/stats/stats.py
@@ -1,5 +1,3 @@
-from typing import Mapping
-
 import numpy as np
 
 from pyaerocom.stats.data_filters import FilterByLimit, FilterNaN
@@ -119,6 +117,11 @@ def _get_default_statistic_config() -> dict[str, StatisticsCalculator]:
     Returns a base configuration dictionary to be used with `calculate_statistics`
     which calculates all implemented statistics. Can be used as a starting
     point for adding additional stats using `dict.update()`
+
+    Returns
+    -------
+    dict :
+        A fresh copy of the default statistics config dictionary.
     """
     return dict(
         refdata_mean=lambda x, y, w: np.nanmean(y),

--- a/pyaerocom/stats/stats.py
+++ b/pyaerocom/stats/stats.py
@@ -178,14 +178,13 @@ def calculate_statistics(
     ref_data : ndarray
         array containing data, that is used to compare `data` array with
     statistics : dict[str, StatisticsCalculator]
-        mapping between statistics name and Callable to calculate that statistics.
+        mapping between statistics name and Callable to calculate that statistics. If None,
+        the dictionary provided by `_get_default_statistic_config()` is used.
     lowlim : float
         lower end of considered value range (e.g. if set 0, then all datapoints
         where either ``data`` or ``ref_data`` is smaller than 0 are removed).
-        Deprecated. Use data_filters with FilterByLimit instead.
     highlim : float
         upper end of considered value range
-        Deprecated. Use data_filters with FilterByLimit instead.
     min_num_valid : int
         minimum number of valid measurements required to compute statistical
         parameters. Stat will be returned as NaN if length(data) is below this threshold.
@@ -194,8 +193,8 @@ def calculate_statistics(
     drop_stats: tuple
         tuple which drops the provided statistics from computed json files.
         For example, setting drop_stats = ("mb", "mab"), results in json files
-        in hm/ts with entries which do not contain the mean bias and mean
-        absolute bias, but the other statistics are preserved.
+        with entries which do not contain the mean bias and mean absolute bias, but
+        the other statistics are preserved.
     Returns
     -------
     StatsDict


### PR DESCRIPTION
## Change Summary

Another step towards allowing users to specify their own custom statistics implementations. `pyaerocom.stats.stats` now provides a `register_custom_statistic()` method which allows adding a custom implementation for a statistic. It is not yet being read from the config dict directly but the functionality can be invoked by adding the following to `cfg_benchmark.py`:

```python
    from pyaerocom.stats.stats import register_custom_statistic

    register_custom_statistic("customstat1", fun= lambda x, y, w: 5)
    register_custom_statistic("customstat2", fun= lambda x, y, w: 3)
```

## Related issue number

fixes #1114

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
