### PR TITLE
Extend aeroval to plot satellite pixels maps

### DIFF
--- a/pyaerocom/aeroval/_processing_base.py
+++ b/pyaerocom/aeroval/_processing_base.py
@@ -208,3 +208,15 @@ class DataImporter(HasColocator):
 
         data = col._read_ungridded(var_name)
         return data
+
+    def read_gridded_obsdata(self, obs_name, var_name):
+        """
+        Import gridded observation data, usually satellite data
+
+        Args:
+            obs_name (str): Name of observation network in :attr:`cfg`
+            var_name (str): Name of variable to be read.
+        """
+        col = self.get_colocator(obs_name=obs_name)
+        data = col._read_gridded(var_name)
+        return data

--- a/pyaerocom/aeroval/_processing_base.py
+++ b/pyaerocom/aeroval/_processing_base.py
@@ -218,5 +218,5 @@ class DataImporter(HasColocator):
             var_name (str): Name of variable to be read.
         """
         col = self.get_colocator(obs_name=obs_name)
-        data = col._read_gridded(var_name)
+        data = col._read_gridded(var_name, is_model=False)
         return data

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -34,7 +34,7 @@ from pyaerocom.exceptions import EntryNotAvailable, VariableDefinitionError
 from pyaerocom.stats.mda8.const import MDA8_OUTPUT_VARS
 from pyaerocom.stats.stats import _init_stats_dummy
 from pyaerocom.utils import recursive_defaultdict
-from pyaerocom.variable_helpers import get_aliases
+from pyaerocom.variable_helpers import get_aliases, get_variable
 
 MapInfo = namedtuple(
     "MapInfo",
@@ -534,7 +534,8 @@ class ExperimentOutput(ProjectOutput):
             return var_ranges_defaults[var]
         try:
             varinfo = VarinfoWeb(var)
-            info = dict(scale=varinfo.cmap_bins, colmap=varinfo.cmap)
+            # TODO: get unit from pyaerocom/data/variables.ini
+            info = dict(scale=varinfo.cmap_bins, colmap=varinfo.cmap, unit=varinfo.unit)
         except (VariableDefinitionError, AttributeError):
             info = var_ranges_defaults["default"]
             logger.warning(
@@ -546,6 +547,7 @@ class ExperimentOutput(ProjectOutput):
         return info
 
     def _create_var_ranges_json(self) -> None:
+        # TODO: add units
         with self.avdb.lock():
             ranges = self.avdb.get_ranges(self.proj_id, self.exp_id, default={})
 
@@ -554,6 +556,7 @@ class ExperimentOutput(ProjectOutput):
             for var in all_vars:
                 if var not in ranges or ranges[var]["scale"] == []:
                     ranges[var] = self._get_cmap_info(var)
+                ranges[var]["unit"] = get_variable(var).unit
             self.avdb.put_ranges(ranges, self.proj_id, self.exp_id)
 
     def _create_statistics_json(self) -> None:

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -560,7 +560,7 @@ class ExperimentOutput(ProjectOutput):
             for var in all_vars:
                 if var not in ranges or ranges[var]["scale"] == []:
                     ranges[var] = self._get_cmap_info(var)
-                ranges[var]["unit"] = get_variable(var).unit
+                ranges[var]["unit"] = get_variable(var).units
             self.avdb.put_ranges(ranges, self.proj_id, self.exp_id)
 
     def _create_statistics_json(self) -> None:

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -547,7 +547,6 @@ class ExperimentOutput(ProjectOutput):
         return info
 
     def _create_var_ranges_json(self) -> None:
-        # TODO: add units
         with self.avdb.lock():
             ranges = self.avdb.get_ranges(self.proj_id, self.exp_id, default={})
 

--- a/pyaerocom/aeroval/experiment_processor.py
+++ b/pyaerocom/aeroval/experiment_processor.py
@@ -151,6 +151,12 @@ class ExperimentProcessor(ProcessingEngine, HasColocator):
         # processing below)
         if self.cfg.webdisp_opts.add_model_maps:
             engine = ModelMapsEngine(self.cfg)
+
+            if isinstance(
+                self.cfg.modelmaps_opts.plot_types, dict
+            ):  # There may be additional obs networks to compute "model" maps for
+                model_list = list(set(model_list) and set(self.cfg.modelmaps_opts.plot_types))
+
             engine.run(model_list=model_list, var_list=var_list)
 
         if not self.cfg.processing_opts.only_model_maps:

--- a/pyaerocom/aeroval/experiment_processor.py
+++ b/pyaerocom/aeroval/experiment_processor.py
@@ -147,8 +147,7 @@ class ExperimentProcessor(ProcessingEngine, HasColocator):
 
         logger.info("Start processing")
 
-        # compute model maps (completely independent of obs-eval
-        # processing below)
+        # compute model maps (completely independent of obs-eval processing below)
         if self.cfg.webdisp_opts.add_model_maps:
             engine = ModelMapsEngine(self.cfg)
 

--- a/pyaerocom/aeroval/helpers.py
+++ b/pyaerocom/aeroval/helpers.py
@@ -13,6 +13,7 @@ from pyaerocom.helpers import (
     to_pandas_timestamp,
 )
 from pyaerocom.variable import Variable
+from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -202,3 +203,10 @@ def delete_dummy_model(model_id: str) -> None:
     for path in renamed.glob("*.nc"):
         print(f"Deleting dummy model {path}")
         path.unlink()
+
+
+class BoundingBox(BaseModel):
+    west: float
+    east: float
+    south: float
+    north: float

--- a/pyaerocom/aeroval/helpers.py
+++ b/pyaerocom/aeroval/helpers.py
@@ -2,6 +2,8 @@ import logging
 import os
 from pathlib import Path
 
+from pydantic import BaseModel
+
 from pyaerocom import const
 from pyaerocom.aeroval.modelentry import ModelEntry
 from pyaerocom.griddeddata import GriddedData
@@ -13,7 +15,6 @@ from pyaerocom.helpers import (
     to_pandas_timestamp,
 )
 from pyaerocom.variable import Variable
-from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -100,18 +100,21 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
             logger.info(f"Processing model maps for {model_name} ({var})")
 
             try:
-                if (
-                    self.cfg.modelmaps_opts.plot_types is CONTOUR
-                    or CONTOUR in self.cfg.modelmaps_opts.plot_types.get(model_name, False)
-                ):
+                make_contour, make_overlay = False, False
+                if isinstance(self.cfg.modelmaps_opts.plot_types, dict):
+                    make_contour = CONTOUR in self.cfg.modelmaps_opts.plot_types.get(
+                        model_name, False
+                    )
+                    make_overlay = OVERLAY in self.cfg.modelmaps_opts.plot_types.get(
+                        model_name, False
+                    )
+
+                if self.cfg.modelmaps_opts.plot_types is CONTOUR or make_contour:
                     _files = self._process_contour_map_var(
                         model_name, var, self.reanalyse_existing
                     )
                     files.extend(_files)
-                if (
-                    self.cfg.modelmaps_opts.plot_types is OVERLAY
-                    or OVERLAY in self.cfg.modelmaps_opts.plot_types.get(model_name, False)
-                ):
+                if self.cfg.modelmaps_opts.plot_types is OVERLAY or make_overlay:
                     # create overlay (pixel) plots
                     _files = self._process_overlay_map_var(
                         model_name, var, self.reanalyse_existing

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -279,7 +279,6 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                     logger.info(f"Skipping overlay processing of {outname}: data already exists.")
                     continue
 
-            # https://github.com/matplotlib/matplotlib/issues/23319
             overlay_plot = plot_overlay_pixel_maps(
                 data[i],
                 cmap=varinfo.cmap,
@@ -287,7 +286,6 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                 outpath=fp_overlay,
             )
 
-            # LB: Below will require some coordination with Thorbjørn
             with self.avdb.lock():
                 self.avdb.put_map_overlay(
                     overlay_plot,
@@ -297,5 +295,3 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                     var,
                     date,
                 )
-
-        # return fp_overlay

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -270,7 +270,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         for i, date in enumerate(tst):
             outname = f"{model_name}_{var}_{date}"
 
-            # Lb: Check if still needed
+            # Note should matche the output location defined in aerovaldb
             fp_overlay = os.path.join(outdir, outname)
 
             if not reanalyse_existing:

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -3,9 +3,7 @@ import os
 
 from pyaerocom import GriddedData, TsType
 from pyaerocom.aeroval._processing_base import DataImporter, ProcessingEngine
-from pyaerocom.aeroval.modelmaps_helpers import (
-    calc_contour_json,
-)
+from pyaerocom.aeroval.modelmaps_helpers import calc_contour_json, CONTOUR, OVERLAY
 from pyaerocom.aeroval.varinfo_web import VarinfoWeb
 from pyaerocom.exceptions import (
     DataCoverageError,
@@ -41,10 +39,9 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
 
         all_files = []
         for model in model_list:
-            if (
-                self.self.cfg.modelmaps_opts.plot_types == "contour"
-                or "contour" in self.self.cfg.modelmaps_opts.plot_types.get(model, False)
-            ):
+            if self.cfg.modelmaps_opts.plot_types == set(
+                CONTOUR
+            ) or CONTOUR in self.cfg.modelmaps_opts.plot_types.get(model, False):
                 try:
                     files = self._run_model(model, var_list)
                 except VarNotAvailableError:
@@ -92,7 +89,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                 files.extend(_files)
                 if (
                     not isinstance(self.cfg.modelmaps_opts.plot_types, str)
-                    and self.cfg.modelmaps_opts.plot_types.get(model_name, False) == "overlay"
+                    and self.cfg.modelmaps_opts.plot_types.get(model_name, False) == OVERLAY
                 ):
                     # create pixel plots
                     breakpoint()

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -270,6 +270,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         for i, date in enumerate(tst):
             outname = f"{model_name}_{var}_{date}"
 
+            # Lb: Check if still needed
             fp_overlay = os.path.join(
                 outdir, f"{outname}.{self.cfg.modelmaps_opts.overlay_save_format}"
             )

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -99,7 +99,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         for var in var_list:
             logger.info(f"Processing model maps for {model_name} ({var})")
 
-            try:
+            try:  # pragma: no cover
                 make_contour, make_overlay = False, False
                 if isinstance(self.cfg.modelmaps_opts.plot_types, dict):
                     make_contour = CONTOUR in self.cfg.modelmaps_opts.plot_types.get(
@@ -142,7 +142,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
             data = data.extract_surface_level()
         return data
 
-    def _process_contour_map_var(self, model_name, var, reanalyse_existing):
+    def _process_contour_map_var(self, model_name, var, reanalyse_existing):  # pragma: no cover
         """
         Process model data to create map geojson files
 
@@ -220,7 +220,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
 
         return fp_geojson
 
-    def _process_overlay_map_var(self, model_name, var, reanalyse_existing):
+    def _process_overlay_map_var(self, model_name, var, reanalyse_existing):  # pragma: no cover
         """Process overlay map (pixels) for either model or obserations
         argument model_name is a misnomer because this can also be applied to observation networks
 

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -271,9 +271,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
             outname = f"{model_name}_{var}_{date}"
 
             # Lb: Check if still needed
-            fp_overlay = os.path.join(
-                outdir, f"{outname}.{self.cfg.modelmaps_opts.overlay_save_format}"
-            )
+            fp_overlay = os.path.join(outdir, outname)
 
             if not reanalyse_existing:
                 if os.path.exists(fp_overlay):
@@ -284,7 +282,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                 data[i],
                 cmap=varinfo.cmap,
                 cmap_bins=varinfo.cmap_bins,
-                outpath=fp_overlay,
+                format=self.cfg.modelmaps_opts.overlay_save_format,
             )
 
             with self.avdb.lock():

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -41,14 +41,18 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
 
         all_files = []
         for model in model_list:
-            try:
-                files = self._run_model(model, var_list)
-            except VarNotAvailableError:
-                files = []
-            if not files:
-                logger.warning(f"no data for model {model}, skipping")
-                continue
-            all_files.extend(files)
+            if (
+                self.self.cfg.modelmaps_opts.plot_types == "contour"
+                or "contour" in self.self.cfg.modelmaps_opts.plot_types.get(model, False)
+            ):
+                try:
+                    files = self._run_model(model, var_list)
+                except VarNotAvailableError:
+                    files = []
+                if not files:
+                    logger.warning(f"no data for model {model}, skipping")
+                    continue
+                all_files.extend(files)
         return files
 
     def _get_vars_to_process(self, model_name, var_list):
@@ -86,6 +90,12 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
             try:
                 _files = self._process_map_var(model_name, var, self.reanalyse_existing)
                 files.extend(_files)
+                if (
+                    not isinstance(self.cfg.modelmaps_opts.plot_types, str)
+                    and self.cfg.modelmaps_opts.plot_types.get(model_name, False) == "overlay"
+                ):
+                    # create pixel plots
+                    breakpoint()
 
             except ModelVarNotAvailable as ex:
                 logger.warning(f"{ex}")

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -105,20 +105,24 @@ def calc_contour_json(data, cmap, cmap_bins):
 
 
 def plot_overlay_pixel_maps(data, cmap, cmap_bins, outpath):
+    plt.close("all")
+    matplotlib.use("Agg")
+
     fig, axis = plt.subplots(
         1,
         1,
         subplot_kw=dict(projection=ccrs.Mercator()),
         figsize=(8, 8),
     )
+
     # LB: see if we can use xarray plotting or need to modify somewhow
     data.plot(
         ax=axis,
         transform=ccrs.PlateCarree(),
         add_colorbar=False,
         add_labels=False,
-        vmin=0,
-        vmax=120,
+        vmin=cmap_bins[0],
+        vmax=cmap_bins[-1],
         cmap=cmap,
     )
 
@@ -131,6 +135,6 @@ def plot_overlay_pixel_maps(data, cmap, cmap_bins, outpath):
         buffer.seek(0)
         image = buffer.getvalue()
 
-    plt.close()
+    plt.close("all")
 
     return image

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -115,7 +115,6 @@ def plot_overlay_pixel_maps(data, cmap, cmap_bins, outpath):
         figsize=(8, 8),
     )
 
-    # LB: see if we can use xarray plotting or need to modify somewhow
     data.plot(
         ax=axis,
         transform=ccrs.PlateCarree(),

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -6,6 +6,7 @@ from matplotlib.axes import Axes
 from matplotlib.colors import ListedColormap, to_hex
 from seaborn import color_palette
 import io
+import xarray
 
 try:
     from geojsoncontour import contourf_to_geojson
@@ -104,7 +105,9 @@ def calc_contour_json(data, cmap, cmap_bins):
     return geojson
 
 
-def plot_overlay_pixel_maps(data, cmap, cmap_bins, outpath):
+def plot_overlay_pixel_maps(
+    data: xarray.DataArray, cmap: str, cmap_bins: list[float], outpath: str, format: str
+):
     plt.close("all")
     matplotlib.use("Agg")
 
@@ -130,6 +133,7 @@ def plot_overlay_pixel_maps(data, cmap, cmap_bins, outpath):
             outpath,
             bbox_inches="tight",
             transparent=True,
+            format=format,
         )
         buffer.seek(0)
         image = buffer.getvalue()

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -1,8 +1,6 @@
 import cartopy.crs as ccrs
-import dask
 import matplotlib
 import matplotlib.pyplot as plt
-import numpy as np
 from cartopy.mpl.geoaxes import GeoAxes
 from matplotlib.axes import Axes
 from matplotlib.colors import ListedColormap, to_hex
@@ -22,60 +20,6 @@ def _jsdate_list(data):
     tst = TsType(data.ts_type)
     idx = make_datetime_index(data.start, data.stop, tst.to_pandas_freq())
     return _get_jsdate(idx.values).tolist()
-
-
-def griddeddata_to_jsondict(data, lat_res_deg=5, lon_res_deg=5):
-    """
-    Convert gridded data to json dictionary
-
-    Parameters
-    ----------
-    data : GriddedData
-        input data to be converted
-    lat_res_deg : int
-        output latitude resolution in decimal degrees
-    lon_res_deg : int
-        output longitude resolution in decimal degrees
-
-    Returns
-    -------
-    dict
-        data dictionary for json output (keys are metadata and data).
-
-    """
-    data = data.regrid(lat_res_deg=lat_res_deg, lon_res_deg=lon_res_deg)
-
-    try:
-        data.check_dimcoords_tseries()
-    except Exception:
-        data.reorder_dimensions_tseries()
-
-    arr = data.to_xarray()
-    latname, lonname = "lat", "lon"
-    try:
-        stacked = arr.stack(station_name=(latname, lonname))
-    except Exception:
-        latname, lonname = "latitude", "longitude"
-        stacked = arr.stack(station_name=(latname, lonname))
-
-    output = {"data": {}, "metadata": {}}
-    dd = output["data"]
-    dd["time"] = _jsdate_list(data)
-    output["metadata"]["var_name"] = data.var_name
-    output["metadata"]["units"] = str(data.units)
-
-    nparr = stacked.data.astype(float)
-    if isinstance(nparr, dask.array.core.Array):
-        nparr = nparr.compute()
-    for i, (lat, lon) in enumerate(stacked.station_name.values):
-        coord = lat, lon
-        vals = nparr[:, i]
-        vals = np.round(vals, 5)
-        dd[str(coord)] = sd = {}
-        sd["lat"] = lat
-        sd["lon"] = lon
-        sd["data"] = vals.tolist()
-    return output
 
 
 def calc_contour_json(data, cmap, cmap_bins):
@@ -127,7 +71,13 @@ def calc_contour_json(data, cmap, cmap_bins):
     for i, date in enumerate(tst):
         datamon = nparr[i]
         contour = ax.contourf(
-            lons, lats, datamon, transform=proj, colors=cm.colors, levels=cmap_bins, extend="max"
+            lons,
+            lats,
+            datamon,
+            transform=proj,
+            colors=cm.colors,
+            levels=cmap_bins,
+            extend="max",
         )
 
         result = contourf_to_geojson(contourf=contour)

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -5,6 +5,7 @@ from cartopy.mpl.geoaxes import GeoAxes
 from matplotlib.axes import Axes
 from matplotlib.colors import ListedColormap, to_hex
 from seaborn import color_palette
+import io
 
 try:
     from geojsoncontour import contourf_to_geojson
@@ -103,8 +104,33 @@ def calc_contour_json(data, cmap, cmap_bins):
     return geojson
 
 
-def plot_pixel_maps(
-    data,
-    cmap,
-):
-    pass
+def plot_overlay_pixel_maps(data, cmap, cmap_bins, outpath):
+    fig, axis = plt.subplots(
+        1,
+        1,
+        subplot_kw=dict(projection=ccrs.Mercator()),
+        figsize=(8, 8),
+    )
+    # LB: see if we can use xarray plotting or need to modify somewhow
+    data.plot(
+        ax=axis,
+        transform=ccrs.PlateCarree(),
+        add_colorbar=False,
+        add_labels=False,
+        vmin=0,
+        vmax=120,
+        cmap=cmap,
+    )
+
+    with io.BytesIO() as buffer:  # use buffer memory
+        plt.savefig(
+            outpath,
+            bbox_inches="tight",
+            transparent=True,
+        )
+        buffer.seek(0)
+        image = buffer.getvalue()
+
+    plt.close()
+
+    return image

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -107,7 +107,7 @@ def calc_contour_json(data, cmap, cmap_bins):
 
 def plot_overlay_pixel_maps(
     data: xarray.DataArray, cmap: str, cmap_bins: list[float], format: str
-):
+):  # pragma: no cover
     plt.close("all")
     matplotlib.use("Agg")
 

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -16,6 +16,11 @@ from pyaerocom.helpers import make_datetime_index
 from pyaerocom.tstype import TsType
 
 
+# names of modelmaps type options
+CONTOUR = "contour"
+OVERLAY = "overlay"
+
+
 def _jsdate_list(data):
     tst = TsType(data.ts_type)
     idx = make_datetime_index(data.start, data.stop, tst.to_pandas_freq())

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -96,3 +96,10 @@ def calc_contour_json(data, cmap, cmap_bins):
 
     plt.close("all")
     return geojson
+
+
+def plot_pixel_maps(
+    data,
+    cmap,
+):
+    pass

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -106,7 +106,7 @@ def calc_contour_json(data, cmap, cmap_bins):
 
 
 def plot_overlay_pixel_maps(
-    data: xarray.DataArray, cmap: str, cmap_bins: list[float], outpath: str, format: str
+    data: xarray.DataArray, cmap: str, cmap_bins: list[float], format: str
 ):
     plt.close("all")
     matplotlib.use("Agg")
@@ -130,7 +130,7 @@ def plot_overlay_pixel_maps(
 
     with io.BytesIO() as buffer:  # use buffer memory
         plt.savefig(
-            outpath,
+            buffer,
             bbox_inches="tight",
             transparent=True,
             format=format,

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -126,7 +126,7 @@ class ModelMapsSetup(BaseModel):
     maps_freq: Literal["hourly", "daily", "monthly", "yearly", "coarsest"] = "coarsest"
     maps_res_deg: PositiveInt = 5
     # plot_types sho
-    plot_types: dict | set[str] = {"contour"}
+    plot_types: dict | set[str] = {CONTOUR}
     overlay_maps: tuple[str, ...] | None = None
     boundaries: BoundingBox | None = None
     # right_menu: tuple[str, ...] | None = None

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -37,10 +37,13 @@ from pyaerocom.aeroval.helpers import (
     check_if_year,
     BoundingBox,
 )
+from pyaerocom.aeroval.modelmaps_helpers import CONTOUR, OVERLAY
 from pyaerocom.aeroval.json_utils import read_json, set_float_serialization_precision
 from pyaerocom.colocation.colocation_setup import ColocationSetup
 
 logger = logging.getLogger(__name__)
+
+PLOT_TYPE_OPTIONS = ({OVERLAY}, {CONTOUR}, {OVERLAY, CONTOUR})
 
 
 class OutputPaths(BaseModel):
@@ -123,11 +126,23 @@ class ModelMapsSetup(BaseModel):
     maps_freq: Literal["hourly", "daily", "monthly", "yearly", "coarsest"] = "coarsest"
     maps_res_deg: PositiveInt = 5
     # LB: need to think about the tuple case...
-    plot_types: dict[str, Literal["overlay", "contour"] | tuple[str, ...]] | str = "contour"
+    plot_types: dict | set[str] = {"contour"}
     overlay_maps: tuple[str, ...] | None = None
     boundaries: BoundingBox | None = None
-    right_menu: tuple[str, ...] | None = None
+    # right_menu: tuple[str, ...] | None = None
+    map_observations_only_in_right_menu: bool = False
     overlay_save_format: Literal["webp", "png"] = "webp"
+
+    @field_validator("plot_types")
+    def validate_plot_types(cls, v):
+        if isinstance(v, dict):
+            for m in v:
+                if not isinstance(v[m], set):
+                    v[m] = set([v[m]])
+                assert v[m] in PLOT_TYPE_OPTIONS
+        if isinstance(v, str):
+            v = set([v])
+        return v
 
 
 class CAMS2_83Setup(BaseModel):

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -144,6 +144,9 @@ class ModelMapsSetup(BaseModel):
         if isinstance(v, str):
             v = set([v])
             assert v in PLOT_TYPE_OPTIONS
+        if isinstance(v, list):  # can occur when reading a serialized config
+            v = set(v)
+            assert v in PLOT_TYPE_OPTIONS
         return v
 
 

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -125,7 +125,7 @@ class OutputPaths(BaseModel):
 class ModelMapsSetup(BaseModel):
     maps_freq: Literal["hourly", "daily", "monthly", "yearly", "coarsest"] = "coarsest"
     maps_res_deg: PositiveInt = 5
-    # LB: need to think about the tuple case...
+    # plot_types sho
     plot_types: dict | set[str] = {"contour"}
     overlay_maps: tuple[str, ...] | None = None
     boundaries: BoundingBox | None = None
@@ -142,6 +142,7 @@ class ModelMapsSetup(BaseModel):
                 assert v[m] in PLOT_TYPE_OPTIONS
         if isinstance(v, str):
             v = set([v])
+            assert v in PLOT_TYPE_OPTIONS
         return v
 
 

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -79,6 +79,7 @@ class OutputPaths(BaseModel):
         "hm/ts",
         "contour",
         "profiles",
+        "contour/overlay",
     ]
     avdb_resource: Path | str | None = None
 

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -126,7 +126,6 @@ class ModelMapsSetup(BaseModel):
     maps_freq: Literal["hourly", "daily", "monthly", "yearly", "coarsest"] = "coarsest"
     maps_res_deg: PositiveInt = 5
     plot_types: dict | set[str] = {CONTOUR}
-    overlay_maps: tuple[str, ...] | None = None
     boundaries: BoundingBox | None = None
     map_observations_only_in_right_menu: bool = False
     overlay_save_format: Literal["webp", "png"] = "webp"

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -122,10 +122,12 @@ class OutputPaths(BaseModel):
 class ModelMapsSetup(BaseModel):
     maps_freq: Literal["hourly", "daily", "monthly", "yearly", "coarsest"] = "coarsest"
     maps_res_deg: PositiveInt = 5
-    plot_types: dict[str, Literal["overlay", "contour"]] | str = "contour"
+    # LB: need to think about the tuple case...
+    plot_types: dict[str, Literal["overlay", "contour"] | tuple[str, ...]] | str = "contour"
+    overlay_maps: tuple[str, ...] | None = None
     boundaries: BoundingBox | None = None
     right_menu: tuple[str, ...] | None = None
-    save_format: Literal["webp", "png"] = "webp"
+    overlay_save_format: Literal["webp", "png"] = "webp"
 
 
 class CAMS2_83Setup(BaseModel):

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -125,11 +125,9 @@ class OutputPaths(BaseModel):
 class ModelMapsSetup(BaseModel):
     maps_freq: Literal["hourly", "daily", "monthly", "yearly", "coarsest"] = "coarsest"
     maps_res_deg: PositiveInt = 5
-    # plot_types sho
     plot_types: dict | set[str] = {CONTOUR}
     overlay_maps: tuple[str, ...] | None = None
     boundaries: BoundingBox | None = None
-    # right_menu: tuple[str, ...] | None = None
     map_observations_only_in_right_menu: bool = False
     overlay_save_format: Literal["webp", "png"] = "webp"
 

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -122,7 +122,7 @@ class OutputPaths(BaseModel):
 class ModelMapsSetup(BaseModel):
     maps_freq: Literal["hourly", "daily", "monthly", "yearly", "coarsest"] = "coarsest"
     maps_res_deg: PositiveInt = 5
-    type: Literal["overlay"] = "overlay"
+    plot_types: dict[str, Literal["overlay", "contour"]] | str = "contour"
     boundaries: BoundingBox | None = None
     right_menu: tuple[str, ...] | None = None
     save_format: Literal["webp", "png"] = "webp"

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -79,7 +79,6 @@ class OutputPaths(BaseModel):
         "hm/ts",
         "contour",
         "profiles",
-        "contour/overlay",
     ]
     avdb_resource: Path | str | None = None
 

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -136,13 +136,14 @@ class ModelMapsSetup(BaseModel):
             for m in v:
                 if not isinstance(v[m], set):
                     v[m] = set([v[m]])
-                assert v[m] in PLOT_TYPE_OPTIONS
+                if v[m] not in PLOT_TYPE_OPTIONS:
+                    raise ConfigError("Model maps set up given a non-valid plot type.")
         if isinstance(v, str):
             v = set([v])
-            assert v in PLOT_TYPE_OPTIONS
         if isinstance(v, list):  # can occur when reading a serialized config
             v = set(v)
-            assert v in PLOT_TYPE_OPTIONS
+        if v not in PLOT_TYPE_OPTIONS:
+            raise ConfigError("Model maps set up given a non-valid plot type.")
         return v
 
 

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -35,6 +35,7 @@ from pyaerocom.aeroval.helpers import (
     _check_statistics_periods,
     _get_min_max_year_periods,
     check_if_year,
+    BoundingBox,
 )
 from pyaerocom.aeroval.json_utils import read_json, set_float_serialization_precision
 from pyaerocom.colocation.colocation_setup import ColocationSetup
@@ -121,6 +122,10 @@ class OutputPaths(BaseModel):
 class ModelMapsSetup(BaseModel):
     maps_freq: Literal["hourly", "daily", "monthly", "yearly", "coarsest"] = "coarsest"
     maps_res_deg: PositiveInt = 5
+    type: Literal["overlay"] = "overlay"
+    boundaries: BoundingBox | None = None
+    right_menu: tuple[str, ...] | None = None
+    save_format: Literal["webp", "png"] = "webp"
 
 
 class CAMS2_83Setup(BaseModel):

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -32,7 +32,7 @@ dependencies:
     - geojsoncontour
     - geocoder_reverse_natural_earth >= 0.0.2
     - pyaro >= 0.0.10
-    - aerovaldb >= 0.1.0
+    - aerovaldb == 0.1.0rc2
 ## testing
   - pytest >=7.4
   - pytest-dependency

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -32,7 +32,7 @@ dependencies:
     - geojsoncontour
     - geocoder_reverse_natural_earth >= 0.0.2
     - pyaro >= 0.0.10
-    - aerovaldb == 0.0.15
+    - aerovaldb == 0.1.0rc2
 ## testing
   - pytest >=7.4
   - pytest-dependency

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -32,7 +32,7 @@ dependencies:
     - geojsoncontour
     - geocoder_reverse_natural_earth >= 0.0.2
     - pyaro >= 0.0.10
-    - aerovaldb == 0.1.0rc2
+    - aerovaldb == 0.1.0
 ## testing
   - pytest >=7.4
   - pytest-dependency

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -32,7 +32,7 @@ dependencies:
     - geojsoncontour
     - geocoder_reverse_natural_earth >= 0.0.2
     - pyaro >= 0.0.10
-    - aerovaldb == 0.1.0
+    - aerovaldb >= 0.1.0
 ## testing
   - pytest >=7.4
   - pytest-dependency

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -32,7 +32,7 @@ dependencies:
     - geojsoncontour
     - geocoder_reverse_natural_earth >= 0.0.2
     - pyaro >= 0.0.10
-    - aerovaldb >= 0.1.0
+    - aerovaldb >= 0.1.1
 ## testing
   - pytest >=7.4
   - pytest-dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "aerovaldb>=0.1.0",
+    "aerovaldb==0.1.0rc2",
     "scitools-iris>=3.8.1",
     "xarray>=2022.12.0",
     "cartopy>=0.21.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "aerovaldb==0.1.0",
+    "aerovaldb>=0.1.0",
     "scitools-iris>=3.8.1",
     "xarray>=2022.12.0",
     "cartopy>=0.21.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "aerovaldb==0.0.17",
+    "aerovaldb==0.1.0rc2",
     "scitools-iris>=3.8.1",
     "xarray>=2022.12.0",
     "cartopy>=0.21.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "aerovaldb>=0.1.0",
+    "aerovaldb>=0.1.1",
     "scitools-iris>=3.8.1",
     "xarray>=2022.12.0",
     "cartopy>=0.21.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "aerovaldb==0.1.0rc2",
+    "aerovaldb==0.1.0",
     "scitools-iris>=3.8.1",
     "xarray>=2022.12.0",
     "cartopy>=0.21.1",

--- a/tests/aeroval/test_aeroval_HIGHLEV.py
+++ b/tests/aeroval/test_aeroval_HIGHLEV.py
@@ -11,7 +11,7 @@ from tests.conftest import geojson_unavail
 
 CHK_CFG1 = {
     "map": ["AERONET-Sun-od550aer_Column_TM5-AP3-CTRL-od550aer_2010.json"],
-    "contour": 1,
+    "contour": 0,
     "hm": [
         "glob_stats_daily.json",
         "glob_stats_monthly.json",

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -298,7 +298,7 @@ def test_Experiment_Output_clean_json_files_CFG1_INVALIDMOD(eval_config: dict):
     proc.run()
     del cfg.model_cfg["mod1"]
     modified = proc.exp_output.clean_json_files()
-    assert len(modified) == 15
+    assert len(modified) == 13
 
 
 @geojson_unavail

--- a/tests/aeroval/test_modelmaps_engine.py
+++ b/tests/aeroval/test_modelmaps_engine.py
@@ -10,7 +10,7 @@ def test__process_map_var():
     stp = EvalSetup(**CFG)
     engine = ModelMapsEngine(stp)
     with pytest.raises(ModelVarNotAvailable) as excinfo:
-        engine._process_map_var("LOTOS", "concco", False)
+        engine._process_contour_map_var("LOTOS", "concco", False)
     assert "no such entry LOTOS" in str(excinfo.value)
 
 

--- a/tests/aeroval/test_modelmaps_helpers.py
+++ b/tests/aeroval/test_modelmaps_helpers.py
@@ -1,4 +1,4 @@
-from pyaerocom.aeroval.modelmaps_helpers import _jsdate_list, griddeddata_to_jsondict
+from pyaerocom.aeroval.modelmaps_helpers import _jsdate_list
 
 
 def test__jsdate_list(data_tm5):
@@ -6,23 +6,3 @@ def test__jsdate_list(data_tm5):
     assert len(vals) == 12
     assert vals[0] == 1263513600000
     assert vals[-1] == 1292371200000
-
-
-def test_griddeddata_to_jsondict(data_tm5):
-    result = griddeddata_to_jsondict(data_tm5)
-    assert isinstance(result, dict)
-    assert "metadata" in result
-    assert len(result["metadata"]) == 2
-    assert "data" in result
-    data = result["data"]
-    assert "time" in data
-    assert len(data["time"]) == 12
-    assert len(data) == 2593
-    del data["time"]
-    pixel = list(data.values())[0]
-    assert "lat" in pixel
-    assert isinstance(pixel["lat"], float)
-    assert "lon" in pixel
-    assert isinstance(pixel["lon"], float)
-    assert "data" in pixel
-    assert len(pixel["data"]) == 12

--- a/tests/aeroval/test_setup_classes.py
+++ b/tests/aeroval/test_setup_classes.py
@@ -169,6 +169,7 @@ def test_EvalSetup_ModelMapsSetup(eval_setup: EvalSetup, cfg_exp1: dict, update:
         assert modelmaps_opts.maps_freq == "coarsest"
         assert "maps_res_deg" not in cfg_exp1
         assert modelmaps_opts.maps_res_deg == 5
+        assert modelmaps_opts.plot_types == {"contour"}
 
 
 @pytest.mark.parametrize(

--- a/tests/aeroval/test_setup_classes.py
+++ b/tests/aeroval/test_setup_classes.py
@@ -7,6 +7,7 @@ import pytest
 from pyaerocom.aeroval import EvalSetup
 from pyaerocom.exceptions import EvalEntryNameError
 from tests.fixtures.aeroval.cfg_test_exp1 import CFG, MODELS, OBS_GROUNDBASED
+from pyaerocom.aeroval.modelmaps_helpers import CONTOUR
 
 
 @pytest.fixture
@@ -169,7 +170,8 @@ def test_EvalSetup_ModelMapsSetup(eval_setup: EvalSetup, cfg_exp1: dict, update:
         assert modelmaps_opts.maps_freq == "coarsest"
         assert "maps_res_deg" not in cfg_exp1
         assert modelmaps_opts.maps_res_deg == 5
-        assert modelmaps_opts.plot_types == {"contour"}
+        assert modelmaps_opts.plot_types == {CONTOUR}
+        assert modelmaps_opts.overlay_save_format == "webp"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Summary

- Remove old `json` file computations (in `contour` directory)
- `ranges.json` contains a unit for each variable 
- Implement requested attributes in `ModelMapsSetup`, and associated helper classes and methods, such as `BoundingBox` and `validate_plot_types`
- Implement `plot_overlay_pixel_maps`
- Rename `_process_map_var` to `_process_contour_map_var`
- Fix tests

I have added some small tests for `modelmaps_opts` in `setup_classes.py` but not for the actual processing of the pixel maps as analogous tests do not seem to exist for the contour plotting.

## Related issue number

closes #401, https://github.com/metno/AeroToolsIssues/issues/5

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [ ] Make PR ready to review
