### PR TITLE
put all temporary and testing data below the path  ~/MyPyaerocom

### DIFF
--- a/pyaerocom/config.py
+++ b/pyaerocom/config.py
@@ -370,8 +370,7 @@ class Config:
     @property
     def OUTPUTDIR(self):
         """Default output directory"""
-        if not check_write_access(self._outputdir):
-            self._outputdir = chk_make_subdir(self.HOMEDIR, self._outhomename)
+        self._outputdir = chk_make_subdir(self.HOMEDIR, self._outhomename)
         return self._outputdir
 
     @property


### PR DESCRIPTION
The title says it all

## Change Summary

just return always a link to ~/MyPyaerocom in the Config class.
Makes all temporary pyaerocom data personal

## Related issue number

fix #1229 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
