### PR TITLE
Fixes for map-plotting of emep-results

### DIFF
--- a/pyaerocom/aeroval/glob_defaults.py
+++ b/pyaerocom/aeroval/glob_defaults.py
@@ -70,7 +70,9 @@ var_ranges_defaults = {
     "concpm25": {"scale": [0, 5, 10, 15, 20, 25, 30, 35, 40, 45], "colmap": "coolwarm"},
     "conco3": {"scale": [0, 15, 30, 45, 60, 75, 90, 105, 120], "colmap": "coolwarm"},
     "vmro3": {"scale": [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70], "colmap": "coolwarm"},
+    "vmrox": {"scale": [20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70], "colmap": "coolwarm"},
     "concno2": {"scale": [0, 10, 20, 30, 40, 50, 60, 70, 80], "colmap": "coolwarm"},
+    "concNno2": {"scale": [0, 0.3, 0.5, 1, 1.3, 1.5, 2, 3, 5], "colmap": "coolwarm"},
     "vmrno2": {"scale": [0, 5, 10, 15, 20, 25, 30, 35, 40], "colmap": "coolwarm"},
     "vmro3max": {"scale": [0, 7.5, 15, 22.5, 30, 37.5, 45, 52.5, 60], "colmap": "coolwarm"},
     "concNhno3": {

--- a/pyaerocom/aeroval/helpers.py
+++ b/pyaerocom/aeroval/helpers.py
@@ -43,8 +43,9 @@ def check_var_ranges_avail(model_data, var_name):
     """
     try:
         VarinfoWeb(var_name)
-    except AttributeError:
+    except AttributeError as aex:
         if model_data.var_name_aerocom == var_name:
+            logger.info(f"re-registering var {var_name} due to: {aex}")
             model_data.register_var_glob(delete_existing=True)
         else:
             raise ValueError(

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -148,7 +148,8 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
             cmapinfo = var_ranges_defaults[var]
             varinfo = VarinfoWeb(var, cmap=cmapinfo["colmap"], cmap_bins=cmapinfo["scale"])
         else:
-            varinfo = VarinfoWeb(var)
+            cmapinfo = var_ranges_defaults["default"]
+            varinfo = VarinfoWeb(var, cmap=cmapinfo["colmap"], cmap_bins=cmapinfo["scale"])
 
         data = self._check_dimensions(data)
 

--- a/pyaerocom/aeroval/varinfo_web.py
+++ b/pyaerocom/aeroval/varinfo_web.py
@@ -42,8 +42,8 @@ class VarinfoWeb:
         var_name: str,
         cmap: str = None,
         cmap_bins: list = None,
-        vmin: float = None,
-        vmax: float = None,
+        vmin: float|None = None,
+        vmax: float|None = None,
     ):
         if cmap_bins is not None:
             if vmin is not None or vmax is not None:

--- a/pyaerocom/aeroval/varinfo_web.py
+++ b/pyaerocom/aeroval/varinfo_web.py
@@ -42,8 +42,8 @@ class VarinfoWeb:
         var_name: str,
         cmap: str = None,
         cmap_bins: list = None,
-        vmin: float|None = None,
-        vmax: float|None = None,
+        vmin: float | None = None,
+        vmax: float | None = None,
     ):
         if cmap_bins is not None:
             if vmin is not None or vmax is not None:

--- a/pyaerocom/colocation/colocation_setup.py
+++ b/pyaerocom/colocation/colocation_setup.py
@@ -270,7 +270,8 @@ class ColocationSetup(BaseModel):
         co-located NetCDF file (under the output location specified by
         :attr:`basedir_coldata` ) for the given variable combination to be
         co-located. If False and output already exists, then co-location is
-        skipped for the associated variable. Default is True.
+        skipped for the associated variable. This flag is also used for contour-plots.
+        Default is True.
     raise_exceptions : bool
         if True, Exceptions that may occur for individual variables to be
         processed, are raised, else the analysis is skipped for such cases.

--- a/pyaerocom/data/variables.ini
+++ b/pyaerocom/data/variables.ini
@@ -3547,7 +3547,7 @@ comments_and_purpose = SO2 and sulfate aerosol precursor.
 
 [vmrox]
 description=Volume mixing ratio of NO2 + O3
-unit = mole mole-1
+unit = nmole mole-1
 
 [mmrox]
 description=Mass mixing ratio of NO2 + O3

--- a/pyaerocom/griddeddata.py
+++ b/pyaerocom/griddeddata.py
@@ -669,23 +669,26 @@ class GriddedData:
             minimum=vmin,
             maximum=vmax,
         )
+        var_existed = False
         if delete_existing:
             varcol = const.VARS
             if self.var_name in varcol:
                 varcol.delete_variable(self.var_name)
+                var_existed = True
         const.VARS.add_var(vardef)
-        logger.warning(
-            f"Adding variable {self.var_name} in pyaerocom.const.VARS. "
-            f"since such a  "
-            f"variable is not defined in pyaerocom. Minimum and maximum "
-            f"values are added automatically based on value range in "
-            f"associated GriddedData object to: minimum={vmin}, maximum="
-            f"{vmax}. Since this will add the variable only temporarily "
-            f"during this run, this might interrupt the processing "
-            f"workflow unexpectedly when rerunning parts of the code without "
-            f"explictly calling GriddedData.register_var_glob. It may be best "
-            f"to add this variable to pyaerocom/data/variables.ini."
-        )
+        if not var_existed:
+            logger.warning(
+                f"Adding variable {self.var_name} in pyaerocom.const.VARS. "
+                f"since such a  "
+                f"variable is not defined in pyaerocom. Minimum and maximum "
+                f"values are added automatically based on value range in "
+                f"associated GriddedData object to: minimum={vmin}, maximum="
+                f"{vmax}. Since this will add the variable only temporarily "
+                f"during this run, this might interrupt the processing "
+                f"workflow unexpectedly when rerunning parts of the code without "
+                f"explictly calling GriddedData.register_var_glob. It may be best "
+                f"to add this variable to pyaerocom/data/variables.ini."
+            )
         return vardef
 
     @ignore_warnings(UserWarning, "Ignoring netCDF variable '.*' invalid units '.*'")


### PR DESCRIPTION
## Change Summary

Several fixes to get map-plotting useful for the emep-reports like

- Fixing units
- Fixing scales
- Using a default-scale 0-10 for variables not previously defined in glob_defaults.py
- removing misleading warnings

## Related issue number

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
