### PR TITLE
Fix 70% of rounding performance issue

### DIFF
--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -147,7 +147,7 @@ def _add_heatmap_entry_json(
     if not model_name in ovc:
         ovc[model_name] = {}
     mn = ovc[model_name]
-    mn[model_var] = round_floats(result)
+    mn[model_var] = result
     write_json(current, heatmap_file, round_floats=False)
 
 

--- a/pyaerocom/stats/stats.py
+++ b/pyaerocom/stats/stats.py
@@ -80,7 +80,9 @@ def _prepare_statistics(
     result = dict()
     for name, stat in statistics.items():
         if len(data) >= min_numvalid:
-            result[name] = round(stat(data, ref_data, weights), 10)
+            # Rounding to ensure values aren't out of bounds due to floating point
+            # arithmetic and to reduce json file size.
+            result[name] = np.round(stat(data, ref_data, weights), decimals=6)
         else:
             result[name] = np.nan
 


### PR DESCRIPTION
## Change Summary

Ensures rounding of stats is performed on numpy arrays instead of iterating over a dict, improving performance.

## Related issue number

#1277 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
