### PR TITLE
Fix reference to OBS_VERT_TYPES_ALT

### DIFF
--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -830,7 +830,9 @@ class Colocator:
     def _try_get_vert_which_alt(self, is_model, var_name):
         if is_model:
             if self.colocation_setup.obs_vert_type in self.colocation_setup.OBS_VERT_TYPES_ALT:
-                return self.OBS_VERT_TYPES_ALT[self.colocation_setup.obs_vert_type]
+                return self.colocation_setup.OBS_VERT_TYPES_ALT[
+                    self.colocation_setup.obs_vert_type
+                ]
         raise DataCoverageError(f"No alternative vert type found for {var_name}")
 
     def _check_remove_outliers_gridded(self, data, var_name, is_model):


### PR DESCRIPTION
## Change Summary

Fixes small issue with OBS_VERT_TYPES_ALT which is no longer on Colocator but ColocationSetup.

## Related issue number

NA

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
