### PR TITLE
Use logger.info rather than logging.info to get correct class

### DIFF
--- a/pyaerocom/aeroval/experiment_processor.py
+++ b/pyaerocom/aeroval/experiment_processor.py
@@ -120,7 +120,7 @@ class ExperimentProcessor(ProcessingEngine, HasColocator):
 
         obs_list = self.cfg.obs_cfg.keylist(obs_name)
         if not self.cfg.model_cfg:
-            logging.info("No model found, will make dummy model data")
+            logger.info("No model found, will make dummy model data")
             self.cfg.webdisp_opts.hide_charts = ["scatterplot"]
             self.cfg.webdisp_opts.hide_pages = ["maps.php", "intercomp.php", "overall.php"]
             model_id = make_dummy_model(obs_list, self.cfg)

--- a/pyaerocom/extras/satellite_l2/aeolus_l2a.py
+++ b/pyaerocom/extras/satellite_l2/aeolus_l2a.py
@@ -384,8 +384,9 @@ class ReadL2Data(ReadL2DataBase):
         # variable name of the topography in the topography file
         self.EMEP_TOPO_FILE_VAR_NAME = "topography"
 
+        # ensure logging shows this file
+        self.logger = logging.getLogger(__name__)
         if loglevel is not None:
-            # self.logger = logging.getLogger(__name__)
             # if self.logger.hasHandlers():
             #     # Logger is already configured, remove all handlers
             #     self.logger.handlers = []
@@ -1159,7 +1160,7 @@ class ReadL2Data(ReadL2DataBase):
                         end_index = index_counter + matching_length
                         if end_index > len(ret_data):
                             # append the needed elements
-                            logging.info(
+                            self.logger.info(
                                 f"adding {end_index - len(ret_data)} elements to ret_data"
                             )
                             ret_data = np.append(
@@ -1178,9 +1179,11 @@ class ReadL2Data(ReadL2DataBase):
                         index_counter += matching_length
 
             elif isinstance(location, tuple):
-                logging.error("passing one location as tuple not supported at this point")
+                self.logger.error("passing one location as tuple not supported at this point")
             else:
-                logging.error("locations have to be passed as a list of tuples with (lat, lon)")
+                self.logger.error(
+                    "locations have to be passed as a list of tuples with (lat, lon)"
+                )
             # return only the part of the array containing some values
             if cut_flag:
                 ret_data = ret_data[:index_counter, :]
@@ -1278,7 +1281,7 @@ class ReadL2Data(ReadL2DataBase):
         lon_max = 360.0
 
         if bbox is not None:
-            logging.info(bbox)
+            self.logger.info(bbox)
             lat_min = bbox[0]
             lat_max = bbox[1]
             lon_min = bbox[2]
@@ -1299,16 +1302,16 @@ class ReadL2Data(ReadL2DataBase):
             # np.where can unfortunately only work with a single criterion
             matching_indexes = np.where(ret_data[:, self._LATINDEX] <= lat_max)
             ret_data = ret_data[matching_indexes[0], :]
-            # logging.warning('len after lat_max: {}'.format(len(ret_data)))
+            # self.logger.warning('len after lat_max: {}'.format(len(ret_data)))
             matching_indexes = np.where(ret_data[:, self._LATINDEX] >= lat_min)
             ret_data = ret_data[matching_indexes[0], :]
-            # logging.warning('len after lat_min: {}'.format(len(ret_data)))
+            # self.logger.warning('len after lat_min: {}'.format(len(ret_data)))
             matching_indexes = np.where(ret_data[:, self._LONINDEX] <= lon_max)
             ret_data = ret_data[matching_indexes[0], :]
-            # logging.warning('len after lon_max: {}'.format(len(ret_data)))
+            # self.logger.warning('len after lon_max: {}'.format(len(ret_data)))
             matching_indexes = np.where(ret_data[:, self._LONINDEX] >= lon_min)
             ret_data = ret_data[matching_indexes[0], :]
-            # logging.warning('len after lon_min: {}'.format(len(ret_data)))
+            # self.logger.warning('len after lon_min: {}'.format(len(ret_data)))
             # matching_length = len(matching_indexes[0])
 
             # end_time = time.perf_counter()
@@ -1324,7 +1327,7 @@ class ReadL2Data(ReadL2DataBase):
             #     data_lat_max = np.nanmax(self.data[:,self._LATINDEX])
             #     data_lon_min = np.nanmin(self.data[:,self._LONINDEX])
             #     data_lon_max = np.nanmax(self.data[:,self._LONINDEX])
-            #     logging.info('[lat_min, lat_max, lon_min, lon_max in data]: '.format([data_lat_min, data_lat_max, data_lon_min, data_lon_max]))
+            #     self.logger.info('[lat_min, lat_max, lon_min, lon_max in data]: '.format([data_lat_min, data_lat_max, data_lon_min, data_lon_max]))
             return ret_data
 
     ###################################################################################

--- a/pyaerocom/extras/satellite_l2/base_reader.py
+++ b/pyaerocom/extras/satellite_l2/base_reader.py
@@ -206,8 +206,9 @@ class ReadL2DataBase(ReadUngriddedBase):
                 self.SUPPORTED_GRIDS[grid_name]["grid_dist_lon"],
             )
 
+        # ensure logging shows this class
+        self.logger = logging.getLogger(__name__)
         if loglevel is not None:
-            # self.logger = logging.getLogger(__name__)
             # if self.logger.hasHandlers():
             #     # Logger is already configured, remove all handlers
             #     self.logger.handlers = []
@@ -835,7 +836,7 @@ class ReadL2DataBase(ReadUngriddedBase):
         data = _data._data
 
         if bbox is not None:
-            logging.info(bbox)
+            self.logger.info(bbox)
             lat_min = bbox[0]
             lat_max = bbox[1]
             lon_min = bbox[2]
@@ -848,16 +849,16 @@ class ReadL2DataBase(ReadUngriddedBase):
             # np.where can unfortunately only work with a single criterion
             matching_indexes = np.where(ret_data[:, self._LATINDEX] <= lat_max)
             ret_data = ret_data[matching_indexes[0], :]
-            # logging.warning('len after lat_max: {}'.format(len(ret_data)))
+            # self.logger.warning('len after lat_max: {}'.format(len(ret_data)))
             matching_indexes = np.where(ret_data[:, self._LATINDEX] >= lat_min)
             ret_data = ret_data[matching_indexes[0], :]
-            # logging.warning('len after lat_min: {}'.format(len(ret_data)))
+            # self.logger.warning('len after lat_min: {}'.format(len(ret_data)))
             matching_indexes = np.where(ret_data[:, self._LONINDEX] <= lon_max)
             ret_data = ret_data[matching_indexes[0], :]
-            # logging.warning('len after lon_max: {}'.format(len(ret_data)))
+            # self.logger.warning('len after lon_max: {}'.format(len(ret_data)))
             matching_indexes = np.where(ret_data[:, self._LONINDEX] >= lon_min)
             ret_data = ret_data[matching_indexes[0], :]
-            # logging.warning('len after lon_min: {}'.format(len(ret_data)))
+            # self.logger.warning('len after lon_min: {}'.format(len(ret_data)))
             # matching_length = len(matching_indexes[0])
             _data._data = ret_data
             return _data

--- a/pyaerocom/extras/satellite_l2/sentinel5p.py
+++ b/pyaerocom/extras/satellite_l2/sentinel5p.py
@@ -421,8 +421,9 @@ class ReadL2Data(ReadL2DataBase):
         # field name whose size determines the number of time steps in a product
         self.TSSIZENAME = self._TIME_OFFSET_NAME
 
+        # ensure logging shows this file
+        self.logger = logging.getLogger(__name__)
         if loglevel is not None:
-            # self.logger = logging.getLogger(__name__)
             # if self.logger.hasHandlers():
             #     # Logger is already configured, remove all handlers
             #     self.logger.handlers = []
@@ -1108,7 +1109,7 @@ class ReadL2Data(ReadL2DataBase):
             # data = _data._data
 
             if bbox is not None:
-                logging.info(bbox)
+                self.logger.info(bbox)
                 lat_min = bbox[0]
                 lat_max = bbox[1]
                 lon_min = bbox[2]
@@ -1127,16 +1128,16 @@ class ReadL2Data(ReadL2DataBase):
 
                 matching_indexes = np.where(ret_data[:, self._LATINDEX] <= lat_max)
                 ret_data = ret_data[matching_indexes[0], :]
-                # logging.warning('len after lat_max: {}'.format(len(ret_data)))
+                # self.logger.warning('len after lat_max: {}'.format(len(ret_data)))
                 matching_indexes = np.where(ret_data[:, self._LATINDEX] >= lat_min)
                 ret_data = ret_data[matching_indexes[0], :]
-                # logging.warning('len after lat_min: {}'.format(len(ret_data)))
+                # self.logger.warning('len after lat_min: {}'.format(len(ret_data)))
                 matching_indexes = np.where(ret_data[:, self._LONINDEX] <= lon_max)
                 ret_data = ret_data[matching_indexes[0], :]
-                # logging.warning('len after lon_max: {}'.format(len(ret_data)))
+                # self.logger.warning('len after lon_max: {}'.format(len(ret_data)))
                 matching_indexes = np.where(ret_data[:, self._LONINDEX] >= lon_min)
                 ret_data = ret_data[matching_indexes[0], :]
-                # logging.warning('len after lon_min: {}'.format(len(ret_data)))
+                # self.logger.warning('len after lon_min: {}'.format(len(ret_data)))
                 # matching_length = len(matching_indexes[0])
                 _data._data = ret_data
                 return _data

--- a/pyaerocom/io/cams2_83/read_obs.py
+++ b/pyaerocom/io/cams2_83/read_obs.py
@@ -108,7 +108,7 @@ class ReadCAMS2_83(ReadUngriddedBase):
         )
         df: pd.DataFrame
         for station, df in data.groupby("station"):
-            logging.info(f"Reading obs for station {station} and variables {vars_to_retrieve}")
+            logger.info(f"Reading obs for station {station} and variables {vars_to_retrieve}")
             output = dict(
                 station_id=station,
                 station_name=station,


### PR DESCRIPTION
## Change Summary

The logging output gave a few cases of "root" loggers where `logging.info` instead of `logger.info` was used.
This PR tries to fix these occurrences, mostly in cams2-83 and satellite data classes.

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
