### PR TITLE
MQI Check: adjust tolerance again to 1e-3

### DIFF
--- a/pyaerocom/aeroval/fairmode_stats.py
+++ b/pyaerocom/aeroval/fairmode_stats.py
@@ -76,7 +76,7 @@ def fairmode_stats(obs_var: str, stats: dict) -> dict:
     assert np.isclose(
         rmsu * beta_mqi,
         np.sqrt((bias) ** 2 + (mod_std - obs_std) ** 2 + (2 * obs_std * mod_std * (1 - R))),
-        rtol=1e-4,
+        rtol=1e-3,
     ), "failed MQI check"
 
     fairmode = dict(


### PR DESCRIPTION
## Change Summary

 1e-4 the long run with main_freq=daily crashed CAMS2_83, so adjust tolerance again

## Related issue number
NA, see chat

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
