### PR TITLE
Update obsentry.py to remove deprecated allow_mutation=False

### DIFF
--- a/pyaerocom/aeroval/obsentry.py
+++ b/pyaerocom/aeroval/obsentry.py
@@ -93,7 +93,6 @@ class ObsEntry(BaseModel):
     model_config = ConfigDict(
         arbitrary_types_allowed=True,
         extra="allow",
-        allow_mutation=False,
         validate_assignment=True,
     )
 


### PR DESCRIPTION
Tried setting frozen=True but this breaks 25 tests in tests/aeroval and tests/cams2_83, so for now we keep it mutable

## Change Summary

Title

## Related issue number

NA

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
