### PR TITLE
numpy <2.0.0

### DIFF
--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -9,7 +9,7 @@ dependencies:
   - matplotlib-base >=3.7.1
   - scipy >=1.10.1
   - pandas >=1.5.3
-  - numpy >=1.24.4
+  - numpy >=1.24.4, <2.0.0
   - seaborn >=0.12.2
   - dask
   - geonum ==1.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "matplotlib>=3.7.1",
     "scipy>=1.10.1",
     "pandas>=1.5.3",
-    "numpy>=1.24.4",
+    "numpy>=1.24.4, <2.0.0",
     "seaborn>=0.12.2",
     "dask",
     "geonum==1.5.0",


### PR DESCRIPTION
## Change Summary

Numpy has recently released version 2.0.0 which breaks pyaerocom (see #1206 ). This PR introduces an upper limit of numpy.

## Related issue number

#1206 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
