### PR TITLE
Memory reduction for emep-reporting

### DIFF
--- a/pyaerocom/_logging.py
+++ b/pyaerocom/_logging.py
@@ -20,6 +20,8 @@ import sys
 import time
 from logging.config import fileConfig
 
+import psutil
+
 from pyaerocom.data import resources
 
 
@@ -30,10 +32,11 @@ class MemUsageFilter(logging.Filter):
 
     def filter(self, record):
         mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+        curmem = psutil.Process().memory_info().rss / (1024 * 1024)
         if mem < 1024:
-            record.mem_usage = f"{mem:.0f}M"
+            record.mem_usage = f"{curmem:.0f}/{mem:.0f}M"
         else:
-            record.mem_usage = f"{mem / 1024:.1f}G"
+            record.mem_usage = f"{curmem / 1024:.1f}/{mem / 1024:.1f}G"
         return True
 
 

--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -194,6 +194,7 @@ def read_dataset(paths: list[Path], *, day: int) -> xr.Dataset:
         paths,
         preprocess=preprocess,
         parallel=False,
+        chunks={"time": 24}
     )
     return ds.pipe(fix_coord).pipe(fix_names)
 

--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -190,12 +190,7 @@ def read_dataset(paths: list[Path], *, day: int) -> xr.Dataset:
     def preprocess(ds: xr.Dataset) -> xr.Dataset:
         return ds.pipe(forecast_day, day=day).pipe(fix_missing_vars)
 
-    ds = xr.open_mfdataset(
-        paths,
-        preprocess=preprocess,
-        parallel=False,
-        chunks={"time": 24}
-    )
+    ds = xr.open_mfdataset(paths, preprocess=preprocess, parallel=False, chunks={"time": 24})
     return ds.pipe(fix_coord).pipe(fix_names)
 
 

--- a/pyaerocom/io/ebas_file_index.py
+++ b/pyaerocom/io/ebas_file_index.py
@@ -319,10 +319,14 @@ class EbasFileIndex:
         else:
             raise ValueError(f"Unsupported request type {type(request)}")
 
-        with sqlite3.connect(self.database) as con:
-            cur = con.cursor()
-            cur.execute(sql_str)
-            return [f for f in cur.fetchall()]
+        try:
+            with sqlite3.connect(self.database) as con:
+                cur = con.cursor()
+                cur.execute(sql_str)
+                return [f for f in cur.fetchall()]
+        except Exception as ex:
+            logger.error(f"Error with {self.database} and {sql_str}")
+            raise ex
 
     def get_file_names(self, request):
         """Get all files that match the request specifications

--- a/pyaerocom/io/gaw/reader.py
+++ b/pyaerocom/io/gaw/reader.py
@@ -369,6 +369,5 @@ class ReadGAW(ReadUngriddedBase):
         # Shorten data_obj._data to the right number of points
         data_obj._data = data_obj._data[:idx]
         # data_obj.data_revision[self.DATASET_NAME] = self.data_revision
-        self.data = data_obj
 
         return data_obj

--- a/pyaerocom/io/mscw_ctm/reader.py
+++ b/pyaerocom/io/mscw_ctm/reader.py
@@ -504,7 +504,7 @@ class ReadMscwCtm:
         if len(fps) > 1 and ts_type == "hourly":
             raise ValueError(f"ts_type {ts_type} can not be hourly when using multiple years")
         logger.info(f"Opening {fps}")
-        ds = xr.open_mfdataset(fps)
+        ds = xr.open_mfdataset(fps, chunks={"time": 24})
 
         self._filedata = ds
 

--- a/pyaerocom/io/read_aasetal.py
+++ b/pyaerocom/io/read_aasetal.py
@@ -316,7 +316,6 @@ class ReadAasEtal(ReadUngriddedBase):
         data_obj._data = data_obj._data[:idx]
         # sanity check
         data_obj._check_index()
-        self.data = data_obj  # initalizing a pointer to it selves
         return data_obj
 
 

--- a/pyaerocom/io/read_earlinet.py
+++ b/pyaerocom/io/read_earlinet.py
@@ -614,7 +614,6 @@ class ReadEarlinet(ReadUngriddedBase):
         # shorten data_obj._data to the right number of points
         data_obj._data = data_obj._data[:idx]
 
-        self.data = data_obj
         return data_obj
 
     def _get_exclude_filelist(self):  # pragma: no cover

--- a/pyaerocom/io/read_eea_aqerep_base.py
+++ b/pyaerocom/io/read_eea_aqerep_base.py
@@ -739,7 +739,6 @@ class ReadEEAAQEREPBase(ReadUngriddedBase):
         # Shorten data_obj._data to the right number of points
         data_obj._data = data_obj._data[:idx]
         # data_obj.data_revision[self.DATASET_NAME] = self.data_revision
-        self.data = data_obj
         self._metadata = None
         self.files = files
 

--- a/pyaerocom/io/readaeronetbase.py
+++ b/pyaerocom/io/readaeronetbase.py
@@ -476,5 +476,4 @@ class ReadAeronetBase(ReadUngriddedBase):
         # shorten data_obj._data to the right number of points
         data_obj._data = data_obj._data[:idx]
         # data_obj.data_revision[self.data_id] = self.data_revision
-        self.data = data_obj
         return data_obj

--- a/pyaerocom/io/readungridded.py
+++ b/pyaerocom/io/readungridded.py
@@ -555,6 +555,9 @@ class ReadUngridded:
             if data_read is not None:
                 data_out.append(data_read)
 
+        # close the cache-object, keeps otherwise data-references
+        cache = None
+
         if _caching is not None:
             const.CACHING = _caching
 

--- a/pyaerocom/io/readungriddedbase.py
+++ b/pyaerocom/io/readungriddedbase.py
@@ -211,7 +211,6 @@ class ReadUngriddedBase(abc.ABC):
     ### Concrete implementations of methods that are the same for all (or most)
     # of the derived reading classes
     def __init__(self, data_id: str | None = None, data_dir: str | None = None):
-        self.data = None  # object that holds the loaded data
         self._data_id = None
         self.files = []
         # list that will be updated in read method to store all files that

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -20,6 +20,7 @@ dependencies:
   - typer >=0.7.0
   - pydantic > 2.0.0
   - pooch >=1.7.0
+  - psutil >= 5.0.0
 ## python < 3.11
   - tomli >=2.0.1
   - importlib-resources >=5.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ dependencies = [
     'cf-units>=3.1',
     "pydantic>=2.7.1",
     "pyaro>=0.0.10",
-    "pooch>=1.7.0"
+    "pooch>=1.7.0",
+    "psutil>=5.0.0"
 ]
 
 [project.readme]
@@ -201,7 +202,7 @@ requires =
 [testenv]
 commands_pre =
     python --version
-    python -m pip freeze --all 
+    python -m pip freeze --all
 commands =
     python -m pytest -ra -q {posargs:--cov --no-cov-on-fail}
 extras =


### PR DESCRIPTION
## Change Summary

This PR fixes some memory issues discovered during work with emep-reporting.

- mem_usage logging writes now current and max rss memory uages
- chunk-hint along time-axis reduces memory by 20G for hourly colocation, without any performance penalty
- data-references of observation-data were kept unnecessary long have been removed

This PR adds also a new requirement: `psutil`

## Related issue number

The remaining issue is now reading eea-data which will keep all existing data per variable in memory, leading to ~55GB peak-memory usage, though during processing only 1-5G data are needed. This will be addressed in https://github.com/metno/pyaro-readers/issues/43

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
