### PR TITLE
Fix maps not being created in CAMS2_83

### DIFF
--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -112,7 +112,6 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                     make_overlay = OVERLAY in self.cfg.modelmaps_opts.plot_types.get(
                         model_name, False
                     )
-
                 if self.cfg.modelmaps_opts.plot_types == {CONTOUR} or make_contour:
                     _files = self._process_contour_map_var(
                         model_name, var, self.reanalyse_existing
@@ -401,6 +400,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         kwargs.update(**self.cfg.colocation_opts.model_kwargs)
         if var in self.cfg.colocation_opts.model_read_opts:
             kwargs.update(self.cfg.colocation_opts.model_read_opts[var])
+        kwargs.update(self.cfg.get_model_entry(model_name)["model_kwargs"])
 
         if model_reader is not None and model_reader in MODELREADERS_USE_MAP_FREQ:
             ts_types = reader.ts_types

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -400,7 +400,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         kwargs.update(**self.cfg.colocation_opts.model_kwargs)
         if var in self.cfg.colocation_opts.model_read_opts:
             kwargs.update(self.cfg.colocation_opts.model_read_opts[var])
-        kwargs.update(self.cfg.get_model_entry(model_name)["model_kwargs"])
+        kwargs.update(self.cfg.get_model_entry(model_name).get("model_kwargs", {}))
 
         if model_reader is not None and model_reader in MODELREADERS_USE_MAP_FREQ:
             ts_types = reader.ts_types


### PR DESCRIPTION
## Change Summary

The cams2_83 reader required a `daterange` argument, which was not being picked up in kwargs, partially due to do work that Daniel and I did to move the model_kwargs argument closer to the model entry instance. i.e., not in the `colocation_opts`. This was meant to minimize confusion and simplify things but it was not being picked up in the `ModelMapsEngine` (which occurs prior to the regular collocations) and hence crashing. In the regular collocation, keys which are in specific model_entry instances are copied over to the `colocation_opts` and the kwargs for the model reader are picked up from there. Hence, why this did not crash the regular collocation code, and only appears in the CAMS2_83, where this specific `daterange` argument is required by `reader.read_var()`

## Related issue number
close #1380 

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

please test @charlienegri 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
