### PR TITLE
Obs name big fix

### DIFF
--- a/pyaerocom/aeroval/collections.py
+++ b/pyaerocom/aeroval/collections.py
@@ -165,7 +165,6 @@ class ObsCollection(BaseCollection):
         """
         try:
             entry = self._entries[key]
-            # entry.obs_name = self.get_web_interface_name(key)
             return entry
         except (KeyError, AttributeError):
             raise EntryNotAvailable(f"no such entry {key}")

--- a/pyaerocom/aeroval/collections.py
+++ b/pyaerocom/aeroval/collections.py
@@ -148,6 +148,7 @@ class ObsCollection(BaseCollection):
         if isinstance(entry, dict):
             entry = ObsEntry(**entry)
         self._entries[key] = entry
+        self._entries[key].obs_name = self.get_web_interface_name(key)
 
     def remove_entry(self, key: str):
         if key in self._entries:
@@ -164,7 +165,7 @@ class ObsCollection(BaseCollection):
         """
         try:
             entry = self._entries[key]
-            entry.obs_name = self.get_web_interface_name(key)
+            # entry.obs_name = self.get_web_interface_name(key)
             return entry
         except (KeyError, AttributeError):
             raise EntryNotAvailable(f"no such entry {key}")

--- a/pyaerocom/aeroval/obsentry.py
+++ b/pyaerocom/aeroval/obsentry.py
@@ -104,7 +104,7 @@ class ObsEntry(BaseModel):
     ######################
     ## Optional attributes
     ######################
-    obs_name: str | None = None
+    obs_name: str | None = None  # not expected to be set directly, rather set by ObsCollection
     obs_ts_type_read: str | dict | None = None
     obs_vert_type: Literal["Column", "Profile", "Surface", "ModelLevel"] = "Surface"
     obs_aux_requires: dict[str, dict] = {}

--- a/pyaerocom/aeroval/obsentry.py
+++ b/pyaerocom/aeroval/obsentry.py
@@ -104,6 +104,7 @@ class ObsEntry(BaseModel):
     ######################
     ## Optional attributes
     ######################
+    obs_name: str | None = None
     obs_ts_type_read: str | dict | None = None
     obs_vert_type: Literal["Column", "Profile", "Surface", "ModelLevel"] = "Surface"
     obs_aux_requires: dict[str, dict] = {}

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -308,6 +308,7 @@ def test_Experiment_Output_clean_json_files_CFG1_INVALIDOBS(eval_config: dict):
     cfg.obs_cfg.add_entry("obs1", cfg.obs_cfg.get_entry("AERONET-Sun"))
     proc = ExperimentProcessor(cfg)
     proc.run()
+    cfg.obs_cfg.remove_entry("obs1")
     modified = proc.exp_output.clean_json_files()
     assert len(modified) == 13
 

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -305,7 +305,7 @@ def test_Experiment_Output_clean_json_files_CFG1_INVALIDMOD(eval_config: dict):
 @pytest.mark.parametrize("cfg", ["cfgexp1"])
 def test_Experiment_Output_clean_json_files_CFG1_INVALIDOBS(eval_config: dict):
     cfg = EvalSetup(**eval_config)
-    cfg.obs_cfg.add_entry("obs1", cfg.obs_cfg.get_entry("AERONET-Sun"))
+    cfg.obs_cfg.add_entry("obs1", eval_config["obs_cfg"]["AERONET-Sun"])
     proc = ExperimentProcessor(cfg)
     proc.run()
     cfg.obs_cfg.remove_entry("obs1")


### PR DESCRIPTION
## Change Summary

place `obs_name` as attribute in `ObsEntry`. set in the `ObsCollection` setter, not the getter. Fix tests to not use the `ObsCollection` getter. unrealistic.

## Related issue number

N/A, see chat

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
