### PR TITLE
Remove double parenthesis in read_pyaro.py L299

### DIFF
--- a/pyaerocom/io/pyaro/read_pyaro.py
+++ b/pyaerocom/io/pyaro/read_pyaro.py
@@ -296,7 +296,7 @@ class PyaroToUngriddedData:
         return self.reader.variables()
 
     def get_stations(self) -> dict[str, Station]:
-        return self.reader.stations()()
+        return self.reader.stations()
 
     def read(self, vars_to_retrieve=None) -> UngriddedData:
         allowed_vars = self.get_variables()

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -31,7 +31,7 @@ dependencies:
   - pip:
     - geojsoncontour
     - geocoder_reverse_natural_earth >= 0.0.2
-    - pyaro >= 0.0.10
+    - pyaro >= 0.0.12
     - aerovaldb >= 0.1.1
 ## testing
   - pytest >=7.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     'cf-units>=3.1',
     "pydantic>=2.7.1",
     "pyproj>=3.0.0",
-    "pyaro>=0.0.10",
+    "pyaro>=0.0.12",
     "pooch>=1.7.0",
     "psutil>=5.0.0",
 ]


### PR DESCRIPTION
## Change Summary

Updated version of pyaro and fix double paranthesis

## Related issue number
Fix #1363
Close https://github.com/metno/pyaerocom/pull/1368
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
