### PR TITLE
setting default contour-map extend max

### DIFF
--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -127,7 +127,7 @@ def calc_contour_json(data, cmap, cmap_bins):
     for i, date in enumerate(tst):
         datamon = nparr[i]
         contour = ax.contourf(
-            lons, lats, datamon, transform=proj, colors=cm.colors, levels=cmap_bins, extend='max'
+            lons, lats, datamon, transform=proj, colors=cm.colors, levels=cmap_bins, extend="max"
         )
 
         result = contourf_to_geojson(contourf=contour)

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -127,7 +127,7 @@ def calc_contour_json(data, cmap, cmap_bins):
     for i, date in enumerate(tst):
         datamon = nparr[i]
         contour = ax.contourf(
-            lons, lats, datamon, transform=proj, colors=cm.colors, levels=cmap_bins
+            lons, lats, datamon, transform=proj, colors=cm.colors, levels=cmap_bins, extend='max'
         )
 
         result = contourf_to_geojson(contourf=contour)


### PR DESCRIPTION
## Change Summary

Set the default extend contour-map extend to 'max' as is the default required behaviour of aeroval.

closes #1186
see also https://github.com/metno/AeroToolsIssues/issues/46

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
