### PR TITLE
Fix set equivalence checking in ModelMapsEngine

### DIFF
--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -109,12 +109,12 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                         model_name, False
                     )
 
-                if self.cfg.modelmaps_opts.plot_types is CONTOUR or make_contour:
+                if self.cfg.modelmaps_opts.plot_types == {CONTOUR} or make_contour:
                     _files = self._process_contour_map_var(
                         model_name, var, self.reanalyse_existing
                     )
                     files.extend(_files)
-                if self.cfg.modelmaps_opts.plot_types is OVERLAY or make_overlay:
+                if self.cfg.modelmaps_opts.plot_types == {OVERLAY} or make_overlay:
                     # create overlay (pixel) plots
                     _files = self._process_overlay_map_var(
                         model_name, var, self.reanalyse_existing


### PR DESCRIPTION
## Change Summary

Title. @jgriesfeller noticed this bug.

## Related issue number

NA

## Checklist

* [ ] Start with a draft-PR
* [ ] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
