### PR TITLE
depend on pyaro 0.0.10 to support multifile-csv obs-databases

### DIFF
--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -28,7 +28,7 @@ dependencies:
   - pip:
     - geojsoncontour
     - geocoder_reverse_natural_earth >= 0.0.2
-    - pyaro >= 0.0.8
+    - pyaro >= 0.0.10
 ## testing
   - pytest >=7.4
   - pytest-dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     'typing-extensions>=4.0.1; python_version < "3.11"',
     # https://github.com/SciTools/cf-units/issues/218
     'cf-units>=3.1',
-    "pyaro>=0.0.8",
+    "pyaro>=0.0.10",
     "pydantic>2",
 
 ]


### PR DESCRIPTION
Depend on pyaro 0.0.10 to support multifile-csv obs-databases and allow new filters as well as additional fields of metadata.

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
