### PR TITLE
MQI Check: change tolerance due to rounding errors

### DIFF
--- a/pyaerocom/aeroval/fairmode_stats.py
+++ b/pyaerocom/aeroval/fairmode_stats.py
@@ -76,7 +76,7 @@ def fairmode_stats(obs_var: str, stats: dict) -> dict:
     assert np.isclose(
         rmsu * beta_mqi,
         np.sqrt((bias) ** 2 + (mod_std - obs_std) ** 2 + (2 * obs_std * mod_std * (1 - R))),
-        rtol=1e-5,
+        rtol=1e-4,
     ), "failed MQI check"
 
     fairmode = dict(


### PR DESCRIPTION
## Change Summary
We are only rounding to 6 decimal places, close to the computation of the statistics. Therefore the 1e-5 tolerance check can be too restrictive due to rounding errors. This reduces it 1e-4

## Related issue number

NA. Discussion in chat based on @charlienegri testing

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
