### PR TITLE
Fix warnings

### DIFF
--- a/pyaerocom/plot/config.py
+++ b/pyaerocom/plot/config.py
@@ -1,3 +1,4 @@
+import warnings
 from warnings import warn
 
 
@@ -152,7 +153,9 @@ class ColorTheme:
         return s
 
 
-COLOR_THEME = ColorTheme(DEFAULT_THEME)
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning, module="pyaerocom")
+    COLOR_THEME = ColorTheme(DEFAULT_THEME)
 
 
 def get_color_theme(theme_name="dark"):

--- a/pyaerocom/plot/mapping.py
+++ b/pyaerocom/plot/mapping.py
@@ -21,7 +21,9 @@ from pyaerocom.plot.helpers import (
 )
 from pyaerocom.region import Region
 
-MPL_PARAMS = custom_mpl()
+with warnings.catch_warnings():
+    warnings.filterwarnings("ignore", category=DeprecationWarning, module="pyaerocom")
+    MPL_PARAMS = custom_mpl()
 
 
 def get_cmap_maps_aerocom(color_theme=None, vmin=None, vmax=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,19 +100,17 @@ log_cli_level = "WARNING"
 addopts = ["--failed-first", "--import-mode=importlib"]
 xfail_strict = true
 testpaths = ["tests"]
-##  uncomment to raise errors from warnings
-#filterwarnings = [
-#    # all warnings are errors
-#    "error",
-#    "ignore::pytest.PytestUnraisableExceptionWarning",
-#    # except deprecation and future warnings ouside this packege
-#    'ignore::PendingDeprecationWarning:^(?!pyaerocom|tests).*:',
-#    'ignore::DeprecationWarning:^(?!pyaerocom|tests).*:',
-#    'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
-#    # and not on this list
-#    "ignore:.*please install Basemap:UserWarning:geonum.*:",
-#    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:",
-#]
+filterwarnings = [
+    # treat warnings as errors
+    "error",
+    "ignore::pytest.PytestUnraisableExceptionWarning",
+    # except deprecation and future warnings ouside this packege
+    'ignore::PendingDeprecationWarning:^(?!pyaerocom|tests).*:',
+    'ignore::DeprecationWarning:^(?!pyaerocom|tests).*:',
+    'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
+    # and not on this list
+    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:",
+]
 
 [tool.coverage.run]
 source = ["pyaerocom"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,8 @@ filterwarnings = [
     'ignore::PendingDeprecationWarning:^(?!pyaerocom|tests).*:',
     'ignore::DeprecationWarning:^(?!pyaerocom|tests).*:',
     'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
+    # Ignore self-deprecation warnings related to plotting
+    'ignore:matplotlib based plotting is no longer directly supported. This (function|class) may be removed in future versions\.:DeprecationWarning:(pyaerocom|tests):',
     # and not on this list
     "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:",  # Issue #1394
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ filterwarnings = [
     'ignore::DeprecationWarning:^(?!pyaerocom|tests).*:',
     'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
     # and not on this list
-    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:",
+    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:",  # Issue #1394
 ]
 
 [tool.coverage.run]

--- a/tests/cams2_83/test_cams2_83_cli_mos.py
+++ b/tests/cams2_83/test_cams2_83_cli_mos.py
@@ -73,6 +73,8 @@ def test_eval_mos_standard(tmp_path: Path, coldata_mos: Path, caplog):
 
 
 @ignore_warnings(RuntimeWarning, "invalid value encountered in divide")
+@ignore_warnings(RuntimeWarning, "Mean of empty slice")
+@ignore_warnings(RuntimeWarning, "All-NaN slice encountered")
 @pytest.mark.usefixtures("fake_ExperimentProcessor", "reset_cachedir")
 def test_eval_mos_medianscores(tmp_path: Path, coldata_mos: Path, caplog):
     options = f"season 2024-03-01 2024-03-05 --data-path {tmp_path} --coldata-path {coldata_mos} --cache {tmp_path} --id mos-colocated-data --name 'Test'"

--- a/tests/stats/mda8/test_mda8.py
+++ b/tests/stats/mda8/test_mda8.py
@@ -52,7 +52,7 @@ def test_data(time, values) -> xr.DataArray:
         # https://github.com/metno/pyaerocom/issues/1323
         pytest.param(
             xr.date_range(start="2024-01-01 06:00:00", periods=30, freq="1h"),
-            np.arange(30),
+            np.arange(30, dtype=float),
             [np.nan, np.nan],
             id="#1323",
         ),
@@ -161,7 +161,7 @@ def test_rollingaverage_label():
     https://github.com/metno/pyaerocom/issues/1323
     """
     data = xr.DataArray(
-        [[[x] for x in range(24)]],
+        [[[float(x)] for x in range(24)]],
         dims=["data_source", "time", "station_name"],
         coords={"time": xr.date_range(start="2024-01-01 00:00", periods=24, freq="1h")},
     )


### PR DESCRIPTION
## Change Summary

<!-- Please give a short summary of the changes. -->

Enables warnings as errors, and fixes the warnings emitted during running of the tests.

Iris warning is still ignored, as the fix is not trivial. The relevant path is [found in this part of the iris code](https://github.com/SciTools/iris/blob/8753cfb9c30f9bb71b6878e4d29000771b6fea9e/lib/iris/analysis/cartography.py#L379), we could fix this by using a [`GeogCS`](https://scitools-iris.readthedocs.io/en/latest/generated/api/iris.coord_systems.html#iris.coord_systems.GeogCS) coordinate system.

## Related issue number

#1066 
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
