### PR TITLE
Improve variable naming

### DIFF
--- a/pyaerocom/aeroval/collections.py
+++ b/pyaerocom/aeroval/collections.py
@@ -112,7 +112,7 @@ class ObsCollection(BaseCollection):
         except (KeyError, AttributeError):
             raise EntryNotAvailable(f"no such entry {key}")
 
-    def get_all_vars(self) -> list:
+    def get_all_vars(self) -> list[str]:
         """
         Get unique list of all obs variables from all entries
 
@@ -190,7 +190,7 @@ class ModelCollection(BaseCollection):
 
     SETTER_CONVERT = {dict: ModelEntry}
 
-    def get_entry(self, key) -> object:
+    def get_entry(self, key) -> ModelEntry:
         """Get model entry configuration
 
         Since the configuration files for experiments are in json format, they

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -794,21 +794,6 @@ class ExperimentOutput(ProjectOutput):
                     new_sorted[var]["obs"][obs_name][vert_code] = models_sorted
         return new_sorted
 
-    def _get_valid_obs_vars(self, obs_name) -> dict:
-        if obs_name in self._valid_obs_vars:
-            return self._valid_obs_vars[obs_name]
-
-        obs_vars = self.obs_config[obs_name]["obs_vars"]
-        add = []
-        for mname, mcfg in self.model_config.items():
-            if "model_add_vars" in mcfg:
-                for ovar, mvar in mcfg["model_add_vars"].items():
-                    if ovar in obs_vars and not mvar in add:
-                        add.append(mvar)
-        obs_vars.extend(add)
-        self._valid_obs_vars[obs_name] = obs_vars
-        return obs_vars
-
     def _add_entry_experiments_json(self, exp_id, data) -> None:
         fp = self.experiments_file
         current = read_json(fp)

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -26,6 +26,8 @@ MapInfo = namedtuple(
     "MapInfo", ["obs_network", "obs_var", "vert_code", "mod_name", "mod_var", "time_period"]
 )
 
+VariableInfo = namedtuple("VariableInfo", ["menu_name", "vertical_type", "category"])
+
 logger = logging.getLogger(__name__)
 
 
@@ -560,7 +562,7 @@ class ExperimentOutput(ProjectOutput):
                 stats_info.update(statistics_trend)
         write_json(stats_info, self.statistics_file, indent=4)
 
-    def _get_var_name_and_type(self, var_name: str) -> tuple[str, str, str]:
+    def _get_var_name_and_type(self, var_name: str) -> VariableInfo:
         """Get menu name and type of observation variable
 
         Parameters
@@ -570,20 +572,19 @@ class ExperimentOutput(ProjectOutput):
 
         Returns
         -------
-        str
-            menu name of this variable
-        str
-            vertical type of this variable (2D, 3D)
-        str
-            variable category
-
+        VariableInfo :
+            named tuple containing
+            - menu name of this variable.
+            - Vertical type of this variable (ie. 2D, 3D).
+            - Category of this variable.
         """
         if var_name in var_web_info:
             name, tp, cat = var_web_info[var_name]
         else:
             name, tp, cat = var_name, "UNDEFINED", "UNDEFINED"
             logger.warning(f"Missing menu name definition for var {var_name}.")
-        return (name, tp, cat)
+
+        return VariableInfo(name, tp, cat)
 
     def _init_menu_entry(self, var: str) -> dict:
         name, tp, cat = self._get_var_name_and_type(var)
@@ -751,7 +752,7 @@ class ExperimentOutput(ProjectOutput):
                 )
         return new
 
-    def _sort_menu_entries(self, avail) -> dict:
+    def _sort_menu_entries(self, avail: dict) -> dict:
         """
         Used in method :func:`update_menu_evaluation_iface`
 
@@ -762,8 +763,6 @@ class ExperimentOutput(ProjectOutput):
         ----------
         avail : dict
             nested dictionary contining info about available results
-        config : AerocomEvaluation
-            Configuration class
 
         Returns
         -------

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 
 from pyaerocom import const
 from pyaerocom._lowlevel_helpers import DirLoc, StrType, TypeValidator, sort_dict_by_name
+from pyaerocom.aeroval.collections import ObsCollection
 from pyaerocom.aeroval.glob_defaults import (
     extended_statistics,
     statistics_defaults,
@@ -16,6 +17,7 @@ from pyaerocom.aeroval.glob_defaults import (
     var_web_info,
 )
 from pyaerocom.aeroval.json_utils import check_make_json, read_json, write_json
+from pyaerocom.aeroval.modelentry import ModelEntry
 from pyaerocom.aeroval.setupclasses import EvalSetup
 from pyaerocom.aeroval.varinfo_web import VarinfoWeb
 from pyaerocom.exceptions import EntryNotAvailable, VariableDefinitionError
@@ -604,7 +606,9 @@ class ExperimentOutput(ProjectOutput):
             pass
         return out
 
-    def _check_ovar_mvar_entry(self, mcfg, mod_var, ocfg, obs_var) -> bool:
+    def _check_ovar_mvar_entry(
+        self, mcfg: ModelEntry, mod_var, ocfg: ObsCollection, obs_var
+    ) -> bool:
         muv = mcfg.model_use_vars
         mrv = mcfg.model_rename_vars
 


### PR DESCRIPTION
## Change Summary

- Improved variable naming mainly in `ExperimentOutput`.
- Adds type hinting.
- Removes superfluous if check (EvalSetup no longer has `var_mapping`).
- Use namedtuple for tuple return types.

## Related issue number

NA

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
