### PR TITLE
MDA8 timestamp and superfluous values

### DIFF
--- a/pyaerocom/stats/mda8/mda8.py
+++ b/pyaerocom/stats/mda8/mda8.py
@@ -93,7 +93,7 @@ def _calc_mda8(data: xr.DataArray) -> xr.DataArray:
 
     # Keep only values for days that existed in the original time series.
     mda8 = mda8.sel(
-        time=[x in set(data.coords["time.date"].values) for x in mda8.coords["time.date"].values]
+        time=np.isin(mda8.coords["time.date"].values, np.unique(data.coords["time.date"].values))
     )
 
     return mda8

--- a/pyaerocom/stats/mda8/mda8.py
+++ b/pyaerocom/stats/mda8/mda8.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import timedelta
 
 import numpy as np
 import pandas as pd
@@ -86,7 +85,7 @@ def _calc_mda8(data: xr.DataArray) -> xr.DataArray:
     in the input dataarray to ensure that the ts does not expand.
     """
     mda8 = _daily_max(_rolling_average_8hr(data))
-    # mda8 = mda8[:, 1:, :]
+
     mda8.attrs["ts_type"] = "daily"
 
     # Ensure time dimension represents the midpoint of the interval.

--- a/pyaerocom/stats/mda8/mda8.py
+++ b/pyaerocom/stats/mda8/mda8.py
@@ -93,7 +93,7 @@ def _calc_mda8(data: xr.DataArray) -> xr.DataArray:
 
     # Keep only values for days that existed in the original time series.
     mda8 = mda8.sel(
-        time=[x in set(data.coords["time.day"].values) for x in mda8.coords["time.day"].values]
+        time=[x in set(data.coords["time.date"].values) for x in mda8.coords["time.date"].values]
     )
 
     return mda8

--- a/pyaerocom/stats/mda8/mda8.py
+++ b/pyaerocom/stats/mda8/mda8.py
@@ -79,6 +79,11 @@ def _calc_mda8(data: xr.DataArray) -> xr.DataArray:
     > ends i.e. the first calculation period for any one day will be the period from
     > 17:00 on the previous day to 01:00 on that day; the last calculation period for
     > any one day will be the period from 16:00 to 24:00 on that day.
+
+    Note:
+    -----
+    Calculated values will only be returned for days which have at least one datapoint
+    in the input dataarray to ensure that the ts does not expand.
     """
     mda8 = _daily_max(_rolling_average_8hr(data))
     # mda8 = mda8[:, 1:, :]

--- a/tests/io/test_readgridded.py
+++ b/tests/io/test_readgridded.py
@@ -203,7 +203,7 @@ def test_file_info(reader_reanalysis: ReadGridded):
 @lustre_unavail
 def test_years_available(reader_reanalysis: ReadGridded):
     # go up to 2023 because 2022 is now available. Will likely need to be updated in the future
-    years = list(range(2003, 2024))
+    years = list(range(2003, 2025))
     assert reader_reanalysis.years_avail == years
 
 

--- a/tests/stats/mda8/test_mda8.py
+++ b/tests/stats/mda8/test_mda8.py
@@ -89,11 +89,10 @@ def test_coldata_to_mda8(coldata):
     assert isinstance(mda8, ColocatedData)
     assert mda8.metadata["ts_type"] == "daily"
     assert mda8.metadata["var_name"] == ["vmro3mda8", "vmro3mda8"]
-    assert mda8.shape == (2, 9, 1)
+    assert mda8.shape == (2, 8, 1)
 
     assert mda8.data.values[0, :, 0] == pytest.approx(
         [
-            np.nan,
             np.nan,
             np.nan,
             1.18741556,
@@ -109,7 +108,6 @@ def test_coldata_to_mda8(coldata):
 
     assert mda8.data.values[1, :, 0] == pytest.approx(
         [
-            np.nan,
             1.57327333,
             1.28884431,
             1.28741556,


### PR DESCRIPTION
## Change Summary
- MDA8 values will now have the interval midpoint as their timestamp (ie. 1pm / 13:00 instead of 1am / 01:00).
- MDA8 will not include calculated values for days which did not have at least one data point in the input timeseries.

## Related issue number

- fix #1262
- fix #1263

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally (Except `test_readgridded/test_years_available`)
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
