### PR TITLE
Cache validation ignore pyaerocom version; use mtime instead of ctime

### DIFF
--- a/pyaerocom/io/cachehandler_ungridded.py
+++ b/pyaerocom/io/cachehandler_ungridded.py
@@ -149,19 +149,27 @@ class CacheHandlerUngridded:
         head = pickle.load(in_handle)
         if not isinstance(head, dict):
             raise CacheReadError("Invalid cache file")
+        pya_version = "pyaerocom_version"
         for k, v in head.items():
             if not k in current:
                 raise CacheReadError(f"Invalid cache header key: {k}")
-            elif not v == current[k]:
-                logger.info(f"{k} is outdated (value: {v}). Current value: {current[k]}")
-                return False
+            else:
+                if k == pya_version:
+                    continue
+                elif v != current[k]:
+                    logger.info(f"{k} is outdated (value: {v}). Current value: {current[k]}")
+                    return False
+        if current[pya_version] != head[pya_version]:
+            logger.info(
+                f"cache generated with pyaerocom {head[pya_version]}, current is {current[pya_version]}"
+            )
         return True
 
     def cache_meta_info(self):
         """Dictionary containing relevant caching meta-info"""
         try:
-            newestp = max(glob.iglob(os.path.join(self.src_data_dir, "*")), key=os.path.getctime)
-            newest_date = os.path.getctime(newestp)
+            newestp = max(glob.iglob(os.path.join(self.src_data_dir, "*")), key=os.path.getmtime)
+            newest_date = os.path.getmtime(newestp)
             newest = os.path.basename(newestp)
 
         except Exception:


### PR DESCRIPTION
## Change Summary

The cache validation of ungridded data was using the pyaercom_version to identify invalid caches. Since caches and pyaerocom_version are independent, this is now only logged, but no longer used to invalidate caches.

In addition, cache validation was using ctime to identify newest files, but ctime is metadata change time, i.e. when permissions/ownerships of data changed last. This has been changed to mtime which is data modification time.

## Related issue number

fixes #1242 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
