### PR TITLE
Fix mda8 misalignment

### DIFF
--- a/pyaerocom/stats/mda8/mda8.py
+++ b/pyaerocom/stats/mda8/mda8.py
@@ -100,10 +100,11 @@ def _calc_mda8(data: xr.DataArray) -> xr.DataArray:
 
 
 def _rolling_average_8hr(arr: xr.DataArray) -> xr.DataArray:
+    # Labeling should be right which probably is the default in xarray.
     return arr.rolling(time=8, min_periods=6).mean()
 
 
 def _daily_max(arr: xr.DataArray) -> xr.DataArray:
-    return arr.resample(time="24H", offset="1h").reduce(
+    return arr.resample(time="24H", origin="start_day", label="left", offset="1h").reduce(
         lambda x, axis: np.apply_along_axis(min_periods_max, 1, x, min_periods=18)
     )

--- a/pyaerocom/stats/mda8/mda8.py
+++ b/pyaerocom/stats/mda8/mda8.py
@@ -100,8 +100,13 @@ def _calc_mda8(data: xr.DataArray) -> xr.DataArray:
 
 
 def _rolling_average_8hr(arr: xr.DataArray) -> xr.DataArray:
-    # Labeling should be right which probably is the default in xarray.
-    return arr.rolling(time=8, min_periods=6).mean()
+    # Xarray labels the data left, while we want it to be labeled right, so we add 8h to
+    # the time index.
+    new_arr = arr.rolling(time=8, min_periods=6).mean()
+    # Xarray labels the data left, while we want it to be labeled right, so we add 8h to
+    # the time index.
+    new_arr["time"] = new_arr.get_index("time") + pd.Timedelta("8h")
+    return new_arr
 
 
 def _daily_max(arr: xr.DataArray) -> xr.DataArray:

--- a/pyaerocom/stats/mda8/mda8.py
+++ b/pyaerocom/stats/mda8/mda8.py
@@ -100,13 +100,8 @@ def _calc_mda8(data: xr.DataArray) -> xr.DataArray:
 
 
 def _rolling_average_8hr(arr: xr.DataArray) -> xr.DataArray:
-    # Xarray labels the data left, while we want it to be labeled right, so we add 8h to
-    # the time index.
-    new_arr = arr.rolling(time=8, min_periods=6).mean()
-    # Xarray labels the data left, while we want it to be labeled right, so we add 8h to
-    # the time index.
-    new_arr["time"] = new_arr.get_index("time") + pd.Timedelta("8h")
-    return new_arr
+    # Xarray labels the data right based on the last data point in the period for rolling.
+    return arr.rolling(time=8, center=False, min_periods=6).mean()
 
 
 def _daily_max(arr: xr.DataArray) -> xr.DataArray:

--- a/tests/stats/mda8/test_mda8.py
+++ b/tests/stats/mda8/test_mda8.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 import xarray as xr
-import pandas as pd
 
 from pyaerocom.colocation.colocated_data import ColocatedData
 from pyaerocom.stats.mda8.mda8 import (
@@ -27,13 +26,13 @@ def test_data(time, values) -> xr.DataArray:
         pytest.param(
             xr.date_range(start="2024-01-01 01:00", periods=49, freq="1h"),
             [0.0] * 49,
-            [np.nan, 0, np.nan],
+            [0, 0, np.nan],
             id="zeros",
         ),
         pytest.param(
             xr.date_range(start="2024-01-01 01:00", periods=49, freq="1h"),
             np.linspace(start=1, stop=49, num=49),
-            [np.nan, 36.5, np.nan],
+            [20.5, 44.5, np.nan],
             id="incrementing-by-1",
         ),
         pytest.param(
@@ -54,7 +53,7 @@ def test_data(time, values) -> xr.DataArray:
         pytest.param(
             xr.date_range(start="2024-01-01 06:00:00", periods=30, freq="1h"),
             np.arange(30),
-            [np.nan, 25.5],
+            [np.nan, np.nan],
             id="#1323",
         ),
     ),
@@ -98,17 +97,17 @@ def test_coldata_to_mda8(coldata):
     assert mda8.shape == (2, 8, 1)
 
     assert mda8.data.values[0, :, 0] == pytest.approx(
-        [np.nan, np.nan, 1.18853785, 1.18604125, 1.18869106, 1.18879322, 1.18807846, 1.18700801],
+        [np.nan, np.nan, 1.18741556, 1.18777241, 1.18869106, 1.18879322, 1.18807846, 1.18700801],
         abs=10**-5,
         nan_ok=True,
     )
 
     assert mda8.data.values[1, :, 0] == pytest.approx(
         [
-            np.nan,
+            1.57327333,
             1.28884431,
-            1.28853785,
-            1.28604125,
+            1.28741556,
+            1.28777241,
             1.28869106,
             1.28879322,
             1.28807846,
@@ -156,7 +155,8 @@ def test_rollingaverage(test_data, exp_ravg):
 def test_rollingaverage_label():
     """
     Checks that the labels of rolling average is correct (we want it to be labeled based
-    on the "right-most" interval, ie. latest measurement in the interval).
+    on the "right-most" interval, ie. latest measurement in the interval). This is currently
+    the case in xarray but not greatly documented, so this test checks for that.
 
     https://github.com/metno/pyaerocom/issues/1323
     """
@@ -169,8 +169,7 @@ def test_rollingaverage_label():
     ravg = _rolling_average_8hr(data)
 
     assert np.all(
-        ravg.get_index("time")
-        == xr.date_range(start="2024-01-01 00:00", periods=24, freq="1h") + pd.Timedelta("8h")
+        ravg.get_index("time") == xr.date_range(start="2024-01-01 00:00", periods=24, freq="1h")
     )
 
 

--- a/tests/stats/mda8/test_mda8.py
+++ b/tests/stats/mda8/test_mda8.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 import xarray as xr
+import pandas as pd
 
 from pyaerocom.colocation.colocated_data import ColocatedData
 from pyaerocom.stats.mda8.mda8 import (
@@ -32,7 +33,7 @@ def test_data(time, values) -> xr.DataArray:
         pytest.param(
             xr.date_range(start="2024-01-01 01:00", periods=49, freq="1h"),
             np.linspace(start=1, stop=49, num=49),
-            [20.5, 44.5, np.nan],
+            [np.nan, 36.5, np.nan],
             id="incrementing-by-1",
         ),
         pytest.param(
@@ -48,6 +49,13 @@ def test_data(time, values) -> xr.DataArray:
             ),
             [np.nan] * 3,
             id="with-nans",
+        ),
+        # https://github.com/metno/pyaerocom/issues/1323
+        pytest.param(
+            xr.date_range(start="2024-01-01 06:00:00", periods=30, freq="1h"),
+            np.arange(30),
+            [np.nan, 25.5],
+            id="#1323",
         ),
     ),
 )
@@ -90,26 +98,17 @@ def test_coldata_to_mda8(coldata):
     assert mda8.shape == (2, 8, 1)
 
     assert mda8.data.values[0, :, 0] == pytest.approx(
-        [
-            np.nan,
-            np.nan,
-            1.18741556,
-            1.18777241,
-            1.18869106,
-            1.18879322,
-            1.18807846,
-            1.18700801,
-        ],
+        [np.nan, np.nan, 1.18853785, 1.18604125, 1.18869106, 1.18879322, 1.18807846, 1.18700801],
         abs=10**-5,
         nan_ok=True,
     )
 
     assert mda8.data.values[1, :, 0] == pytest.approx(
         [
-            1.57327333,
+            np.nan,
             1.28884431,
-            1.28741556,
-            1.28777241,
+            1.28853785,
+            1.28604125,
             1.28869106,
             1.28879322,
             1.28807846,
@@ -170,7 +169,8 @@ def test_rollingaverage_label():
     ravg = _rolling_average_8hr(data)
 
     assert np.all(
-        ravg.get_index("time") == xr.date_range(start="2024-01-01 00:00", periods=24, freq="1h")
+        ravg.get_index("time")
+        == xr.date_range(start="2024-01-01 00:00", periods=24, freq="1h") + pd.Timedelta("8h")
     )
 
 

--- a/tests/stats/mda8/test_mda8.py
+++ b/tests/stats/mda8/test_mda8.py
@@ -27,7 +27,7 @@ def test_data(time, values) -> xr.DataArray:
         pytest.param(
             xr.date_range(start="2024-01-01 01:00", periods=49, freq="1h"),
             [0.0] * 49,
-            [0, 0, np.nan],
+            [np.nan, 0, np.nan],
             id="zeros",
         ),
         pytest.param(

--- a/tests/stats/mda8/test_mda8.py
+++ b/tests/stats/mda8/test_mda8.py
@@ -156,9 +156,9 @@ def test_rollingaverage(test_data, exp_ravg):
 def test_rollingaverage_label():
     """
     Checks that the labels of rolling average is correct (we want it to be labeled based
-    on the "left-most" interval, ie. earliest measurement). This seems to be the
-    current behaviour of xarray (but not well documented) and this test should
-    detect if this behaviour changes in xarray in the future.
+    on the "right-most" interval, ie. latest measurement in the interval).
+
+    https://github.com/metno/pyaerocom/issues/1323
     """
     data = xr.DataArray(
         [[[x] for x in range(24)]],

--- a/tests/stats/mda8/test_mda8.py
+++ b/tests/stats/mda8/test_mda8.py
@@ -154,6 +154,26 @@ def test_rollingaverage(test_data, exp_ravg):
     assert all(ravg[0, :, 0] == pytest.approx(exp_ravg, abs=0, nan_ok=True))
 
 
+def test_rollingaverage_label():
+    """
+    Checks that the labels of rolling average is correct (we want it to be labeled based
+    on the "left-most" interval, ie. earliest measurement). This seems to be the
+    current behaviour of xarray (but not well documented) and this test should
+    detect if this behaviour changes in xarray in the future.
+    """
+    data = xr.DataArray(
+        [[[x] for x in range(24)]],
+        dims=["data_source", "time", "station_name"],
+        coords={"time": xr.date_range(start="2024-01-01 00:00", periods=24, freq="1h")},
+    )
+
+    ravg = _rolling_average_8hr(data)
+
+    assert np.all(
+        ravg.get_index("time") == xr.date_range(start="2024-01-01 00:00", periods=24, freq="1h")
+    )
+
+
 @pytest.mark.parametrize(
     "time,values,exp_daily_max",
     (

--- a/tests/stats/mda8/test_mda8.py
+++ b/tests/stats/mda8/test_mda8.py
@@ -168,9 +168,8 @@ def test_rollingaverage_label():
 
     ravg = _rolling_average_8hr(data)
 
-    assert np.all(
-        ravg.get_index("time") == xr.date_range(start="2024-01-01 00:00", periods=24, freq="1h")
-    )
+    assert ravg["time"].isel(time=0) == np.datetime64("2024-01-01 00:00")
+    assert ravg["time"].isel(time=23) == np.datetime64("2024-01-01 23:00")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Summary

Per discusion with @avaldebe, there is an issue where the mda8 calculation relies on undocumented xarray behaviour. This PR aims to make arguments explicit where possible as well as testing for the undocumented behaviour in xarray so that possible future regressions can be detected. This also fixes an issue where 8 hour average was left labeled instead of rightlabeled, resulting in the mda8 binning to be shifted by 8 hours from the defined window.

## Related issue number

closes #1323 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
