### PR TITLE
fixing netcdf-chunk cache overflow, avoid h5netcdf

### DIFF
--- a/pyaerocom/io/__init__.py
+++ b/pyaerocom/io/__init__.py
@@ -3,7 +3,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-
 # Submodule
 from . import cams2_83
 
@@ -36,3 +35,4 @@ from .pyaro.read_pyaro import ReadPyaro
 from .pyaro.pyaro_config import PyaroConfig
 
 from . import helpers_units
+from . import netcdf_fix

--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -190,14 +190,10 @@ def read_dataset(paths: list[Path], *, day: int) -> xr.Dataset:
     def preprocess(ds: xr.Dataset) -> xr.Dataset:
         return ds.pipe(forecast_day, day=day).pipe(fix_missing_vars)
 
-    # h5 chunk cache is 1 MB, netcdf4 chunk-cache is 64MB
-    # using h5netcdf saves therefore up to 63MB/file
-    # in our case only ~20MB/file, i.e. 0.5GB/month
     ds = xr.open_mfdataset(
         paths,
         preprocess=preprocess,
         parallel=False,
-        engine="h5netcdf",  # chunks={"time": 1}
     )
     return ds.pipe(fix_coord).pipe(fix_names)
 
@@ -210,7 +206,7 @@ def check_files(paths: list[Path]) -> list[Path]:
 
     for p in tqdm(paths, disable=None):
         try:
-            with xr.open_dataset(p, engine="h5netcdf") as ds:
+            with xr.open_dataset(p) as ds:
                 if len(ds.time.data) < 2:
                     logger.warning(f"To few timestamps in {p}. Skipping file")
                     continue

--- a/pyaerocom/io/netcdf_fix.py
+++ b/pyaerocom/io/netcdf_fix.py
@@ -1,0 +1,9 @@
+import logging
+
+import netCDF4
+
+# avoid a broken autoadjusting chunk-cache in netcdf by setting a static cache
+# see https://github.com/Unidata/netcdf-c/issues/2913
+nc_cache = netCDF4.get_chunk_cache()
+netCDF4.set_chunk_cache(2 * nc_cache[0], nc_cache[1], nc_cache[2])
+logging.getLogger(__name__).debug("netcdf-chunk-cache fix applied")

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -5,7 +5,6 @@ channels:
 dependencies:
   - iris >=3.8.1
   - xarray <=2022.10.0
-  - h5netcdf >1.0.0
   - cartopy >=0.21.1
   - matplotlib-base >=3.7.1
   - scipy >=1.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ requires-python = ">=3.10"
 dependencies = [
     "scitools-iris>=3.8.1",
     "xarray<=2022.10.0",
-    "h5netcdf>=1.0.0",               # xarray backend, no chunk-cache
     "cartopy>=0.21.1",
     "matplotlib>=3.7.1",
     "scipy>=1.10.1",


### PR DESCRIPTION
## Change Summary

use a static netcdf-chunk-cache to avoid a huge auto-adjusted cache, see https://github.com/Unidata/netcdf-c/issues/2913
The auto-adjusted cache is in particularly painful when opening many files, i.e. with `xarray.open_mfdataset`

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
