### PR TITLE
small change to init kwargs correctly

### DIFF
--- a/pyaerocom/io/pyaro/read_pyaro.py
+++ b/pyaerocom/io/pyaro/read_pyaro.py
@@ -5,13 +5,14 @@ from copy import deepcopy
 from typing import NewType, Optional, Union
 
 import numpy as np
+from pyaro import list_timeseries_engines, open_timeseries
+from pyaro.timeseries import Data, Reader, Station
+from pyaro.timeseries.Wrappers import VariableNameChangingReader
+
 from pyaerocom.io.pyaro.pyaro_config import PyaroConfig
 from pyaerocom.io.readungriddedbase import ReadUngriddedBase
 from pyaerocom.tstype import TsType
 from pyaerocom.ungriddeddata import UngriddedData
-from pyaro import list_timeseries_engines, open_timeseries
-from pyaro.timeseries import Data, Reader, Station
-from pyaro.timeseries.Wrappers import VariableNameChangingReader
 
 logger = logging.getLogger(__name__)
 

--- a/pyaerocom/io/pyaro/read_pyaro.py
+++ b/pyaerocom/io/pyaro/read_pyaro.py
@@ -5,14 +5,13 @@ from copy import deepcopy
 from typing import NewType, Optional, Union
 
 import numpy as np
-from pyaro import list_timeseries_engines, open_timeseries
-from pyaro.timeseries import Data, Reader, Station
-from pyaro.timeseries.Wrappers import VariableNameChangingReader
-
 from pyaerocom.io.pyaro.pyaro_config import PyaroConfig
 from pyaerocom.io.readungriddedbase import ReadUngriddedBase
 from pyaerocom.tstype import TsType
 from pyaerocom.ungriddeddata import UngriddedData
+from pyaro import list_timeseries_engines, open_timeseries
+from pyaro.timeseries import Data, Reader, Station
+from pyaro.timeseries.Wrappers import VariableNameChangingReader
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +116,10 @@ class PyaroToUngriddedData:
 
     def _open_reader(self) -> Reader:
         data_id = self.config.data_id
-        kwargs = self.config.model_extra
+        if self.config.model_extra is not None:
+            kwargs = self.config.model_extra
+        else:
+            kwargs = {}
 
         if self.config.name_map is None:
             return open_timeseries(


### PR DESCRIPTION
## Change Summary
 small 2 line change to init kwargs correctly. Necessary since the parallelization calls the reading directly for caching

## Related issue number
fix #1197

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
