### PR TITLE
docs: Fix missing download testdata section in documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -657,7 +657,7 @@ Molar masses and related helpers
 Access to minimal test dataset
 ------------------------------
 
-.. automodule:: pyaerocom.sample_data_access
+.. automodule:: pyaerocom.sample_data_access.minimal_dataset
    :members:
    :undoc-members:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -657,7 +657,7 @@ Molar masses and related helpers
 Access to minimal test dataset
 ------------------------------
 
-.. automodule:: pyaerocom.access_testdata
+.. automodule:: pyaerocom.sample_data_access
    :members:
    :undoc-members:
 

--- a/pyaerocom/sample_data_access/minimal_dataset.py
+++ b/pyaerocom/sample_data_access/minimal_dataset.py
@@ -33,8 +33,8 @@ def download_minimal_dataset(
 ):
     """Download test_data_file and extracts it.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     file_name :
         The file name to be downloaded.
     extract_dir :

--- a/pyaerocom/sample_data_access/minimal_dataset.py
+++ b/pyaerocom/sample_data_access/minimal_dataset.py
@@ -7,8 +7,10 @@ from pyaerocom import const
 
 logger = logging.getLogger(__name__)
 
+__all__ = ["download_minimal_dataset"]
+
 #: tarfile to download
-TESTDATA_FILE = "testdata-minimal.tar.gz.20240722"
+DEFAULT_TESTDATA_FILE = "testdata-minimal.tar.gz.20240722"
 
 minimal_dataset = pooch.create(
     path=const.OUTPUTDIR,  # ~/MyPyaerocom/
@@ -27,13 +29,17 @@ minimal_dataset = pooch.create(
 
 
 def download_minimal_dataset(
-    file_name: str = TESTDATA_FILE, /, extract_dir_override: str | None = None
+    file_name: str = DEFAULT_TESTDATA_FILE, /, extract_dir_override: str | None = None
 ):
     """Download test_data_file and extracts it.
 
-    :param file_name : The file name to be downloaded.
-    :param extract_dir : An optional folder override to where to extract the file. By
-    default files are extracted into ~/MyPyaerocom
+    Parameters:
+    ===========
+    file_name :
+        The file name to be downloaded.
+    extract_dir :
+        An optional folder override to where to extract the file. By
+        default files are extracted into `~/MyPyaerocom`
     """
     logger.debug(f"fetch {file_name} to {minimal_dataset.path}")
 

--- a/pyaerocom/sample_data_access/minimal_dataset.py
+++ b/pyaerocom/sample_data_access/minimal_dataset.py
@@ -34,7 +34,7 @@ def download_minimal_dataset(
     """Download test_data_file and extracts it.
 
     Parameters:
-    ===========
+    -----------
     file_name :
         The file name to be downloaded.
     extract_dir :


### PR DESCRIPTION
## Change Summary

Noticed that the section for downloading sample data in the documentation is currently blank. This PR should fix that:

https://pyaerocom.readthedocs.io/en/latest/api.html#access-to-minimal-test-dataset

## Related issue number

NA

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
