### PR TITLE
Implement pyaro-readers using documented API

### DIFF
--- a/pyaerocom/io/pyaro/read_pyaro.py
+++ b/pyaerocom/io/pyaro/read_pyaro.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TypeVar
+from typing import TypeVar, Generic
 import functools
 from collections import defaultdict
 
@@ -137,7 +137,7 @@ class PyaroToUngriddedData:
 
         T = TypeVar("T")
 
-        class UniqueMapper:
+        class UniqueMapper(Generic[T]):
             """Assign a unique ID to each item it has
             not seen before
             """
@@ -159,11 +159,9 @@ class PyaroToUngriddedData:
             def __getitem__(self, key: T) -> float:
                 return self.inner[key]
 
-            def __contains__(self, item: T) -> bool:
-                return item in self.inner
-
-        station_mapper = UniqueMapper()
-        var_mapper = UniqueMapper()
+        # unique in (station_name, variable_name, units, tstype)
+        station_mapper: UniqueMapper[tuple[str, str, str, str]] = UniqueMapper()
+        var_mapper: UniqueMapper[str] = UniqueMapper()
 
         stations_with_metadata = self.get_stations()
 

--- a/pyaerocom/io/pyaro/read_pyaro.py
+++ b/pyaerocom/io/pyaro/read_pyaro.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import NewType, TypeVar
+from typing import TypeVar
 import functools
 from collections import defaultdict
 
@@ -17,10 +17,6 @@ from pyaerocom.tstype import TsType
 from pyaerocom.ungriddeddata import UngriddedData
 
 logger = logging.getLogger(__name__)
-
-
-MetadataEntry = NewType("MetadataEntry", dict[str, str | list[str]])
-Metadata = NewType("Metadata", dict[str, MetadataEntry])
 
 
 class ReadPyaro(ReadUngriddedBase):

--- a/pyaerocom/io/pyaro/read_pyaro.py
+++ b/pyaerocom/io/pyaro/read_pyaro.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class ReadPyaro(ReadUngriddedBase):
-    __version__ = "1.0.1"
+    __version__ = "1.1.0"
 
     SUPPORTED_DATASETS = list(list_timeseries_engines().keys())
 

--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -4,6 +4,7 @@ import fnmatch
 import logging
 import os
 from datetime import datetime
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -163,7 +164,7 @@ class UngriddedData:
     @staticmethod
     def _from_raw_parts(
         data: npt.NDTArray[float],
-        metadata: dict[float, dict[str, str]],
+        metadata: dict[float, dict[str, Any]],
         meta_idx: dict[float, dict[str, list[int]]],
         var_idx: dict[str, float],
     ) -> UngriddedData:

--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 import matplotlib.pyplot as plt
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
 
 from pyaerocom import const
@@ -74,11 +75,11 @@ class UngriddedData:
 
     Attributes
     ----------
-    metadata : dict
+    metadata : dict[float, dict[str, Any]]
         dictionary containing meta information about the data. Keys are
         floating point numbers corresponding to each station, values are
         corresponding dictionaries containing station information.
-    meta_idx : dict
+    meta_idx : dict[float, dict[str, list[int]]]
         dictionary containing index mapping for each station and variable. Keys
         correspond to metadata key (float -> station, see :attr:`metadata`) and
         values are dictionaries containing keys specifying variable name and
@@ -87,7 +88,7 @@ class UngriddedData:
         information is redunant and is there to accelarate station data
         extraction since the data index matches for a given metadata block
         do not need to be searched in the underlying numpy array.
-    var_idx : dict
+    var_idx : dict[str, float]
         mapping of variable name (keys, e.g. od550aer) to numerical variable
         index of this variable in data numpy array (in column specified by
         :attr:`_VARINDEX`)
@@ -158,6 +159,22 @@ class UngriddedData:
 
         self.filter_hist = {}
         self._is_vertical_profile = False
+
+    @staticmethod
+    def _from_raw_parts(
+        data: npt.NDTArray[float],
+        metadata: dict[float, dict[str, str]],
+        meta_idx: dict[float, dict[str, list[int]]],
+        var_idx: dict[str, float],
+    ) -> UngriddedData:
+        data_obj = UngriddedData()
+
+        data_obj._data = data
+        data_obj.meta_idx = meta_idx
+        data_obj.metadata = metadata
+        data_obj.var_idx = var_idx
+
+        return data_obj
 
     def _get_data_revision_helper(self, data_id):
         """


### PR DESCRIPTION
## Change Summary

<!-- Please give a short summary of the changes. -->
The current iteration of the pyaro reader assumes one can index into the pyaro object to get a structured numpy element containing the metadata. This PR changes this to implement using the pyaro interface.

In addition this PR tries to read the data into the `UngriddedData` object more efficiently than line-by-line.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

Possible fix for #1302 


## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
