### PR TITLE
add missing definitions for conco3mda8, necessary for cams2_83

### DIFF
--- a/pyaerocom/aeroval/data/var_scale_colmap.ini
+++ b/pyaerocom/aeroval/data/var_scale_colmap.ini
@@ -82,6 +82,10 @@ colmap = coolwarm
 scale = [0.0, 15.0, 30.0, 45.0, 60.0, 75.0, 90.0, 105.0, 120.0]
 colmap = coolwarm
 
+[conco3mda8]
+scale = [0.0, 15.0, 30.0, 45.0, 60.0, 75.0, 90.0, 105.0, 120.0]
+colmap = coolwarm
+
 [vmro3]
 scale = [20.0, 25.0, 30.0, 35.0, 40.0, 45.0, 50.0, 55.0, 60.0, 65.0, 70.0]
 colmap = coolwarm

--- a/pyaerocom/aeroval/data/var_web_info.ini
+++ b/pyaerocom/aeroval/data/var_web_info.ini
@@ -105,6 +105,11 @@ menu_name = O3
 vertical_type = 3D
 category = Gas concentrations
 
+[conco3mda8]
+menu_name = O3 MDA8
+vertical_type = 3D
+category = Gas concentrations
+
 [concno310]
 menu_name = NO3_PM10
 vertical_type = 3D

--- a/pyaerocom/data/variables.ini
+++ b/pyaerocom/data/variables.ini
@@ -3097,6 +3097,10 @@ unit = ug m-3
 description=Mass concentration of ozone
 unit = ug m-3
 
+[conco3mda8]
+description=MDA8 of O3 mass concentration
+unit = ug m-3
+
 [vmro3mda8]
 description=MDA8 of O3 VMR.
 unit = nmol mol-1

--- a/pyaerocom/scripts/cams2_83/config.py
+++ b/pyaerocom/scripts/cams2_83/config.py
@@ -69,6 +69,7 @@ GLOBAL_CONFIG = dict(
         "vmro3max",
         "vmro3",
         "conco3",
+        "conco3mda8",
         "vmrox",
         "concso2",
         "vmrco",

--- a/pyaerocom/stats/mda8/const.py
+++ b/pyaerocom/stats/mda8/const.py
@@ -1,3 +1,3 @@
 # Variable names for which mda8 values are to be calculated.
 MDA8_INPUT_VARS = ("conco3", "vmro3")
-MDA8_OUTPUT_VARS = ("vmro3mda8",)
+MDA8_OUTPUT_VARS = ("conco3mda8","vmro3mda8",)

--- a/pyaerocom/stats/mda8/const.py
+++ b/pyaerocom/stats/mda8/const.py
@@ -1,3 +1,6 @@
 # Variable names for which mda8 values are to be calculated.
 MDA8_INPUT_VARS = ("conco3", "vmro3")
-MDA8_OUTPUT_VARS = ("conco3mda8","vmro3mda8",)
+MDA8_OUTPUT_VARS = (
+    "conco3mda8",
+    "vmro3mda8",
+)

--- a/tests/test_varcollection.py
+++ b/tests/test_varcollection.py
@@ -26,9 +26,14 @@ def test_invalid_entries(collection: VarCollection):
 @pytest.mark.parametrize(
     "var_ini,exception,error",
     [
-        pytest.param(None, ValueError, "Invalid input for var_ini, need str", id="ValueError"),
         pytest.param(
-            "/bla/blub", FileNotFoundError, "File /bla/blub does not exist", id="FileNotFoundError"
+            None, ValueError, "Invalid input for var_ini, need str", id="ValueError"
+        ),
+        pytest.param(
+            "/bla/blub",
+            FileNotFoundError,
+            "File /bla/blub does not exist",
+            id="FileNotFoundError",
         ),
     ],
 )
@@ -74,7 +79,10 @@ def test_VarCollection_get_var_error(collection: VarCollection):
     var_name = "bla"
     with pytest.raises(VariableDefinitionError) as e:
         collection.get_var(var_name)
-    assert str(e.value) == f"Error (VarCollection): input variable {var_name} is not supported"
+    assert (
+        str(e.value)
+        == f"Error (VarCollection): input variable {var_name} is not supported"
+    )
 
 
 @pytest.mark.parametrize(
@@ -83,7 +91,7 @@ def test_VarCollection_get_var_error(collection: VarCollection):
         ("*blaaaaaaa*", 0),
         ("dep*", 9),
         ("od*", 26),
-        ("conc*", 98),
+        ("conc*", 99),
     ],
 )
 def test_VarCollection_find(collection: VarCollection, search_pattern: str, num: int):
@@ -96,7 +104,9 @@ def test_VarCollection_delete_var_MULTIDEF(collection: VarCollection):
     collection.all_vars.append(var_name)
     with pytest.raises(VariableDefinitionError) as e:
         collection.delete_variable(var_name)
-    assert f"found multiple matches for variable {var_name} in VarCollection" in str(e.value)
+    assert f"found multiple matches for variable {var_name} in VarCollection" in str(
+        e.value
+    )
 
 
 def test_VarCollection___dir__(collection: VarCollection):
@@ -108,7 +118,9 @@ def test_VarCollection___dir__(collection: VarCollection):
 
 
 @pytest.mark.parametrize("var_name,found", [("blablub", False), ("od550aer", True)])
-def test_VarCollection___contains__(collection: VarCollection, var_name: str, found: bool):
+def test_VarCollection___contains__(
+    collection: VarCollection, var_name: str, found: bool
+):
     assert (var_name in collection) == found
 
 

--- a/tests/test_varcollection.py
+++ b/tests/test_varcollection.py
@@ -26,9 +26,7 @@ def test_invalid_entries(collection: VarCollection):
 @pytest.mark.parametrize(
     "var_ini,exception,error",
     [
-        pytest.param(
-            None, ValueError, "Invalid input for var_ini, need str", id="ValueError"
-        ),
+        pytest.param(None, ValueError, "Invalid input for var_ini, need str", id="ValueError"),
         pytest.param(
             "/bla/blub",
             FileNotFoundError,
@@ -79,10 +77,7 @@ def test_VarCollection_get_var_error(collection: VarCollection):
     var_name = "bla"
     with pytest.raises(VariableDefinitionError) as e:
         collection.get_var(var_name)
-    assert (
-        str(e.value)
-        == f"Error (VarCollection): input variable {var_name} is not supported"
-    )
+    assert str(e.value) == f"Error (VarCollection): input variable {var_name} is not supported"
 
 
 @pytest.mark.parametrize(
@@ -104,9 +99,7 @@ def test_VarCollection_delete_var_MULTIDEF(collection: VarCollection):
     collection.all_vars.append(var_name)
     with pytest.raises(VariableDefinitionError) as e:
         collection.delete_variable(var_name)
-    assert f"found multiple matches for variable {var_name} in VarCollection" in str(
-        e.value
-    )
+    assert f"found multiple matches for variable {var_name} in VarCollection" in str(e.value)
 
 
 def test_VarCollection___dir__(collection: VarCollection):
@@ -118,9 +111,7 @@ def test_VarCollection___dir__(collection: VarCollection):
 
 
 @pytest.mark.parametrize("var_name,found", [("blablub", False), ("od550aer", True)])
-def test_VarCollection___contains__(
-    collection: VarCollection, var_name: str, found: bool
-):
+def test_VarCollection___contains__(collection: VarCollection, var_name: str, found: bool):
     assert (var_name in collection) == found
 
 


### PR DESCRIPTION
## Change Summary

adding a bunch of missing definitions in order to make `conco3mda8` work, as needed by cams2_83

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
