### PR TITLE
allow list of strings and Path like objects in PyaroConfig

### DIFF
--- a/pyaerocom/io/pyaro/pyaro_config.py
+++ b/pyaerocom/io/pyaro/pyaro_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from importlib import resources
 from pathlib import Path
-from typing import ClassVar, Union
+from typing import ClassVar
 
 import yaml
 from pydantic import BaseModel, ConfigDict
@@ -29,7 +29,7 @@ class PyaroConfig(BaseModel):
 
     name: str
     data_id: str
-    filename_or_obj_or_url: Union[str, list[str], Path, list[Path]]
+    filename_or_obj_or_url: str | list[str] | Path | list[Path]
     filters: dict[str, dict[str, list[str]] | dict[str, list[tuple]]]
     name_map: dict[str, str] | None = None  # no Unit conversion option
 

--- a/pyaerocom/io/pyaro/pyaro_config.py
+++ b/pyaerocom/io/pyaro/pyaro_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from importlib import resources
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, Union
 
 import yaml
 from pydantic import BaseModel, ConfigDict
@@ -28,7 +28,7 @@ class PyaroConfig(BaseModel):
 
     name: str
     data_id: str
-    filename_or_obj_or_url: [str, list[str], Path, list[Path]]
+    filename_or_obj_or_url: Union [str, list[str], Path, list[Path]]
     filters: dict[str, dict[str, list[str]] | dict[str, list[tuple]]]
     name_map: dict[str, str] | None = None  # no Unit conversion option
 

--- a/pyaerocom/io/pyaro/pyaro_config.py
+++ b/pyaerocom/io/pyaro/pyaro_config.py
@@ -12,6 +12,7 @@ import pyaerocom as pya
 
 logger = logging.getLogger(__name__)
 
+
 # TODO Check a validator if extra/kwarg is serializable. Either in json_repr or as a @field_validator on extra
 
 
@@ -28,7 +29,7 @@ class PyaroConfig(BaseModel):
 
     name: str
     data_id: str
-    filename_or_obj_or_url: Union [str, list[str], Path, list[Path]]
+    filename_or_obj_or_url: Union[str, list[str], Path, list[Path]]
     filters: dict[str, dict[str, list[str]] | dict[str, list[tuple]]]
     name_map: dict[str, str] | None = None  # no Unit conversion option
 

--- a/pyaerocom/io/pyaro/pyaro_config.py
+++ b/pyaerocom/io/pyaro/pyaro_config.py
@@ -28,7 +28,7 @@ class PyaroConfig(BaseModel):
 
     name: str
     data_id: str
-    filename_or_obj_or_url: str
+    filename_or_obj_or_url: [str, list[str], Path, list[Path]]
     filters: dict[str, dict[str, list[str]] | dict[str, list[tuple]]]
     name_map: dict[str, str] | None = None  # no Unit conversion option
 


### PR DESCRIPTION
## Change Summary
allow `[str, list[str], Path, list[Path]]` as `filename_or_obj_or_url` in `PyaroConfig`

## Related issue number
fix #1399 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
