### PR TITLE
try new syntax to exclude mda8 from maps

### DIFF
--- a/pyaerocom/data/variables.ini
+++ b/pyaerocom/data/variables.ini
@@ -3100,12 +3100,12 @@ unit = ug m-3
 [conco3mda8]
 description=MDA8 of O3 mass concentration
 unit = ug m-3
-only_use_in = ["evaluation", "intercomp", "overall"]
+only_use_in = evaluation intercomp overall
 
 [vmro3mda8]
 description=MDA8 of O3 VMR.
 unit = nmol mol-1
-only_use_in = ["evaluation", "intercomp", "overall"]
+only_use_in = evaluation intercomp overall
 
 [concco]
 description=Mass concentration of organic carbon


### PR DESCRIPTION
previous fix breaks menu.json, wrong syntax

## Related issue number

trying to close #1324

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
