### PR TITLE
Allow any argument to pyaro filters

### DIFF
--- a/pyaerocom/io/pyaro/pyaro_config.py
+++ b/pyaerocom/io/pyaro/pyaro_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from importlib import resources
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, Any
 
 import yaml
 from pydantic import BaseModel, ConfigDict
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 # TODO Check a validator if extra/kwarg is serializable. Either in json_repr or as a @field_validator on extra
+
+FilterArgs = dict[str, Any]
 
 
 class PyaroConfig(BaseModel):
@@ -30,7 +32,7 @@ class PyaroConfig(BaseModel):
     name: str
     data_id: str
     filename_or_obj_or_url: str | list[str] | Path | list[Path]
-    filters: dict[str, dict[str, list[str]] | dict[str, list[tuple]]]
+    filters: dict[str, FilterArgs]
     name_map: dict[str, str] | None = None  # no Unit conversion option
 
     ##########################


### PR DESCRIPTION
## Change Summary

Filters should be allowed any input argument

## Related issues
Found when trying to use the `relaltitude` filter, which requires a `str` and `float`, neither of which are allowed by the type validator

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
