### PR TITLE
add conco3mda8 to fairmode stats

### DIFF
--- a/pyaerocom/aeroval/fairmode_stats.py
+++ b/pyaerocom/aeroval/fairmode_stats.py
@@ -15,6 +15,7 @@ import numpy as np
 SPECIES = dict(
     concno2=dict(UrRV=0.24, RV=200, alpha=0.2),
     conco3=dict(UrRV=0.18, RV=120, alpha=0.79),
+    conco3mda8=dict(UrRV=0.18, RV=120, alpha=0.79),
     concpm10=dict(UrRV=0.28, RV=50, alpha=0.25),
     concpm25=dict(UrRV=0.36, RV=25, alpha=0.5),
 )


### PR DESCRIPTION
## Change Summary

conco3mda is the variable that should be used for fairmode stats, we leave conco3 there for now but in principle it can be removed at some point

## Related issue number

trying to close  #1327

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
