### PR TITLE
Fix metaindx shift after metadata filter

### DIFF
--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -2048,6 +2048,7 @@ class UngriddedData:
                 stop = data_idx_new + totnum
 
                 new._data[data_idx_new:stop, :] = self._data[indices, :]
+                new._data[data_idx_new:stop, new._METADATAKEYINDEX] = meta_idx_new
                 new.meta_idx[meta_idx_new][var] = np.arange(data_idx_new, stop)
                 new.var_idx[var] = self.var_idx[var]
                 data_idx_new += totnum


### PR DESCRIPTION
## Change Summary

The metadata index array was not correctly offset to match the new indices during metadata filter which caused lookup of metadata using `UngriddedData.metadata` to be broken after using `UngriddedData.filter_by_meta()`

## Related issue number

closes #1354

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
