### PR TITLE
Aerovaldb use pypi release

### DIFF
--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -32,7 +32,7 @@ dependencies:
     - geojsoncontour
     - geocoder_reverse_natural_earth >= 0.0.2
     - pyaro >= 0.0.10
-    - aerovaldb == 0.15.0
+    - aerovaldb == 0.0.15
 ## testing
   - pytest >=7.4
   - pytest-dependency

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -32,7 +32,7 @@ dependencies:
     - geojsoncontour
     - geocoder_reverse_natural_earth >= 0.0.2
     - pyaro >= 0.0.10
-    - git+https://github.com/metno/aerovaldb.git@v0.0.14
+    - aerovaldb == 0.15.0
 ## testing
   - pytest >=7.4
   - pytest-dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "pyaerocom"
-version = "0.22.0dev0"
+version = "0.21.1"
 authors = [{ name = "MET Norway" }]
 description = "pyaerocom model evaluation software"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "pyaerocom"
-version = "0.21.1"
+version = "0.22.dev0"
 authors = [{ name = "MET Norway" }]
 description = "pyaerocom model evaluation software"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "aerovaldb == 0.15.0",
+    "aerovaldb == 0.0.15",
     "scitools-iris>=3.8.1",
     "xarray>=2022.12.0",
     "cartopy>=0.21.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "aerovaldb@git+https://github.com/metno/aerovaldb.git@v0.0.14",
+    "aerovaldb == 0.15.0",
     "scitools-iris>=3.8.1",
     "xarray>=2022.12.0",
     "cartopy>=0.21.1",


### PR DESCRIPTION
## Change Summary

Use aerovaldb release on pypi instead of git install.

https://pypi.org/project/aerovaldb/0.0.15/

Creates a new release tag v0.21.1: https://github.com/metno/pyaerocom/releases/tag/v0.21.1

## Related issue number

https://github.com/metno/aerovaldb/issues/62

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
