### PR TITLE
Fix mda8 crash when configured frequencies are all hourly

### DIFF
--- a/pyaerocom/colocation/colocation_setup.py
+++ b/pyaerocom/colocation/colocation_setup.py
@@ -423,6 +423,9 @@ class ColocationSetup(BaseModel):
 
     model_kwargs: dict = {}
 
+    main_freq: str = "monthly"
+    freqs: list[str] = ["monthly", "yearly"]
+
     @field_validator("model_kwargs")
     @classmethod
     def validate_kwargs(cls, v):

--- a/pyaerocom/colocation/colocation_setup.py
+++ b/pyaerocom/colocation/colocation_setup.py
@@ -285,6 +285,14 @@ class ColocationSetup(BaseModel):
     add_meta : dict
         additional metadata that is supposed to be added to each output
         :class:`ColocatedData` object.
+    main_freq:
+        Main output frequency for AeroVal (some of the AeroVal processing
+        steps are only done for this resolution, since they would create too
+        much output otherwise, such as statistics timeseries or scatter plot in
+        "Overall Evaluation" tab on AeroVal).
+        Note that this frequency needs to be included in next setting "freqs".
+    freqs:
+        Frequencies for which statistical parameters are computed
     """
 
     ##########################

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -363,6 +363,8 @@ class Colocator:
             dictionaries comprising key / value pairs of obs variables and
             associated instances of :class:`ColocatedData`.
         """
+        # MDA8 is a daily value so it doesn't make sense to calculate it if
+        # no frequency is daily or coarser.
         calc_mda8 = False
         if self.colocation_setup.main_freq in ["daily", "monthly", "yearly"]:
             calc_mda8 = True

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -363,6 +363,12 @@ class Colocator:
             dictionaries comprising key / value pairs of obs variables and
             associated instances of :class:`ColocatedData`.
         """
+        calc_mda8 = False
+        if self.colocation_setup.main_freq in ["daily", "monthly", "yearly"]:
+            calc_mda8 = True
+        if any(x in ["daily", "monthly", "yearly"] for x in self.colocation_setup.freqs):
+            calc_mda8 = True
+
         data_out = defaultdict(lambda: dict())
         # ToDo: see if the following could be solved via custom context manager
         try:
@@ -383,7 +389,7 @@ class Colocator:
                 )  # note this can be ColocatedData or ColocatedDataLists
                 data_out[mod_var][obs_var] = coldata
 
-                if obs_var in MDA8_INPUT_VARS:
+                if calc_mda8 and (obs_var in MDA8_INPUT_VARS):
                     try:
                         mda8 = mda8_colocated_data(
                             coldata, obs_var=f"{obs_var}mda8", mod_var=f"{mod_var}mda8"


### PR DESCRIPTION
## Change Summary

Fixes issue where pyaerocom would crash with `UnboundLocalError` due to mda8 calculation when all frequency calculations are hourly. MDA8 will now be calculated only when `main_freq` is coarser than hourly or one of the frequencies provided in `freqs` is coarser than hourly.

## Related issue number

closes #1279 
## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
