### PR TITLE
Collocation of emep-mscw output with gridded data in a projection

### DIFF
--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -759,9 +759,17 @@ def colocate_gridded_ungridded(
     else:
         # gridded data with projection,
         # add x/y information to ungridded
-        xvals, yvals = data.proj_info.to_proj(latitude, longitude)
-        xrange = (np.min(xvals), np.max(xvals))
-        yrange = (np.min(yvals), np.max(yvals))
+        for coord in data.cube.dim_coords:
+            if coord.var_name == data.proj_info.x_axis:
+                vals = coord.points
+                xrange = (np.min(vals), np.max(vals))
+            if coord.var_name == data.proj_info.y_axis:
+                vals = coord.points
+                yrange = (np.min(vals), np.max(vals))
+        if xrange is None or yrange is None:
+            raise VariableDefinitionError(
+                f"x/y axis not found in cube: {data.proj_info.x_axis}, {data.proj_info.y_axis}"
+            )
         data_ref = data_ref.filter_by_projection(data.proj_info.to_proj, xrange, yrange)
 
     # get timeseries from all stations in provided time resolution

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -681,10 +681,12 @@ def colocate_gridded_ungridded(
     """
     if filter_name is None:
         filter_name = const.DEFAULT_REG_FILTER
-    try:
-        data.check_dimcoords_tseries()
-    except DimensionOrderError:
-        data.reorder_dimensions_tseries()
+    if data.proj_info is None:
+        # reordering only implemented if no projection
+        try:
+            data.check_dimcoords_tseries()
+        except DimensionOrderError:
+            data.reorder_dimensions_tseries()
 
     var, var_aerocom = resolve_var_name(data)
     if var_ref is None:
@@ -747,12 +749,20 @@ def colocate_gridded_ungridded(
 
     latitude = data.latitude.points
     longitude = data.longitude.points
-    lat_range = [np.min(latitude), np.max(latitude)]
-    lon_range = [np.min(longitude), np.max(longitude)]
-    # use only sites that are within model domain
+    if data.proj_info is None:
+        lat_range = [np.min(latitude), np.max(latitude)]
+        lon_range = [np.min(longitude), np.max(longitude)]
+        # use only sites that are within model domain
 
-    # filter_by_meta wipes is_vertical_profile
-    data_ref = data_ref.filter_by_meta(latitude=lat_range, longitude=lon_range)
+        # filter_by_meta wipes is_vertical_profile
+        data_ref = data_ref.filter_by_meta(latitude=lat_range, longitude=lon_range)
+    else:
+        # gridded data with projection,
+        # add x/y information to ungridded
+        xvals, yvals = data.proj_info.to_proj(latitude, longitude)
+        xrange = (np.min(xvals), np.max(xvals))
+        yrange = (np.min(yvals), np.max(yvals))
+        data_ref = data_ref.filter_by_projection(data.proj_info.to_proj, xrange, yrange)
 
     # get timeseries from all stations in provided time resolution
     # (time resampling is done below in main loop)
@@ -774,6 +784,7 @@ def colocate_gridded_ungridded(
             f"Variable {var_ref} is not available in specified time interval ({start}-{stop})"
         )
 
+    # to read
     grid_stat_data = data.to_time_series(longitude=ungridded_lons, latitude=ungridded_lats)
 
     pd_freq = col_tst.to_pandas_freq()

--- a/pyaerocom/griddeddata.py
+++ b/pyaerocom/griddeddata.py
@@ -41,6 +41,7 @@ from pyaerocom.helpers import (
 )
 from pyaerocom.helpers_landsea_masks import load_region_mask_iris
 from pyaerocom.mathutils import estimate_value_range, exponent
+from pyaerocom.projection_information import ProjectionInformation
 from pyaerocom.region import Region
 from pyaerocom.stationdata import StationData
 from pyaerocom.time_config import IRIS_AGGREGATORS, TS_TYPE_TO_NUMPY_FREQ
@@ -130,10 +131,17 @@ class GriddedData:
         concatenated=False,
         region=None,
         reader=None,
+        proj_info=None,
     )
 
     def __init__(
-        self, input=None, var_name=None, check_unit=True, convert_unit_on_init=True, **meta
+        self,
+        input=None,
+        var_name=None,
+        check_unit=True,
+        convert_unit_on_init=True,
+        proj_info: ProjectionInformation | None = None,
+        **meta,
     ):
         if input is None:
             input = iris.cube.Cube([])
@@ -152,6 +160,8 @@ class GriddedData:
         self._coord_var_names = None
         self._coord_standard_names = None
         self._coord_long_names = None
+        # projection information
+        meta.update({"proj_info": proj_info})
 
         if input:
             self.load_input(input, var_name)
@@ -194,6 +204,10 @@ class GriddedData:
             raise VariableDefinitionError(
                 f"No default access available for variable {self.var_name}"
             )
+
+    @property
+    def proj_info(self) -> ProjectionInformation:
+        return self.metadata["proj_info"]
 
     @property
     def ts_type(self):
@@ -1130,10 +1144,11 @@ class GriddedData:
             collapse_scalar = coords.pop("collapse_scalar")
         else:
             collapse_scalar = True
-        try:
-            self.check_dimcoords_tseries()
-        except DimensionOrderError:
-            self.reorder_dimensions_tseries()
+        if self.proj_info is None:
+            try:
+                self.check_dimcoords_tseries()
+            except DimensionOrderError:
+                self.reorder_dimensions_tseries()
         pinfo = False
         if np.prod(self.shape) > 5913000:  # (shape of 2x2 deg, daily data)
             pinfo = True
@@ -1176,10 +1191,11 @@ class GriddedData:
         )
 
     def _to_time_series_xarray(self, scheme="nearest", add_meta=None, ts_type=None, **coords):
-        try:
-            self.check_dimcoords_tseries()
-        except DimensionOrderError:
-            self.reorder_dimensions_tseries()
+        if self.proj_info is None:
+            try:
+                self.check_dimcoords_tseries()
+            except DimensionOrderError:
+                self.reorder_dimensions_tseries()
 
         arr = self.to_xarray()
 
@@ -1198,7 +1214,21 @@ class GriddedData:
                 lon = vals
         if lat is None or lon is None:
             raise ValueError("Please provide latitude and longitude coords")
-        subset = extract_latlon_dataarray(arr, lat, lon, method=scheme, new_index_name="latlon")
+        if self.proj_info is None:
+            subset = extract_latlon_dataarray(
+                arr, lat, lon, method=scheme, new_index_name="latlon"
+            )
+        else:
+            x, y = self.proj_info.to_proj(lat, lon)
+            subset = extract_latlon_dataarray(
+                arr,
+                x,
+                y,
+                lon_dimname=self.proj_info.x_axis,
+                lat_dimname=self.proj_info.y_axis,
+                method=scheme,
+                new_index_name="latlon",
+            )
 
         lat_id = subset.attrs["lat_dimname"]
         lon_id = subset.attrs["lon_dimname"]
@@ -1219,8 +1249,11 @@ class GriddedData:
         result = []
         subset = subset.compute()
         data_np = subset.data
-        lats = subset[lat_id].data
-        lons = subset[lon_id].data
+        if self.proj_info is None:
+            lats = subset[lat_id].data
+            lons = subset[lon_id].data
+        else:
+            lats, lons = self.proj_info.to_latlon(subset[lon_id].data, subset[lat_id].data)
         for sidx in range(subset.shape[-1]):
             data = StationData(
                 latitude=lats[sidx],
@@ -2603,8 +2636,8 @@ class GriddedData:
                     f"Skipping assignment of var_name from metadata in GriddedData, "
                     f"since attr. needs to be str and is {val}"
                 )
-                continue
-            self._grid.attributes[key] = val
+            else:
+                self._grid.attributes[key] = val
 
     def delete_all_coords(self, inplace=True):
         """Deletes all coordinates (dimension + auxiliary) in this object"""

--- a/pyaerocom/griddeddata.py
+++ b/pyaerocom/griddeddata.py
@@ -1222,8 +1222,8 @@ class GriddedData:
             x, y = self.proj_info.to_proj(lat, lon)
             subset = extract_latlon_dataarray(
                 arr,
-                x,
-                y,
+                lon=x,
+                lat=y,
                 lon_dimname=self.proj_info.x_axis,
                 lat_dimname=self.proj_info.y_axis,
                 method=scheme,

--- a/pyaerocom/helpers.py
+++ b/pyaerocom/helpers.py
@@ -119,6 +119,7 @@ def extract_latlon_dataarray(
     check_domain=True,
 ):
     """Extract individual lat / lon coordinates from `DataArray`
+    lon/lat can also be x/y coordinates if the `DataArray` has only projected axes.
 
     Parameters
     ----------

--- a/pyaerocom/projection_information.py
+++ b/pyaerocom/projection_information.py
@@ -1,0 +1,89 @@
+from pyproj import CRS, transformer
+import xarray
+
+
+class ProjectionInformationException(Exception):
+    pass
+
+
+class ProjectionInformation:
+    def __init__(self):
+        self._crs = None
+        self._x_axis = None
+        self._y_axis = None
+        self._units = None
+
+    @property
+    def x_axis(self):
+        return self._x_axis
+
+    @property
+    def y_axis(self):
+        return self._y_axis
+
+    def to_proj(self, latitude, longitude):
+        """convert latitude and longitude to x and y
+
+        :param latitude: latitude values
+        :param longitude: longitude values
+        :return: tuple of x and y coordinates
+        """
+        trans = transformer.Transformer.from_crs(4326, self._crs)
+        return trans.transform(latitude, longitude)
+
+    def to_latlon(self, x, y):
+        """convert x and y to latitude and longitude
+
+        :param x: x values
+        :param y: y values
+        :return: tuple of latitude and longitude coordinates
+        """
+        trans = transformer.Transformer.from_crs(self._crs, 4326)
+        return trans.transform(x, y)
+
+    @staticmethod
+    def from_xarray(ds: xarray.Dataset, var: str):
+        """initialize the ProjectionInformation from an xarray variable
+
+        returns None if no projection exists for the variable or ProjectionInformation
+        """
+        da = ds[var]
+        if not "grid_mapping" in da.attrs:
+            return None
+        pi = ProjectionInformation()
+        pi._crs = CRS.from_cf(ds[da.grid_mapping].attrs)
+
+        for c in da.coords:
+            if len(da.coords[c].dims) != 1:
+                continue
+            if "standard_name" in da.coords[c].attrs:
+                if da.coords[c].standard_name in (
+                    "longitude",
+                    "grid_longitude",
+                    "projection_x_coordinate",
+                ):
+                    pi._x_axis = c
+                    break
+            if "axis" in da.coords[c].attrs:
+                if da.coords[c].axis in ("x", "X"):
+                    pi._x_axis = c
+                    break
+        for c in da.coords:
+            if len(da.coords[c].dims) != 1:
+                continue
+            if "standard_name" in da.coords[c].attrs:
+                if da.coords[c].standard_name in (
+                    "latitude",
+                    "grid_latitude",
+                    "projection_y_coordinate",
+                ):
+                    pi._y_axis = c
+                    break
+            if "axis" in da.coords[c].attrs:
+                if da.coords[c].axis in ("y", "Y"):
+                    pi._y_axis = c
+                    break
+        if pi._x_axis is None or pi._y_axis is None:
+            raise ProjectionInformationException(f"no x or y axis found for variable '{var}'")
+        pi._units = da.coords[pi._y_axis].units
+        return pi

--- a/pyaerocom/projection_information.py
+++ b/pyaerocom/projection_information.py
@@ -1,5 +1,5 @@
-from pyproj import CRS, transformer
 import xarray
+from pyproj import CRS, transformer
 
 
 class ProjectionInformationException(Exception):

--- a/pyaerocom/sample_data_access/minimal_dataset.py
+++ b/pyaerocom/sample_data_access/minimal_dataset.py
@@ -8,7 +8,7 @@ from pyaerocom import const
 logger = logging.getLogger(__name__)
 
 #: tarfile to download
-TESTDATA_FILE = "testdata-minimal.tar.gz.20231116"
+TESTDATA_FILE = "testdata-minimal.tar.gz.20240722"
 
 minimal_dataset = pooch.create(
     path=const.OUTPUTDIR,  # ~/MyPyaerocom/
@@ -21,6 +21,7 @@ minimal_dataset = pooch.create(
         "testdata-minimal.tar.gz.20231017": "md5:705d91e01ca7647b4c93dfe67def661f",
         "testdata-minimal.tar.gz.20231019": "md5:f8912ee83d6749fb2a9b1eda1d664ca2",
         "testdata-minimal.tar.gz.20231116": "md5:5da747f6596817295ba7affe3402b722",
+        "testdata-minimal.tar.gz.20240722": "md5:7d933901c6d273d012f132c60df086cc",
     },
 )
 

--- a/pyaerocom/scripts/testdata-minimal/README.md
+++ b/pyaerocom/scripts/testdata-minimal/README.md
@@ -1,6 +1,6 @@
 # Scripts for test dataset creation of pyaerocom
 This directory consists of scripts to create the minimal test dataset needed
-for automatic testing and continuous integration of pyaerocom. The scripts need access to Met Norway's 
+for automatic testing and continuous integration of pyaerocom. The scripts need access to Met Norway's
 internal file storage and are therefore
 of limited use to the general public. In order to not be forgotten during major updates of pyaerocom
 they are included in the main pyaerocom gihub repository anyway.
@@ -8,7 +8,7 @@ they are included in the main pyaerocom gihub repository anyway.
 The minimal test data created from these scripts will usually go to the subdirectory `~/MyPyaerocom/testdata-minimal`
 Example model and observation data can be found in sub-directories `modeldata` and `obsdata`, respectively.
 
-At this time only `create_subset_ebas.py` is running with the 
+At this time only `create_subset_ebas.py` is running with the
 latest version of pyaerocom
 
 ## Data usage guidelines
@@ -40,9 +40,20 @@ Howto for that:
 ```
 cd ~/MyPyaerocom
 mkdir -p ~/tmp
-tar -cvzf ~/tmp/testdata-minimal.tar.gz testdata-minimal
+cd ~/tmp
+# untar the last testdataset to that directory, e.g.
+tar xvfz ~/MyPyaerocom/testdata-minimal.tar.gz.20231116
+# add your new data to ~/tmp/testdata-minimal
+# update the README.md in ~/tmp/testdata-minimal/README.md if required (mainly licences of test-datasets)
+NEWTESTDATA=~/tmp/testdata-minimal.tar.gz.$(date +%Y%m%d)
+tar cvzf $NEWTESTDATA testdata-minimal
+md5sum $NEWTESTDATA
 ```
-The resulting file `~/tmp/testdata-minimal.tar.gz` then needs to be copied to the right place.
-Please ask your fellow developers in case you do not know how to do that.
+Register the new filename and the md5sum in `pyaerocom/minimal_dataset.py`.
 
+The resulting file `~/tmp/testdata-minimal.tar.gz.YYYYMMDD` then needs to be uploaded to https://pyaerocom.met.no/pyaerocom-suppl , e.g.
+
+```
+scp $NEWTESTDATA ubuntu@pyaerocom.met.no:/var/www/pyaerocom-suppl
+```
 

--- a/pyaerocom/scripts/testdata-minimal/README.md
+++ b/pyaerocom/scripts/testdata-minimal/README.md
@@ -49,7 +49,7 @@ NEWTESTDATA=~/tmp/testdata-minimal.tar.gz.$(date +%Y%m%d)
 tar cvzf $NEWTESTDATA testdata-minimal
 md5sum $NEWTESTDATA
 ```
-Register the new filename and the md5sum in `pyaerocom/minimal_dataset.py`.
+Register the new filename and the md5sum in `pyaerocom/sample_data_access/minimal_dataset.py`.
 
 The resulting file `~/tmp/testdata-minimal.tar.gz.YYYYMMDD` then needs to be uploaded to https://pyaerocom.met.no/pyaerocom-suppl , e.g.
 

--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -1926,6 +1926,44 @@ class UngriddedData:
             data = data.filter_region(region_id)
         return data
 
+    def filter_by_projection(
+        self, projection, xrange: tuple[float, float], yrange: tuple[float, float]
+    ):
+        """Filter the ungridded data to a horizontal bounding box given by a projection
+
+        :param projection: a function turning projection(lat, lon) -> (x, y)
+        :param xrange: x range (min/max included) in the projection plane
+        :param yrange: y range (min/max included) in the projection plane
+        """
+        meta_matches = []
+        totnum = 0
+        for meta_idx, meta in self.metadata.items():
+            lon = meta["longitude"]
+            lat = meta["latitude"]
+            x, y = projection(lat, lon)
+
+            matchX = in_range(x, xrange[0], xrange[1])
+            matchY = in_range(y, yrange[0], yrange[1])
+
+            if matchX and matchY:
+                meta_matches.append(meta_idx)
+                for var in meta["var_info"]:
+                    if var in self.ALLOWED_VERT_COORD_TYPES:
+                        continue  # altitude is not actually a variable but is stored in var_info like one
+                    try:
+                        totnum += len(self.meta_idx[meta_idx][var])
+                    except KeyError:
+                        logger.debug(
+                            f"Ignoring variable {var} in meta block {meta_idx} "
+                            f"since no data could be found"
+                        )
+
+        if len(meta_matches) == len(self.metadata):
+            logger.info(f"filter_by_projection result in unchanged data object")
+            return self
+        new = self._new_from_meta_blocks(meta_matches, totnum)
+        return new
+
     def filter_by_meta(self, negate=None, **filter_attributes):
         """Flexible method to filter these data based on input meta specs
 

--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -1942,10 +1942,10 @@ class UngriddedData:
             lat = meta["latitude"]
             x, y = projection(lat, lon)
 
-            matchX = in_range(x, xrange[0], xrange[1])
-            matchY = in_range(y, yrange[0], yrange[1])
+            match_x = in_range(x, xrange[0], xrange[1])
+            match_y = in_range(y, yrange[0], yrange[1])
 
-            if matchX and matchY:
+            if match_x and match_y:
                 meta_matches.append(meta_idx)
                 for var in meta["var_info"]:
                     if var in self.ALLOWED_VERT_COORD_TYPES:

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -19,6 +19,7 @@ dependencies:
   - openpyxl
   - typer >=0.7.0
   - pydantic > 2.0.0
+  - pyproj >= 3.0.0
   - pooch >=1.7.0
   - psutil >= 5.0.0
 ## python < 3.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     # https://github.com/SciTools/cf-units/issues/218
     'cf-units>=3.1',
     "pydantic>=2.7.1",
+    "pyproj>=3.0.0",
     "pyaro>=0.0.10",
     "pooch>=1.7.0",
     "psutil>=5.0.0"

--- a/tests/colocation/test_colocated_projection.py
+++ b/tests/colocation/test_colocated_projection.py
@@ -1,5 +1,3 @@
-import sys
-
 from pyaerocom.colocation.colocation_utils import colocate_gridded_ungridded
 from pyaerocom.griddeddata import GriddedData
 from pyaerocom.io.mscw_ctm.reader import ReadMscwCtm

--- a/tests/colocation/test_colocated_projection.py
+++ b/tests/colocation/test_colocated_projection.py
@@ -1,3 +1,5 @@
+from pytest import approx
+
 from pyaerocom.colocation.colocation_utils import colocate_gridded_ungridded
 from pyaerocom.griddeddata import GriddedData
 from pyaerocom.io.mscw_ctm.reader import ReadMscwCtm
@@ -28,7 +30,7 @@ def test_read_emep_colocate_projection():
     S2 = create_fake_station_data(
         "concpm10",
         {"concpm10": {"units": "ug m-3"}},
-        1,
+        2,
         "2024-06-30T23:30:00",
         "2024-07-01T05:30:00",
         "h",
@@ -38,4 +40,9 @@ def test_read_emep_colocate_projection():
     S2.latitude = 60.5
     S2.station_name = "S2"
     ug = UngriddedData.from_station_data([S1, S2])
-    colocate_gridded_ungridded(data_emep, ug)
+    cd = colocate_gridded_ungridded(data_emep, ug)
+    assert cd.data.dims == ("data_source", "time", "station_name")
+    assert cd.data[0, 0, 0] == 1
+    assert cd.data[0, 0, 1] == 2
+    assert cd.data[1, 0, 0] == approx(2.558, abs=1e-3)
+    assert cd.data[1, 0, 1] == approx(2.444, abs=1e-3)

--- a/tests/colocation/test_colocated_projection.py
+++ b/tests/colocation/test_colocated_projection.py
@@ -1,13 +1,17 @@
 import sys
+
 from pyaerocom.colocation.colocation_utils import colocate_gridded_ungridded
 from pyaerocom.griddeddata import GriddedData
 from pyaerocom.io.mscw_ctm.reader import ReadMscwCtm
 from pyaerocom.ungriddeddata import UngriddedData
+from tests.fixtures.data_access import TEST_DATA
 from tests.fixtures.stations import create_fake_station_data
+
+ROOT = TEST_DATA["MODELS"].path
 
 
 def test_read_emep_colocate_projection():
-    reader = ReadMscwCtm(data_dir="/home/heikok/tmp/emep4no20240630/")
+    reader = ReadMscwCtm(data_dir=str(ROOT / "emep4no20240630"))
     data_emep = reader.read_var("concpm10", ts_type="hourly")
     assert isinstance(data_emep, GriddedData)
 

--- a/tests/colocation/test_colocated_projection.py
+++ b/tests/colocation/test_colocated_projection.py
@@ -1,0 +1,39 @@
+import sys
+from pyaerocom.colocation.colocation_utils import colocate_gridded_ungridded
+from pyaerocom.griddeddata import GriddedData
+from pyaerocom.io.mscw_ctm.reader import ReadMscwCtm
+from pyaerocom.ungriddeddata import UngriddedData
+from tests.fixtures.stations import create_fake_station_data
+
+
+def test_read_emep_colocate_projection():
+    reader = ReadMscwCtm(data_dir="/home/heikok/tmp/emep4no20240630/")
+    data_emep = reader.read_var("concpm10", ts_type="hourly")
+    assert isinstance(data_emep, GriddedData)
+
+    S1 = create_fake_station_data(
+        "concpm10",
+        {"concpm10": {"units": "ug m-3"}},
+        1,
+        "2024-06-30T23:30:00",
+        "2024-07-01T05:30:00",
+        "h",
+        {"ts_type": "hourly"},
+    )
+    S1.longitude = 10
+    S1.latitude = 60
+    S1.station_name = "S1"
+    S2 = create_fake_station_data(
+        "concpm10",
+        {"concpm10": {"units": "ug m-3"}},
+        1,
+        "2024-06-30T23:30:00",
+        "2024-07-01T05:30:00",
+        "h",
+        {"ts_type": "hourly"},
+    )
+    S2.longitude = 10.5
+    S2.latitude = 60.5
+    S2.station_name = "S2"
+    ug = UngriddedData.from_station_data([S1, S2])
+    colocate_gridded_ungridded(data_emep, ug)

--- a/tests/io/mscw_ctm/test_reader.py
+++ b/tests/io/mscw_ctm/test_reader.py
@@ -244,7 +244,7 @@ def test_ReadMscwCtm_read_var_error(
 )
 def test_ReadMscwCtm__compute_var(var_name, ts_type, data_dir: str):
     reader = ReadMscwCtm(data_dir=data_dir)
-    data = reader._compute_var(var_name, ts_type)
+    data, proj_info = reader._compute_var(var_name, ts_type)
     assert isinstance(data, xr.DataArray)
 
 

--- a/tests/test_projection_info.py
+++ b/tests/test_projection_info.py
@@ -1,10 +1,14 @@
-from pytest import approx
 import xarray
+from pytest import approx
+
 from pyaerocom.projection_information import ProjectionInformation
+from tests.fixtures.data_access import TEST_DATA
+
+ROOT = TEST_DATA["MODELS"].path
 
 
 def test_projection_information():
-    with xarray.open_dataset("/home/heikok/tmp/emep4no20240630/Base_hour.nc") as ds:
+    with xarray.open_dataset(str(ROOT / "emep4no20240630" / "Base_hour.nc")) as ds:
         pi = ProjectionInformation.from_xarray(ds, "SURF_ug_PM10_rh50")
         assert pi is not None
         assert pi.x_axis == "i"

--- a/tests/test_projection_info.py
+++ b/tests/test_projection_info.py
@@ -1,0 +1,20 @@
+from pytest import approx
+import xarray
+from pyaerocom.projection_information import ProjectionInformation
+
+
+def test_projection_information():
+    with xarray.open_dataset("/home/heikok/tmp/emep4no20240630/Base_hour.nc") as ds:
+        pi = ProjectionInformation.from_xarray(ds, "SURF_ug_PM10_rh50")
+        assert pi is not None
+        assert pi.x_axis == "i"
+        assert pi.y_axis == "j"
+        x0, y0 = float(ds["i"][0]), float(ds["j"][0])
+        lon0, lat0 = float(ds["lon"][0, 0]), float(ds["lat"][0, 0])
+        (lat, lon) = pi.to_latlon(x0, y0)
+        assert lat == approx(lat0, abs=1e-3)
+        assert lon == approx(lon0, abs=1e-3)
+
+        x, y = pi.to_proj(lat, lon)
+        assert x == approx(x0, abs=1.0)
+        assert y == approx(y0, abs=1.0)


### PR DESCRIPTION
## Change Summary

- Add `ProjectionInformation` `proj_info` to `GriddedData`, the projection projection-information consist of a projection functions to convert between lat/lon and x/y in the projection, as well as of the dimension-names of the x/y-axes.
- Read `ProjectionInformation` when reading a variable in mscw-ctm reader and add that to GriddedData
- Collocation, when using the xarray-collocation is now able to convert the observations lat/lon to x/y and perform collocation on x/y values in the projection-plane when reading the gridded-data.
- Make `pyproj` an explicit dependency (currently only implicit dependency of `iris` and `cartopy`)

## Related issue number

solves the EMEP4NO part of #1175 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
