### PR TITLE
Fix 1246: var_list not being applied appropriately to obs_vars from networks 

### DIFF
--- a/.github/ISSUE_TEMPLATE/general_issue.md
+++ b/.github/ISSUE_TEMPLATE/general_issue.md
@@ -5,3 +5,5 @@ title: ''
 labels: ''
 
 ---
+
+ * [ ] I assert that this issue is not a bug, feature request, nor suggest changes to the documentation. I accept the possibility that this issue will not be addressed if it falls under one of the aforementioned categories.

--- a/.github/ISSUE_TEMPLATE/general_issue.md
+++ b/.github/ISSUE_TEMPLATE/general_issue.md
@@ -1,9 +1,0 @@
----
-name: General issue
-about: Used for general issues, not covered by other templates.
-title: ''
-labels: ''
-
----
-
- * [ ] I assert that this issue is not a bug, feature request, nor suggest changes to the documentation. I accept the possibility that this issue will not be addressed if it falls under one of the aforementioned categories.

--- a/pyaerocom/aeroval/experiment_processor.py
+++ b/pyaerocom/aeroval/experiment_processor.py
@@ -66,6 +66,17 @@ class ExperimentProcessor(ProcessingEngine, HasColocator):
                 engine.run(files_to_convert)
 
         else:
+            # If a var_list is given, only run on the obs networks which contain that variable
+            if var_list:
+                var_list_asked = var_list
+                obs_vars = ocfg["obs_vars"]
+                var_list = list(set(obs_vars) & set(var_list))
+                if not var_list:
+                    logger.warning(
+                        "var_list %s and obs_vars %s mismatch.", var_list_asked, obs_vars
+                    )
+                    return
+
             col = self.get_colocator(model_name, obs_name)
             if self.cfg.processing_opts.only_json:
                 files_to_convert = col.get_available_coldata_files(var_list)
@@ -144,7 +155,6 @@ class ExperimentProcessor(ProcessingEngine, HasColocator):
             for obs_name in obs_list:
                 for model_name in model_list:
                     self._run_single_entry(model_name, obs_name, var_list)
-
         if update_interface:
             self.update_interface()
         if use_dummy_model:

--- a/pyaerocom/aeroval/experiment_processor.py
+++ b/pyaerocom/aeroval/experiment_processor.py
@@ -111,7 +111,7 @@ class ExperimentProcessor(ProcessingEngine, HasColocator):
         var_list : list, optional
             list variables supposed to be analysed. If None, then all
             variables available are used. Defaults to None. Can also be
-            `str` type.
+            `str` type. Must match at least some of the variables provided by a observation network.
         update_interface : bool
             if true, relevant json files that determine what is displayed
             online are updated after the run, including the the menu.json file

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -687,7 +687,7 @@ class Colocator:
     def _filter_var_matches_var_name(self, var_matches, var_name):
         filtered = {}
         for mvar, ovar in var_matches.items():
-            if mvar in var_name or ovar in var_name:
+            if mvar == var_name or ovar == var_name:
                 filtered[mvar] = ovar
         if len(filtered) == 0:
             raise DataCoverageError(var_name)

--- a/tests/aeroval/test_experiment_processor.py
+++ b/tests/aeroval/test_experiment_processor.py
@@ -43,3 +43,17 @@ def test_ExperimentProcessor_run_error(processor: ExperimentProcessor, kwargs: d
     with pytest.raises(KeyError) as e:
         processor.run(**kwargs)
     assert str(e.value) == error
+
+
+@geojson_unavail
+@pytest.mark.parametrize(
+    "cfg,kwargs,error",
+    [
+        ("cfgexp2", dict(var_list="BLUB"), "var_list %s and obs_vars %s mismatch."),
+    ],
+)
+def test_ExperimentProcessor_catch_wrong_var_list(
+    processor: ExperimentProcessor, kwargs: dict, error: str, caplog
+):
+    processor.run(**kwargs)
+    assert any([error in str(record) for record in caplog.records])


### PR DESCRIPTION
## Change Summary

- `colocator.py::_filter_var_matches_var_names()` checks on string equality not subset inclusion
- `pyaerocom/aeroval/experiment_processor.py`: code has been added such that if a `var_list` is given, only run against the obs networks which contain that variable
- A test has been added which checks the above functionality


## Related issue number

Fix #1246 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
