### PR TITLE
Rename setup_classes & include creation_date in ExperimentInfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,5 @@ sorted_out
 
 
 pytest.ini
+
+playground/

--- a/.gitignore
+++ b/.gitignore
@@ -160,4 +160,5 @@ sorted_out
 
 pytest.ini
 
+# can store scripts etc. locally for testing and dev purposes
 playground/

--- a/docs/api-aeroval.rst
+++ b/docs/api-aeroval.rst
@@ -11,7 +11,7 @@ Tools for AeroVal experiment setup
 High level analysis setup for AeroVal experiment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. automodule:: pyaerocom.aeroval.setupclasses
+.. automodule:: pyaerocom.aeroval.setup_classes
    :members:
 
 Specification of observation datasets

--- a/pyaerocom/aeroval/__init__.py
+++ b/pyaerocom/aeroval/__init__.py
@@ -1,3 +1,3 @@
 # isort:skip_file
-from .setupclasses import EvalSetup
+from .setup_classes import EvalSetup
 from .experiment_processor import ExperimentProcessor

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -27,7 +27,7 @@ from pyaerocom.aeroval.glob_defaults import (
 )
 from pyaerocom.aeroval.json_utils import round_floats
 from pyaerocom.aeroval.modelentry import ModelEntry
-from pyaerocom.aeroval.setup_classes import EvalSetup
+from pyaerocom.aeroval import EvalSetup
 from pyaerocom.aeroval.varinfo_web import VarinfoWeb
 from pyaerocom.colocation.colocated_data import ColocatedData
 from pyaerocom.exceptions import EntryNotAvailable, VariableDefinitionError

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -27,7 +27,7 @@ from pyaerocom.aeroval.glob_defaults import (
 )
 from pyaerocom.aeroval.json_utils import round_floats
 from pyaerocom.aeroval.modelentry import ModelEntry
-from pyaerocom.aeroval.setupclasses import EvalSetup
+from pyaerocom.aeroval.setup_classes import EvalSetup
 from pyaerocom.aeroval.varinfo_web import VarinfoWeb
 from pyaerocom.colocation.colocated_data import ColocatedData
 from pyaerocom.exceptions import EntryNotAvailable, VariableDefinitionError

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -298,7 +298,7 @@ class ExperimentInfo(BaseModel):
     public: bool = False
     exp_pi: str = getuser()
     pyaerocom_version: str = __version__
-    creation_date: str = datetime.today().strftime("%Y-%m-%d")
+    creation_date: str = str(datetime.now())
 
 
 class EvalSetup(BaseModel):

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -298,7 +298,7 @@ class ExperimentInfo(BaseModel):
     public: bool = False
     exp_pi: str = getuser()
     pyaerocom_version: str = __version__
-    creation_date: str = str(datetime.now())
+    creation_date: str = f"{datetime.datetime.now(datetime.timezone.utc):%Y-%m-%dT%H:%M:%S.%fZ}"
 
 
 class EvalSetup(BaseModel):

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -298,7 +298,7 @@ class ExperimentInfo(BaseModel):
     public: bool = False
     exp_pi: str = getuser()
     pyaerocom_version: str = __version__
-    creation_date: str = f"{datetime.datetime.now(datetime.timezone.utc):%Y-%m-%dT%H:%M:%S.%fZ}"
+    creation_date: str = f"{datetime.now(datetime.timezone.utc):%Y-%m-%dT%H:%M:%S.%fZ}"
 
 
 class EvalSetup(BaseModel):

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -6,7 +6,7 @@ from functools import cached_property
 from getpass import getuser
 from pathlib import Path
 from typing import Annotated, Literal
-from datetime import datetime
+import datetime
 
 from pyaerocom.aeroval.glob_defaults import VarWebInfo, VarWebScaleAndColormap
 
@@ -298,7 +298,7 @@ class ExperimentInfo(BaseModel):
     public: bool = False
     exp_pi: str = getuser()
     pyaerocom_version: str = __version__
-    creation_date: str = f"{datetime.now(datetime.timezone.utc):%Y-%m-%dT%H:%M:%S.%fZ}"
+    creation_date: str = f"{datetime.datetime.now(datetime.timezone.utc):%Y-%m-%dT%H:%M:%S.%fZ}"
 
 
 class EvalSetup(BaseModel):

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -6,6 +6,7 @@ from functools import cached_property
 from getpass import getuser
 from pathlib import Path
 from typing import Annotated, Literal
+from datetime import datetime
 
 from pyaerocom.aeroval.glob_defaults import VarWebInfo, VarWebScaleAndColormap
 
@@ -297,6 +298,7 @@ class ExperimentInfo(BaseModel):
     public: bool = False
     exp_pi: str = getuser()
     pyaerocom_version: str = __version__
+    creation_date: str = datetime.today().strftime("%Y-%m-%d")
 
 
 class EvalSetup(BaseModel):

--- a/tests/aeroval/test_aeroval_HIGHLEV.py
+++ b/tests/aeroval/test_aeroval_HIGHLEV.py
@@ -6,13 +6,17 @@ import pytest
 
 from pyaerocom.aeroval import ExperimentProcessor
 from pyaerocom.aeroval.experiment_output import ExperimentOutput
-from pyaerocom.aeroval.setupclasses import EvalSetup
+from pyaerocom.aeroval.setup_classes import EvalSetup
 from tests.conftest import geojson_unavail
 
 CHK_CFG1 = {
     "map": ["AERONET-Sun-od550aer_Column_TM5-AP3-CTRL-od550aer_2010.json"],
     "contour": 1,
-    "hm": ["glob_stats_daily.json", "glob_stats_monthly.json", "glob_stats_yearly.json"],
+    "hm": [
+        "glob_stats_daily.json",
+        "glob_stats_monthly.json",
+        "glob_stats_yearly.json",
+    ],
     "hm/ts": 10,  # number of .json files in sub dir
     "scat": ["AERONET-Sun-od550aer_Column_TM5-AP3-CTRL-od550aer_2010.json"],
     "ts": 11,  # number of .json files in subdir

--- a/tests/aeroval/test_aeroval_HIGHLEV.py
+++ b/tests/aeroval/test_aeroval_HIGHLEV.py
@@ -6,7 +6,7 @@ import pytest
 
 from pyaerocom.aeroval import ExperimentProcessor
 from pyaerocom.aeroval.experiment_output import ExperimentOutput
-from pyaerocom.aeroval.setup_classes import EvalSetup
+from pyaerocom.aeroval import EvalSetup
 from tests.conftest import geojson_unavail
 
 CHK_CFG1 = {

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -9,7 +9,7 @@ from pyaerocom import const
 from pyaerocom.aeroval import ExperimentProcessor
 from pyaerocom.aeroval.experiment_output import ExperimentOutput, ProjectOutput
 from pyaerocom.aeroval.json_utils import read_json, write_json
-from pyaerocom.aeroval.setupclasses import EvalSetup
+from pyaerocom.aeroval.setup_classes import EvalSetup
 from tests.conftest import geojson_unavail
 
 BASEDIR_DEFAULT = Path(const.OUTPUTDIR) / "aeroval" / "data"
@@ -171,7 +171,14 @@ def test_ExperimentOutput__info_from_map_file():
         "EBAS-2010-ac550aer_Surface_ECHAM-HAM-ac550dryaer_2010.json"
     )
 
-    assert output == ("EBAS-2010", "ac550aer", "Surface", "ECHAM-HAM", "ac550dryaer", "2010")
+    assert output == (
+        "EBAS-2010",
+        "ac550aer",
+        "Surface",
+        "ECHAM-HAM",
+        "ac550dryaer",
+        "2010",
+    )
 
 
 @pytest.mark.parametrize(
@@ -243,7 +250,10 @@ def test_ExperimentOutput_delete_experiment_data(tmp_path: Path, also_coldata: b
         ),
         (
             "concprcpso4",
-            {"colmap": "coolwarm", "scale": [0, 1.25, 2.5, 3.75, 5, 6.25, 7.5, 8.75, 10]},
+            {
+                "colmap": "coolwarm",
+                "scale": [0, 1.25, 2.5, 3.75, 5, 6.25, 7.5, 8.75, 10],
+            },
         ),
     ],
 )
@@ -339,7 +349,10 @@ def test_ExperimentOutput_reorder_experiments_error(dummy_expout: ExperimentOutp
 def test_Experiment_Output_drop_stats_and_decimals(
     eval_config: dict, drop_stats, stats_decimals: int
 ):
-    eval_config["drop_stats"], eval_config["stats_decimals"] = drop_stats, stats_decimals
+    eval_config["drop_stats"], eval_config["stats_decimals"] = (
+        drop_stats,
+        stats_decimals,
+    )
     cfg = EvalSetup(**eval_config)
     cfg.model_cfg["mod1"] = cfg.model_cfg["TM5-AP3-CTRL"]
     proc = ExperimentProcessor(cfg)

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -9,7 +9,7 @@ from pyaerocom import const
 from pyaerocom.aeroval import ExperimentProcessor
 from pyaerocom.aeroval.experiment_output import ExperimentOutput, ProjectOutput
 from pyaerocom.aeroval.json_utils import read_json, write_json
-from pyaerocom.aeroval.setup_classes import EvalSetup
+from pyaerocom.aeroval import EvalSetup
 from tests.conftest import geojson_unavail
 
 BASEDIR_DEFAULT = Path(const.OUTPUTDIR) / "aeroval" / "data"

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -113,7 +113,7 @@ def test_ExperimentOutput():
 def test_ExperimentOutput_error():
     with pytest.raises(ValueError) as e:
         ExperimentOutput(None)
-    assert str(e.value) == "need instance of <class 'pyaerocom.aeroval.setupclasses.EvalSetup'>"
+    assert str(e.value) == "need instance of <class 'pyaerocom.aeroval.setup_classes.EvalSetup'>"
 
 
 def test_ExperimentOutput_exp_id(dummy_expout: ExperimentOutput):

--- a/tests/aeroval/test_experiment_processor.py
+++ b/tests/aeroval/test_experiment_processor.py
@@ -4,7 +4,7 @@ import pytest
 
 from pyaerocom.aeroval.experiment_output import ExperimentOutput
 from pyaerocom.aeroval.experiment_processor import ExperimentProcessor
-from pyaerocom.aeroval.setup_classes import EvalSetup
+from pyaerocom.aeroval import EvalSetup
 from tests.conftest import geojson_unavail
 
 

--- a/tests/aeroval/test_experiment_processor.py
+++ b/tests/aeroval/test_experiment_processor.py
@@ -4,7 +4,7 @@ import pytest
 
 from pyaerocom.aeroval.experiment_output import ExperimentOutput
 from pyaerocom.aeroval.experiment_processor import ExperimentProcessor
-from pyaerocom.aeroval.setupclasses import EvalSetup
+from pyaerocom.aeroval.setup_classes import EvalSetup
 from tests.conftest import geojson_unavail
 
 
@@ -35,8 +35,16 @@ def test_ExperimentProcessor_run(processor: ExperimentProcessor):
 @pytest.mark.parametrize(
     "cfg,kwargs,error",
     [
-        ("cfgexp2", dict(model_name="BLA"), "'No matches could be found that match input BLA'"),
-        ("cfgexp2", dict(obs_name="BLUB"), "'No matches could be found that match input BLUB'"),
+        (
+            "cfgexp2",
+            dict(model_name="BLA"),
+            "'No matches could be found that match input BLA'",
+        ),
+        (
+            "cfgexp2",
+            dict(obs_name="BLUB"),
+            "'No matches could be found that match input BLUB'",
+        ),
     ],
 )
 def test_ExperimentProcessor_run_error(processor: ExperimentProcessor, kwargs: dict, error: str):

--- a/tests/aeroval/test_helpers.py
+++ b/tests/aeroval/test_helpers.py
@@ -10,7 +10,7 @@ from pyaerocom.aeroval.helpers import (
     check_if_year,
     make_dummy_model,
 )
-from pyaerocom.aeroval.setup_classes import EvalSetup
+from pyaerocom.aeroval import EvalSetup
 
 
 @pytest.mark.parametrize(

--- a/tests/aeroval/test_helpers.py
+++ b/tests/aeroval/test_helpers.py
@@ -10,7 +10,7 @@ from pyaerocom.aeroval.helpers import (
     check_if_year,
     make_dummy_model,
 )
-from pyaerocom.aeroval.setupclasses import EvalSetup
+from pyaerocom.aeroval.setup_classes import EvalSetup
 
 
 @pytest.mark.parametrize(

--- a/tests/aeroval/test_modelmaps_engine.py
+++ b/tests/aeroval/test_modelmaps_engine.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pyaerocom.aeroval.modelmaps_engine import ModelMapsEngine
-from pyaerocom.aeroval.setup_classes import EvalSetup
+from pyaerocom.aeroval import EvalSetup
 from pyaerocom.exceptions import ModelVarNotAvailable
 from tests.fixtures.aeroval.cfg_test_exp1 import CFG
 

--- a/tests/aeroval/test_modelmaps_engine.py
+++ b/tests/aeroval/test_modelmaps_engine.py
@@ -1,7 +1,7 @@
 import pytest
 
 from pyaerocom.aeroval.modelmaps_engine import ModelMapsEngine
-from pyaerocom.aeroval.setupclasses import EvalSetup
+from pyaerocom.aeroval.setup_classes import EvalSetup
 from pyaerocom.exceptions import ModelVarNotAvailable
 from tests.fixtures.aeroval.cfg_test_exp1 import CFG
 

--- a/tests/aeroval/test_setup_classes.py
+++ b/tests/aeroval/test_setup_classes.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 import pytest
 
-from pyaerocom.aeroval.setup_classes import EvalSetup
+from pyaerocom.aeroval import EvalSetup
 from pyaerocom.exceptions import EvalEntryNameError
 from tests.fixtures.aeroval.cfg_test_exp1 import CFG, MODELS, OBS_GROUNDBASED
 

--- a/tests/aeroval/test_setupclasses.py
+++ b/tests/aeroval/test_setupclasses.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 import pytest
 
-from pyaerocom.aeroval.setupclasses import EvalSetup
+from pyaerocom.aeroval.setup_classes import EvalSetup
 from pyaerocom.exceptions import EvalEntryNameError
 from tests.fixtures.aeroval.cfg_test_exp1 import CFG, MODELS, OBS_GROUNDBASED
 
@@ -62,7 +62,11 @@ def test_EvalSetup_INVALID_ENTRY_NAMES(cfg_exp1: dict, error: str):
 
 
 @pytest.mark.parametrize(
-    "update", (pytest.param(None, id="defaults"), pytest.param(dict(proj_id="blah"), id="custom"))
+    "update",
+    (
+        pytest.param(None, id="defaults"),
+        pytest.param(dict(proj_id="blah"), id="custom"),
+    ),
 )
 def test_EvalSetup_ProjectInfo(eval_setup: EvalSetup, cfg_exp1: dict):
     assert eval_setup.proj_info.proj_id == cfg_exp1["proj_id"]
@@ -73,12 +77,20 @@ def test_EvalSetup_ProjectInfo(eval_setup: EvalSetup, cfg_exp1: dict):
     (
         pytest.param(None, id="defaults"),
         pytest.param(
-            dict(exp_id="exp42", exp_descr="Hello world!", exp_name="Lorem Ipsum...", public=True),
+            dict(
+                exp_id="exp42",
+                exp_descr="Hello world!",
+                exp_name="Lorem Ipsum...",
+                public=True,
+            ),
             id="custom1",
         ),
         pytest.param(
             dict(
-                exp_id="exp54", exp_descr="Hello world!", exp_name="Lorem Ipsum...", public=False
+                exp_id="exp54",
+                exp_descr="Hello world!",
+                exp_name="Lorem Ipsum...",
+                public=False,
             ),
             id="custom2",
         ),
@@ -97,7 +109,8 @@ def test_EvalSetup_ExperimentInfo(eval_setup: EvalSetup, cfg_exp1: dict):
     (
         pytest.param(None, id="defaults"),
         pytest.param(
-            dict(freqs=["yearly", "monthly"], main_freq="yearly", periods=[]), id="custom1"
+            dict(freqs=["yearly", "monthly"], main_freq="yearly", periods=[]),
+            id="custom1",
         ),
         pytest.param(
             dict(freqs=["monthly"], main_freq="monthly", periods=["2010", "2011", "2016"]),


### PR DESCRIPTION
## Change Summary

- Renamed `setupclasses.py` to `setup_classes.py` to follow Python module naming standard of splitting words with underscores
- Added a `creation_date` attribute to `ExperimentInfo`. Defaults to `datetime.today().strftime("%Y-%m-%d")` but can also be provided if a pyaeroval user wants to modified it.

## Related issue number

Close https://github.com/metno/AeroToolsIssues/issues/75

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
