### PR TITLE
New minimaldata

### DIFF
--- a/pyaerocom/sample_data_access/minimal_dataset.py
+++ b/pyaerocom/sample_data_access/minimal_dataset.py
@@ -24,7 +24,7 @@ minimal_dataset = pooch.create(
         "testdata-minimal.tar.gz.20231019": "md5:f8912ee83d6749fb2a9b1eda1d664ca2",
         "testdata-minimal.tar.gz.20231116": "md5:5da747f6596817295ba7affe3402b722",
         "testdata-minimal.tar.gz.20240722": "md5:7d933901c6d273d012f132c60df086cc",
-        "testdata-minimal.tar.gz.20241120": "47d667457067c203aeb5bb7a62a3aefc",
+        "testdata-minimal.tar.gz.20241120": "md5:47d667457067c203aeb5bb7a62a3aefc",
     },
 )
 

--- a/pyaerocom/sample_data_access/minimal_dataset.py
+++ b/pyaerocom/sample_data_access/minimal_dataset.py
@@ -10,7 +10,7 @@ logger = logging.getLogger(__name__)
 __all__ = ["download_minimal_dataset"]
 
 #: tarfile to download
-DEFAULT_TESTDATA_FILE = "testdata-minimal.tar.gz.20240722"
+DEFAULT_TESTDATA_FILE = "testdata-minimal.tar.gz.20241120"
 
 minimal_dataset = pooch.create(
     path=const.OUTPUTDIR,  # ~/MyPyaerocom/

--- a/pyaerocom/sample_data_access/minimal_dataset.py
+++ b/pyaerocom/sample_data_access/minimal_dataset.py
@@ -24,6 +24,7 @@ minimal_dataset = pooch.create(
         "testdata-minimal.tar.gz.20231019": "md5:f8912ee83d6749fb2a9b1eda1d664ca2",
         "testdata-minimal.tar.gz.20231116": "md5:5da747f6596817295ba7affe3402b722",
         "testdata-minimal.tar.gz.20240722": "md5:7d933901c6d273d012f132c60df086cc",
+        "testdata-minimal.tar.gz.20241120": "47d667457067c203aeb5bb7a62a3aefc",
     },
 )
 

--- a/pyaerocom/sample_data_access/minimal_dataset.py
+++ b/pyaerocom/sample_data_access/minimal_dataset.py
@@ -24,7 +24,7 @@ minimal_dataset = pooch.create(
         "testdata-minimal.tar.gz.20231019": "md5:f8912ee83d6749fb2a9b1eda1d664ca2",
         "testdata-minimal.tar.gz.20231116": "md5:5da747f6596817295ba7affe3402b722",
         "testdata-minimal.tar.gz.20240722": "md5:7d933901c6d273d012f132c60df086cc",
-        "testdata-minimal.tar.gz.20241120": "md5:47d667457067c203aeb5bb7a62a3aefc",
+        "testdata-minimal.tar.gz.20241120": "md5:4d2bc1782b1f468321817139d327e014",
     },
 )
 


### PR DESCRIPTION
## Change Summary

Adds the hash for the new testdata minimal which includes a new EMEP file with data for 1999

## Related issue number

Related to https://github.com/metno/pyaerocom-tutorials/issues/19 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
