### PR TITLE
Fix SO4 in seasalt

### DIFF
--- a/pyaerocom/io/mscw_ctm/additional_variables.py
+++ b/pyaerocom/io/mscw_ctm/additional_variables.py
@@ -316,7 +316,7 @@ def calc_conNtnh_emep(*arrs):
 
 
 def calc_concso4t(concso4, concss):
-    factor = 0.007
+    factor = 0.077  # 7.7% SO4+ in seasalt
     concso4t = concso4 + factor * concss
     concso4t.attrs["units"] = "ug m-3"
 


### PR DESCRIPTION
## Change Summary

Seasalt contains approx 7.7% SO4. The earlier value of 0.7% must have been typo.

Reported by @svetlanat on chat.

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
