### PR TITLE
Suppress or fix warnings

### DIFF
--- a/pyaerocom/io/read_ebas.py
+++ b/pyaerocom/io/read_ebas.py
@@ -1516,13 +1516,14 @@ class ReadEbas(ReadUngriddedBase):
         if TsType(freq_ebas).check_match_total_seconds(most_common_dt):
             return freq_ebas
 
-        logger.warning(
+        logger.info(
             f"Detected wrong frequency {freq_ebas}. Trying to infer the correct frequency..."
         )
         try:
             freq = TsType.from_total_seconds(most_common_dt)
             return str(freq)
         except TemporalResolutionError:
+            logger.warning("Unable to infer the correct frequency...")
             raise TemporalResolutionError(
                 f"Failed to derive correct sampling frequency in {file.file_name}. "
                 f"Most common meas period (stop_meas - start_meas) in file is "

--- a/pyaerocom/stats/implementations.py
+++ b/pyaerocom/stats/implementations.py
@@ -1,7 +1,9 @@
 import numpy as np
-from scipy.stats import kendalltau, spearmanr
+from scipy.stats import ConstantInputWarning, kendalltau, spearmanr
 
 from pyaerocom.mathutils import corr, sum
+
+from .._warnings import ignore_warnings
 
 
 def stat_R(data: np.ndarray, ref_data: np.ndarray, weights: np.ndarray | None) -> np.float64:
@@ -45,6 +47,7 @@ def stat_mab(data: np.ndarray, ref_data: np.ndarray, weights: np.ndarray | None)
     return sum(np.abs(difference)) / len(data)
 
 
+@ignore_warnings(RuntimeWarning, "invalid value encountered in divide")
 def stat_mnmb(data: np.ndarray, ref_data: np.ndarray, weights: np.ndarray | None) -> np.float64:
     """
     Modified normalised mean bias implementation.
@@ -56,6 +59,7 @@ def stat_mnmb(data: np.ndarray, ref_data: np.ndarray, weights: np.ndarray | None
     return 2 / len(data) * sum(difference / (data + ref_data))
 
 
+@ignore_warnings(RuntimeWarning, "invalid value encountered in divide")
 def stat_fge(data: np.ndarray, ref_data: np.ndarray, weights: np.ndarray | None) -> np.float64:
     """
     Fractional gross error implementation.
@@ -67,6 +71,9 @@ def stat_fge(data: np.ndarray, ref_data: np.ndarray, weights: np.ndarray | None)
     return 2 / len(data) * sum(np.abs(difference / (data + ref_data)), weights=weights)
 
 
+@ignore_warnings(
+    ConstantInputWarning, "An input array is constant; the correlation coefficient is not defined."
+)
 def stat_R_spearman(
     data: np.ndarray, ref_data: np.ndarray, weights: np.ndarray | None
 ) -> np.float64:

--- a/tests/cams2_83/test_cams2_83_cli_mos.py
+++ b/tests/cams2_83/test_cams2_83_cli_mos.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
+from _warnings import ignore_warnings
 from pyaerocom.scripts.cams2_83.cli_mos import app
 
 runner = CliRunner()
@@ -71,6 +72,7 @@ def test_eval_mos_standard(tmp_path: Path, coldata_mos: Path, caplog):
     assert "Done Running Statistics (MOS)" in caplog.text
 
 
+@ignore_warnings(RuntimeWarning, "invalid value encountered in divide")
 @pytest.mark.usefixtures("fake_ExperimentProcessor", "reset_cachedir")
 def test_eval_mos_medianscores(tmp_path: Path, coldata_mos: Path, caplog):
     options = f"season 2024-03-01 2024-03-05 --data-path {tmp_path} --coldata-path {coldata_mos} --cache {tmp_path} --id mos-colocated-data --name 'Test'"

--- a/tests/cams2_83/test_cams2_83_cli_mos.py
+++ b/tests/cams2_83/test_cams2_83_cli_mos.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
-from _warnings import ignore_warnings
+from pyaerocom._warnings import ignore_warnings
 from pyaerocom.scripts.cams2_83.cli_mos import app
 
 runner = CliRunner()

--- a/tests/io/test_helpers_units.py
+++ b/tests/io/test_helpers_units.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pytest
 from scipy.constants import Avogadro
 
+from _warnings import ignore_warnings
 from pyaerocom.io.helpers_units import (
     mass_to_nr_molecules,
     nr_molecules_to_mass,
@@ -52,23 +53,35 @@ def test_unitconv_sfc_conc(dummy_data):
     assert np.all(result == pytest.approx(1.99796663, 1e-4))
 
 
+@ignore_warnings(
+    FutureWarning,
+    "'M' is deprecated and will be removed in a future version, please use 'ME' instead.",
+)
 def test_unitconv_wet_depo_bck(dummy_data):
-    time = pd.Series(pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="ME"))
+    time = pd.Series(pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="M"))
     result = unitconv_wet_depo_bck(dummy_data, time)
     assert len(result) == len(
         dummy_data
     )  # sufficent to check length b/c wet depo will change month-to-month
 
 
+@ignore_warnings(
+    FutureWarning,
+    "'M' is deprecated and will be removed in a future version, please use 'ME' instead.",
+)
 def test_unitconv_wet_depo_from_emep(dummy_data):
-    time = pd.Series(pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="ME"))
+    time = pd.Series(pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="M"))
     result = unitconv_wet_depo_from_emep(dummy_data, time)
     assert len(result) == len(
         dummy_data
     )  # sufficent to check length b/c wet depo will change month-to-month
 
 
+@ignore_warnings(
+    FutureWarning,
+    "'M' is deprecated and will be removed in a future version, please use 'ME' instead.",
+)
 def test_unitconv_wet_depo_from_emep_time_not_pandas_series(dummy_data):
-    time = pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="ME")
+    time = pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="M")
     result = unitconv_wet_depo_from_emep(dummy_data, time)
     assert len(result) == len(dummy_data)

--- a/tests/io/test_helpers_units.py
+++ b/tests/io/test_helpers_units.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 from scipy.constants import Avogadro
 
-from _warnings import ignore_warnings
+from pyaerocom._warnings import ignore_warnings
 from pyaerocom.io.helpers_units import (
     mass_to_nr_molecules,
     nr_molecules_to_mass,

--- a/tests/io/test_helpers_units.py
+++ b/tests/io/test_helpers_units.py
@@ -57,6 +57,8 @@ def test_unitconv_sfc_conc(dummy_data):
     FutureWarning,
     "'M' is deprecated and will be removed in a future version, please use 'ME' instead.",
 )
+# TODO: The above warning is ignored because the old-dependency CI tests don't currently
+# support ME. Once we bump dependencies so we can change over, this should be removed.
 def test_unitconv_wet_depo_bck(dummy_data):
     time = pd.Series(pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="M"))
     result = unitconv_wet_depo_bck(dummy_data, time)
@@ -69,6 +71,8 @@ def test_unitconv_wet_depo_bck(dummy_data):
     FutureWarning,
     "'M' is deprecated and will be removed in a future version, please use 'ME' instead.",
 )
+# TODO: The above warning is ignored because the old-dependency CI tests don't currently
+# support ME. Once we bump dependencies so we can change over, this should be removed.
 def test_unitconv_wet_depo_from_emep(dummy_data):
     time = pd.Series(pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="M"))
     result = unitconv_wet_depo_from_emep(dummy_data, time)
@@ -81,6 +85,8 @@ def test_unitconv_wet_depo_from_emep(dummy_data):
     FutureWarning,
     "'M' is deprecated and will be removed in a future version, please use 'ME' instead.",
 )
+# TODO: The above warning is ignored because the old-dependency CI tests don't currently
+# support ME. Once we bump dependencies so we can change over, this should be removed.
 def test_unitconv_wet_depo_from_emep_time_not_pandas_series(dummy_data):
     time = pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="M")
     result = unitconv_wet_depo_from_emep(dummy_data, time)

--- a/tests/io/test_helpers_units.py
+++ b/tests/io/test_helpers_units.py
@@ -53,7 +53,7 @@ def test_unitconv_sfc_conc(dummy_data):
 
 
 def test_unitconv_wet_depo_bck(dummy_data):
-    time = pd.Series(pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="M"))
+    time = pd.Series(pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="ME"))
     result = unitconv_wet_depo_bck(dummy_data, time)
     assert len(result) == len(
         dummy_data
@@ -61,7 +61,7 @@ def test_unitconv_wet_depo_bck(dummy_data):
 
 
 def test_unitconv_wet_depo_from_emep(dummy_data):
-    time = pd.Series(pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="M"))
+    time = pd.Series(pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="ME"))
     result = unitconv_wet_depo_from_emep(dummy_data, time)
     assert len(result) == len(
         dummy_data
@@ -69,6 +69,6 @@ def test_unitconv_wet_depo_from_emep(dummy_data):
 
 
 def test_unitconv_wet_depo_from_emep_time_not_pandas_series(dummy_data):
-    time = pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="M")
+    time = pd.date_range(start="2000-01-01", periods=len(dummy_data), freq="ME")
     result = unitconv_wet_depo_from_emep(dummy_data, time)
     assert len(result) == len(dummy_data)

--- a/tests/stats/mda8/test_mda8.py
+++ b/tests/stats/mda8/test_mda8.py
@@ -3,14 +3,12 @@ import pytest
 import xarray as xr
 
 from pyaerocom.colocation.colocated_data import ColocatedData
-from pyaerocom.colocation.colocation_3d import ColocatedDataLists
 from pyaerocom.stats.mda8.mda8 import (
     _calc_mda8,
     _daily_max,
     _rolling_average_8hr,
     mda8_colocated_data,
 )
-from tests.fixtures.collocated_data import coldata
 
 
 @pytest.fixture

--- a/tests/stats/mda8/test_mda8.py
+++ b/tests/stats/mda8/test_mda8.py
@@ -25,7 +25,7 @@ def test_data(time, values) -> xr.DataArray:
     (
         pytest.param(
             xr.date_range(start="2024-01-01 01:00", periods=49, freq="1h"),
-            [0] * 49,
+            [0.0] * 49,
             [0, 0, np.nan],
             id="zeros",
         ),
@@ -125,7 +125,7 @@ def test_coldata_to_mda8(coldata):
     (
         (
             xr.date_range(start="2024-01-01 01:00", periods=48, freq="1h"),
-            [0, 1, 2, 3, 4, 5, 6, 7] * 6,
+            [0.0, 1, 2, 3, 4, 5, 6, 7] * 6,
             [np.nan] * 5 + [2.5, 3] + [3.5] * 41,
         ),
         (


### PR DESCRIPTION
## Change Summary

This PR reduces the number of warnings in the log by either suppressing them, fixing the underlying issue or ignoring them depending on the warning:

- f"Detected wrong frequency {freq_ebas}. Trying to infer the correct frequency...": Is logged as info instead. Warning is only logged when inference fails.
- In `stats/implementations.py`, "invalid value encountered in divide" (caused by division by zero) and `ConstantInputWarning` (correlation undefined for constant arrays) are ignored.

## Related issue number

#1066 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
