### PR TITLE
Simplify mscw-reader path requirements, read year_available from files

### DIFF
--- a/pyaerocom/io/mscw_ctm/reader.py
+++ b/pyaerocom/io/mscw_ctm/reader.py
@@ -305,7 +305,7 @@ class ReadMscwCtm:
             file = os.path.split(path)[1]
 
             if self._get_tst_from_file(file) != ts_type:
-                logger.info(f"ignoring file {path}: not of type {ts_type}")
+                logger.debug(f"ignoring file {path}: not of type {ts_type}")
                 continue
 
             try:

--- a/pyaerocom/io/mscw_ctm/reader.py
+++ b/pyaerocom/io/mscw_ctm/reader.py
@@ -171,6 +171,7 @@ class ReadMscwCtm:
 
     DEFAULT_FILE_NAME = "Base_day.nc"
 
+    #: pattern for 4-digit years for 19XX and 20XX used for trend subdirectories
     YEAR_PATTERN = r".*((?:19|20)\d\d).*"
 
     def __init__(self, data_id=None, data_dir=None, **kwargs):

--- a/pyaerocom/io/mscw_ctm/reader.py
+++ b/pyaerocom/io/mscw_ctm/reader.py
@@ -50,8 +50,6 @@ class ReadMscwCtm:
 
     Parameters
     ----------
-    filepath : str
-        Path to netcdf file.
     data_id : str
         string ID of model (e.g. "AATSR_SU_v4.3","CAM5.3-Oslo_CTRL2016")
     data_dir : str, optional
@@ -178,7 +176,6 @@ class ReadMscwCtm:
         self._filename = None
         self._filedata = None
         self._filepaths = None
-        self._filepath = None
 
         self._file_mask = self.FILE_MASKS[0]
         self._files = None
@@ -350,25 +347,6 @@ class ReadMscwCtm:
             return
         self._filename = val
         self._filedata = None
-
-    @property
-    def filepath(self):
-        """
-        Path to data file
-        """
-        if self.data_dir is None and self._filepaths is None:  # pragma: no cover
-            raise AttributeError("data_dir or filepaths needs to be set before accessing")
-        return self._filepath
-
-    @filepath.setter
-    def filepath(self, value):
-        if not isinstance(value, str):
-            raise TypeError("needs to be a string")
-
-        self._filepath = value
-        ddir, fname = os.path.split(value)
-        self.data_dir = ddir
-        self.filename = fname
 
     @property
     def filepaths(self):

--- a/pyaerocom/io/mscw_ctm/reader.py
+++ b/pyaerocom/io/mscw_ctm/reader.py
@@ -150,8 +150,6 @@ class ReadMscwCtm:
         # "concpolyol": calc_concpolyol,
     }
 
-    #: supported filename masks, placeholder is for frequencies
-    FILE_MASKS = ["Base_*.nc"]
     #: supported filename template, freq-placeholder is for frequencies
     FILE_FREQ_TEMPLATE = "Base_{freq}.nc"
 
@@ -384,9 +382,6 @@ class ReadMscwCtm:
 
         Returns
         -------
-        str
-            file mask used (is identified automatically based on
-            :attr:`FILE_MASKS`)
         list
             list of file matches
 
@@ -548,20 +543,19 @@ class ReadMscwCtm:
         Raises
         ------
         ValueError
-            If no file could be inferred.
+            On wrong ts_type.
 
         Returns
         -------
         fname : str
-            Name of data file inferred based on current file mask and input
+            Name of data file based on ts_type
             freq.
 
         """
-        for substr, tst in self.FREQ_CODES.items():
-            if tst == ts_type:
-                fname = self.FILE_FREQ_TEMPLATE.format(freq=substr)
-                return fname
-        raise ValueError(f"failed to infer filename from input ts_type={ts_type}")
+        if not ts_type in self.REVERSE_FREQ_CODES:
+            raise ValueError(f"unknown ts_type={ts_type}")
+        freq = self.REVERSE_FREQ_CODES[ts_type]
+        return self.FILE_FREQ_TEMPLATE.format(freq=freq)
 
     def _compute_var(self, var_name_aerocom, ts_type):
         """Compute auxiliary variable

--- a/tests/io/mscw_ctm/test_reader.py
+++ b/tests/io/mscw_ctm/test_reader.py
@@ -358,30 +358,6 @@ def test_ReadMscwCtm_has_var_error(reader):
     assert str(e.value) == "Error (VarCollection): input variable blaa is not supported"
 
 
-def test_ReadMscwCtm_filepath(reader, data_dir: str):
-    path = Path(data_dir) / "Base_month.nc"
-    reader.filepath = str(path)
-    assert Path(reader.filepath) == path
-
-
-@pytest.mark.parametrize(
-    "value, exception, error",
-    [
-        (None, TypeError, "needs to be a string"),
-        ("", FileNotFoundError, ""),
-        (
-            "/tmp",
-            FileNotFoundError,
-            "No valid model files could be found in / for any of the supported file masks: ['Base_*.nc']",
-        ),
-    ],
-)
-def test_ReadMscwCtm_filepath_error(reader, value, exception, error):
-    with pytest.raises(exception) as e:
-        reader.filepath = value
-    assert str(e.value) == error
-
-
 def test_ReadMscwCtm__str__():
     assert str(ReadMscwCtm()) == "ReadMscwCtm"
 

--- a/tests/io/mscw_ctm/test_reader.py
+++ b/tests/io/mscw_ctm/test_reader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
@@ -135,6 +136,15 @@ def reader() -> ReadMscwCtm:
 def data_dir(path_emep: dict[str, str]) -> str:
     """path to EMEP test data"""
     return path_emep["data_dir"]
+
+
+def test_ReadMscwCtm__get_year_from_nc(data_dir: str):
+    yr = ReadMscwCtm._get_year_from_nc(os.path.join(data_dir, "Base_fullrun.nc"))
+    assert yr == 2017
+    yr = ReadMscwCtm._get_year_from_nc(os.path.join(data_dir, "Base_day.nc"))
+    assert yr == 2017
+    yr = ReadMscwCtm._get_year_from_nc(os.path.join(data_dir, "Base_month.nc"))
+    assert yr == 2017
 
 
 def test_ReadMscwCtm__init__(data_dir: str):

--- a/tests/io/mscw_ctm/test_reader.py
+++ b/tests/io/mscw_ctm/test_reader.py
@@ -172,8 +172,7 @@ def test_ReadMscwCtm_data_dir_error(value, exception, error: str):
 
 def test__ReadMscwCtm__check_files_in_data_dir(data_dir: str):
     reader = ReadMscwCtm()
-    mask, matches = reader._check_files_in_data_dir(data_dir)
-    assert mask == "Base_*.nc"
+    matches = reader._check_files_in_data_dir(data_dir)
     assert len(matches) == 3
 
 
@@ -558,16 +557,18 @@ def test_read_emep_wrong_tst(data_path: Path, wrong_tst: str):
         wrong_path = Path(filepaths[0]).with_name(f"Base_{wrong_tst}.nc")
         reader._get_tst_from_file(str(wrong_path))
 
-    assert str(e.value) == f"The ts_type {wrong_tst} is not supported"
+    assert str(e.value) == f"The file {wrong_path} is not supported"
 
 
 def test_read_emep_LF_tst(tmp_path: Path):
     data_path = emep_data_path(tmp_path, "month", vars_and_units={"prmm": "mm"})
     reader = ReadMscwCtm(data_dir=str(data_path))
-    filepaths = reader.filepaths
-    wrong_path = Path(filepaths[0]).with_name(f"Base_LF_month.nc")
+    with pytest.raises(ValueError) as e:
+        filepaths = reader.filepaths
+        wrong_path = Path(filepaths[0]).with_name(f"Base_LF_month.nc")
+        reader._get_tst_from_file(str(wrong_path))
 
-    assert reader._get_tst_from_file(str(wrong_path)) is None
+    assert str(e.value) == f"The file {wrong_path} is not supported"
 
 
 def test_read_emep_year_defined_twice(tmp_path: Path):

--- a/tests/io/mscw_ctm/test_reader.py
+++ b/tests/io/mscw_ctm/test_reader.py
@@ -306,15 +306,13 @@ def test_ReadMscwCtm_ts_type_from_filename_error(reader):
     ],
 )
 def test_ReadMscwCtm_filename_from_ts_type(reader, filename, ts_type):
-    reader._file_mask = reader.FILE_MASKS[0]
     assert reader.filename_from_ts_type(ts_type) == filename
 
 
 def test_ReadMscwCtm_filename_from_ts_type_error(reader):
-    reader._file_mask = reader.FILE_MASKS[0]
     with pytest.raises(ValueError) as e:
         reader.filename_from_ts_type("blaaa")
-    assert str(e.value) == "failed to infer filename from input ts_type=blaaa"
+    assert str(e.value) == "unknown ts_type=blaaa"
 
 
 def test_ReadMscwCtm_years_avail(data_dir: str):


### PR DESCRIPTION
## Change Summary

- The mscw-reader no longer reads unknown model-files. Known model-files are now clearly stated instead of guessed by globs.
- There is no longer a requirement of 4-digits in the data-dir which were interpreted as year.
- years-available are now read from the model-files like Base_fullrun.nc
- Trends/multi-year analysis can be given as a `data-dir` to a directory containing subdirectories with four-digits. The subdirectories must contain Base_*.nc files (with * being hour, day, month, fullrun)
- the `filepath` attribute was never used and therefore removed

## Related issue number

fixes #896 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
