### PR TITLE
rename deprecated pandas time-frequencies

### DIFF
--- a/pyaerocom/mathutils.py
+++ b/pyaerocom/mathutils.py
@@ -115,6 +115,7 @@ def weighted_cov(ref_data, data, weights):
     return np.sum(weights * (ref_data - avgx) * (data - avgy)) / np.sum(weights)
 
 
+@ignore_warnings(RuntimeWarning, "invalid value encountered in scalar divide")
 def weighted_corr(ref_data, data, weights):
     """Compute weighted correlation
 

--- a/pyaerocom/time_config.py
+++ b/pyaerocom/time_config.py
@@ -32,16 +32,16 @@ IRIS_AGGREGATORS = {
 # some helper dictionaries for conversion of temporal resolution
 # https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases
 TS_TYPE_TO_PANDAS_FREQ = {
-    "minutely": "T",
-    "hourly": "H",
+    "minutely": "min",
+    "hourly": "h",
     "daily": "D",
     "weekly": "W-MON",
     "monthly": "MS",  # Month start !
     "season": "Q",
-    "yearly": "AS",
+    "yearly": "YS",
 }
 
-PANDAS_RESAMPLE_OFFSETS = {"AS": "181D", "MS": "14D", "D": "12H", "H": "30T"}
+PANDAS_RESAMPLE_OFFSETS = {"YS": "181D", "MS": "14D", "D": "12h", "h": "30min"}
 
 PANDAS_FREQ_TO_TS_TYPE = {v: k for k, v in TS_TYPE_TO_PANDAS_FREQ.items()}
 

--- a/tests/io/test_helpers_units.py
+++ b/tests/io/test_helpers_units.py
@@ -53,7 +53,7 @@ def test_unitconv_sfc_conc(dummy_data):
 
 
 def test_unitconv_wet_depo_bck(dummy_data):
-    time = pd.Series(pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="M"))
+    time = pd.Series(pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="ME"))
     result = unitconv_wet_depo_bck(dummy_data, time)
     assert len(result) == len(
         dummy_data
@@ -61,7 +61,7 @@ def test_unitconv_wet_depo_bck(dummy_data):
 
 
 def test_unitconv_wet_depo_from_emep(dummy_data):
-    time = pd.Series(pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="M"))
+    time = pd.Series(pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="ME"))
     result = unitconv_wet_depo_from_emep(dummy_data, time)
     assert len(result) == len(
         dummy_data
@@ -69,6 +69,6 @@ def test_unitconv_wet_depo_from_emep(dummy_data):
 
 
 def test_unitconv_wet_depo_from_emep_time_not_pandas_series(dummy_data):
-    time = pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="M")
+    time = pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="ME")
     result = unitconv_wet_depo_from_emep(dummy_data, time)
     assert len(result) == len(dummy_data)

--- a/tests/test_tstype.py
+++ b/tests/test_tstype.py
@@ -247,7 +247,7 @@ def test_TsType_to_numpy_freq_error():
 @pytest.mark.parametrize(
     "tst,freq",
     [
-        pytest.param(TsType("3hourly"), "3H", id="3hourly"),
+        pytest.param(TsType("3hourly"), "3h", id="3hourly"),
         pytest.param(TsType("daily"), "D", id="daily"),
     ],
 )


### PR DESCRIPTION
## Change Summary

Some Pandas time-frequencies have been deprecated in pandas 2.2 and give now many deprecation warnings. These time-frequencies have now been updated to use the newer ones (but already available in pandas 1.5).

see https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#offset-aliases

## Related issue number

Related to #1066 , but does not fix it completely.

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
