### PR TITLE
Allow trends to run even if a component does not have any data due to min_yrs constraints

### DIFF
--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -163,7 +163,7 @@ class ColdataToJsonEngine(ProcessingEngine):
         )
         if min_yrs > 0:
             logger.info(
-                f"Removing stations with less than {min_yrs} years of continuous data, with sequential_yrs = {sequential_yrs}"
+                f"Removing stations with less than {min_yrs} years of data, with sequential_yrs = {sequential_yrs}"
             )
             coldata = _remove_less_covered(coldata, min_yrs, sequential_yrs)
 

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1642,15 +1642,14 @@ def _remove_less_covered(
             max_yrs = _find_n_yrs(years)
 
         if min_yrs > max_yrs:
-            print(f"Dropping {s}; It has only {max_yrs}")
-            logging.info(f"Dropping {s}; It has only {max_yrs}")
+            logger.info(f"Dropping {s}; It has only {max_yrs}")
             data.data = data.data.drop_sel(station_name=s)
 
     new_stations = data.data.station_name.data
 
-    print(f"Removed {len(stations)-len(new_stations)} stations")
+    logger.info(f"Removed {len(stations)-len(new_stations)} stations")
     if len(new_stations) == 0:
-        raise TrendsError(
+        logger.warning(
             f"No stations left after removing stations with fewer than {min_yrs} years!"
         )
 

--- a/pyaerocom/geodesy.py
+++ b/pyaerocom/geodesy.py
@@ -108,7 +108,9 @@ def get_country_info_coords(coords):
     # (more a list of this)
     ret_proto = {"city": "", "country_code": "", "code": ""}
 
-    if isnumeric(coords[0]) and len(coords) == 2:  # only one coordinate
+    if len(coords) == 0:  # no coordinates
+        pass
+    elif isnumeric(coords[0]) and len(coords) == 2:  # only one coordinate
         lat, lon = coords
         try:
             dummy = geo.lookup(lat, lon)

--- a/tests/aeroval/test_coldatatojson_helpers2.py
+++ b/tests/aeroval/test_coldatatojson_helpers2.py
@@ -335,7 +335,7 @@ def test__remove_less_covered(
     assert len(new_stations) == station_nb
 
 
-def test__remove_less_covered_error():
+def test__remove_less_covered_all():
     cd = COLDATA["fake_3d_partial_trends_coltime"]()
-    with pytest.raises(TrendsError, match="No stations left"):
-        _remove_less_covered(cd, 1000)
+    new_cd = _remove_less_covered(cd, 1000)
+    assert new_cd.data.station_name.shape[0] == 0


### PR DESCRIPTION
Trends may have a min_yrs constraint rejection all stations which haven't measured at least `min_yrs`. This can lead to components having 0 data. 0 data crashed pyaerocom (or raised a TrendException). This PR changes the behaviour so that 0 data of a trend-analysis is an acceptable result. It will be logged if the `min_yrs` constraint removed all stations.


## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
