### PR TITLE
Lowlevel helpers clean up

### DIFF
--- a/pyaerocom/_lowlevel_helpers.py
+++ b/pyaerocom/_lowlevel_helpers.py
@@ -77,6 +77,7 @@ def _class_name(obj):
     return type(obj).__name__
 
 
+# TODO: CHeck to see if instances of these classes can instead use pydantic
 class Validator(abc.ABC):
     def __set_name__(self, owner, name):
         self._name = name
@@ -110,56 +111,6 @@ class StrType(Validator):
     def validate(self, val):
         if not isinstance(val, str):
             raise ValueError(f"need str, got {val}")
-        return val
-
-
-class StrWithDefault(Validator):
-    def __init__(self, default: str):
-        self.default = default
-
-    def validate(self, val):
-        if not isinstance(val, str):
-            if val is None:
-                val = self.default
-            else:
-                raise ValueError(f"need str or None, got {val}")
-        return val
-
-
-class FlexList(Validator):
-    """list that can be instantated via input str, tuple or list or None"""
-
-    def validate(self, val):
-        if isinstance(val, str):
-            val = [val]
-        elif isinstance(val, tuple):
-            val = list(val)
-        elif val is None:
-            val = []
-        elif not isinstance(val, list):
-            raise ValueError(f"failed to convert {val} to list")
-        return val
-
-
-class EitherOf(Validator):
-    _allowed = FlexList()
-
-    def __init__(self, allowed: list):
-        self._allowed = allowed
-
-    def validate(self, val):
-        if not any([x == val for x in self._allowed]):
-            raise ValueError(f"invalid value {val}, needs to be either of {self._allowed}.")
-        return val
-
-
-class ListOfStrings(FlexList):
-    def validate(self, val):
-        # make sure to have a list
-        val = super().validate(val)
-        # make sure all entries are strings
-        if not all([isinstance(x, str) for x in val]):
-            raise ValueError(f"not all items are str type in input list {val}")
         return val
 
 

--- a/pyaerocom/_lowlevel_helpers.py
+++ b/pyaerocom/_lowlevel_helpers.py
@@ -77,7 +77,7 @@ def _class_name(obj):
     return type(obj).__name__
 
 
-# TODO: CHeck to see if instances of these classes can instead use pydantic
+# TODO: Check to see if instances of these classes can instead use pydantic
 class Validator(abc.ABC):
     def __set_name__(self, owner, name):
         self._name = name

--- a/pyaerocom/aeroval/aux_io_helpers.py
+++ b/pyaerocom/aeroval/aux_io_helpers.py
@@ -66,9 +66,10 @@ class _AuxReadSpec(BaseModel):
     @model_validator(mode="after")
     def validate_fun(self) -> None:
         if callable(self.fun):
-            return
+            return self
         elif isinstance(self.fun, str):
             self.fun = self.funcs[self.fun]
+            return self
         else:
             raise ValueError("failed to retrieve aux func")
 

--- a/pyaerocom/aeroval/aux_io_helpers.py
+++ b/pyaerocom/aeroval/aux_io_helpers.py
@@ -8,6 +8,8 @@ if sys.version_info >= (3, 11):
 else:
     from typing_extensions import Self
 
+from typing import TYPE_CHECKING
+
 from pydantic import (
     BaseModel,
     model_validator,
@@ -64,7 +66,10 @@ class _AuxReadSpec(BaseModel):
 
     """
 
-    fun: str | Callable
+    if TYPE_CHECKING:
+        fun: Callable
+    else:
+        fun: str | Callable
     vars_required: list[str]
     funcs: dict[str, Callable]
 

--- a/pyaerocom/aeroval/aux_io_helpers.py
+++ b/pyaerocom/aeroval/aux_io_helpers.py
@@ -1,8 +1,14 @@
 import importlib
 import os
 import sys
+from collections.abc import Callable
 
-from pyaerocom._lowlevel_helpers import AsciiFileLoc, ListOfStrings
+from pydantic import (
+    BaseModel,
+    model_validator,
+)
+
+from pyaerocom._lowlevel_helpers import AsciiFileLoc
 
 
 def check_aux_info(fun, vars_required, funcs):
@@ -26,11 +32,11 @@ def check_aux_info(fun, vars_required, funcs):
         required.
 
     """
-    spec = _AuxReadSpec(fun, vars_required, funcs)
+    spec = _AuxReadSpec(fun=fun, vars_required=vars_required, funcs=funcs)
     return dict(fun=spec.fun, vars_required=spec.vars_required)
 
 
-class _AuxReadSpec:
+class _AuxReadSpec(BaseModel):
     """
     Class that specifies requirements for computation of additional variables
 
@@ -53,39 +59,18 @@ class _AuxReadSpec:
 
     """
 
-    vars_required = ListOfStrings()
+    fun: str | Callable
+    vars_required: list[str]
+    funcs: dict[str, Callable]
 
-    def __init__(self, fun, vars_required: list, funcs: dict):
-        self.vars_required = vars_required
-        self.fun = self.get_func(fun, funcs)
-
-    def get_func(self, fun, funcs):
-        """
-        Get callable function for computation of variable
-
-        Parameters
-        ----------
-        fun : str or callable
-            Name of function or function.
-        funcs : dict
-            Dictionary with possible functions (values) and names (keys)
-
-        Raises
-        ------
-        ValueError
-            If function could not be retrieved.
-
-        Returns
-        -------
-        callable
-            callable function object.
-
-        """
-        if callable(fun):
-            return fun
-        elif isinstance(fun, str):
-            return funcs[fun]
-        raise ValueError("failed to retrieve aux func")
+    @model_validator(mode="after")
+    def validate_fun(self) -> None:
+        if callable(self.fun):
+            return
+        elif isinstance(self.fun, str):
+            self.fun = self.funcs[self.fun]
+        else:
+            raise ValueError("failed to retrieve aux func")
 
 
 class ReadAuxHandler:

--- a/pyaerocom/aeroval/aux_io_helpers.py
+++ b/pyaerocom/aeroval/aux_io_helpers.py
@@ -2,6 +2,7 @@ import importlib
 import os
 import sys
 from collections.abc import Callable
+from typing import Self
 
 from pydantic import (
     BaseModel,
@@ -64,7 +65,7 @@ class _AuxReadSpec(BaseModel):
     funcs: dict[str, Callable]
 
     @model_validator(mode="after")
-    def validate_fun(self) -> None:
+    def validate_fun(self) -> Self:
         if callable(self.fun):
             return self
         elif isinstance(self.fun, str):

--- a/pyaerocom/aeroval/aux_io_helpers.py
+++ b/pyaerocom/aeroval/aux_io_helpers.py
@@ -2,7 +2,11 @@ import importlib
 import os
 import sys
 from collections.abc import Callable
-from typing import Self
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
 
 from pydantic import (
     BaseModel,

--- a/tests/aeroval/test_aux_io_helpers.py
+++ b/tests/aeroval/test_aux_io_helpers.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from textwrap import dedent
 
+from pydantic import ValidationError
 from pytest import mark, param, raises
 
 from pyaerocom.aeroval.aux_io_helpers import ReadAuxHandler, check_aux_info
@@ -52,20 +53,26 @@ def test_check_aux_info(fun, vars_required: list[str], funcs: dict):
 
 
 @mark.parametrize(
-    "fun,vars_required,funcs,error",
+    "fun,vars_required,funcs,error,",
     [
-        param(None, [], {}, "failed to retrieve aux func", id="no func"),
+        param(
+            None,
+            [],
+            {},
+            "2 validation errors for _AuxReadSpec",
+            id="no func",
+        ),
         param(
             None,
             [42],
             {},
-            "not all items are str type in input list [42]",
+            "3 validation errors for _AuxReadSpec",
             id="bad type vars_required",
         ),
     ],
 )
 def test_check_aux_info_error(fun, vars_required: list[str], funcs: dict, error: str):
-    with raises(ValueError) as e:
+    with raises(ValidationError) as e:
         check_aux_info(fun, vars_required, funcs)
 
-    assert str(e.value) == error
+    assert error in str(e.value)


### PR DESCRIPTION
## Change Summary

- Implement `_AuxReadSpec` in terms of pydantic
- Consequently, remove unused `Validator` child classes `StrWithDefault`, `FlexList`, `EitherOf`, `ListOfStrings`

## Related issue number

N/A 
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
