### PR TITLE
Fix fairmode rounding issue

### DIFF
--- a/pyaerocom/stats/stats.py
+++ b/pyaerocom/stats/stats.py
@@ -80,7 +80,7 @@ def _prepare_statistics(
     result = dict()
     for name, stat in statistics.items():
         if len(data) >= min_numvalid:
-            result[name] = stat(data, ref_data, weights)
+            result[name] = round(stat(data, ref_data, weights), 10)
         else:
             result[name] = np.nan
 

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -237,9 +237,9 @@ def test_fairmode_R_in_expected_range():
     # because fairmode_stats() expects R values exactly in the range, but
     # values may be outside due to floating point shenanigans.
     # https://xkcd.com/217/
-    # As of the time of writing this test, all the parametrizations
-    # surface the error, if rounding is *not* applied in
-    # `stats.stats._prepare_stats()`.
+    # As of the time of writing this test, the data used for this test is
+    # known to result in a failing test, IF *no* rounding is applied in
+    # `stats.stats._prepare_statistics().`
     # https://github.com/metno/pyaerocom/pull/1142
     data1 = np.asarray([17.2073523845202, 15.543783901903302, np.nan])
     data2 = np.asarray([15.046913580246915, 18.462202650290884, np.nan])

--- a/tests/stats/test_stats.py
+++ b/tests/stats/test_stats.py
@@ -228,3 +228,22 @@ def test_calc_statistics_drop_stats(data, ref_data, drop):
     stats = calculate_statistics(data, ref_data, drop_stats=drop)
 
     assert all([x not in stats.keys() for x in drop])
+
+
+def test_fairmode_R_in_expected_range():
+    # This test is meant to test for a specific issue where
+    # using fairmode=true would result in errors due to the calculated
+    # R values being slightly out of range -1<=R<=1. The error is caused
+    # because fairmode_stats() expects R values exactly in the range, but
+    # values may be outside due to floating point shenanigans.
+    # https://xkcd.com/217/
+    # As of the time of writing this test, all the parametrizations
+    # surface the error, if rounding is *not* applied in
+    # `stats.stats._prepare_stats()`.
+    # https://github.com/metno/pyaerocom/pull/1142
+    data1 = np.asarray([17.2073523845202, 15.543783901903302, np.nan])
+    data2 = np.asarray([15.046913580246915, 18.462202650290884, np.nan])
+
+    stats = calculate_statistics(data1, data2)
+
+    assert -1 <= stats["R"] <= 1


### PR DESCRIPTION
## Change Summary

#1117 introduced an issue where floating point arithmetic or lack of rounding resultet in R stats outside of its permissible range [1, -1] when using `fairmode=True`. This PR fixes this issue, by rounding the calculated values in `_prepare_stats`. 

## Related issue number

Discussion in cams2_83 chat

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
