### PR TITLE
Rename pyaro related fields

### DIFF
--- a/pyaerocom/colocation/colocation_setup.py
+++ b/pyaerocom/colocation/colocation_setup.py
@@ -69,7 +69,7 @@ class ColocationSetup(BaseModel):
     model_id : str
         ID of model to be used.
 
-    obs_config: PyaroConfig
+    pyaro_config: PyaroConfig
         In the case Pyaro is used, a config must be provided. In that case obs_id(see below)
         is ignored and only the config is used.
     obs_id : str
@@ -335,7 +335,7 @@ class ColocationSetup(BaseModel):
         if isinstance(v, str):
             return pd.Timestamp(v)
 
-    obs_config: PyaroConfig | None = None
+    pyaro_config: PyaroConfig | None = None
 
     ###############################
     # Attributes with defaults
@@ -450,7 +450,7 @@ class ColocationSetup(BaseModel):
     def __init__(
         self,
         model_id: str | None = None,
-        obs_config: PyaroConfig | None = None,
+        pyaro_config: PyaroConfig | None = None,
         obs_id: str | None = None,
         obs_vars: tuple[str, ...] | None = (),
         ts_type: str = "monthly",
@@ -462,7 +462,7 @@ class ColocationSetup(BaseModel):
     ) -> None:
         super().__init__(
             model_id=model_id,
-            obs_config=obs_config,
+            pyaro_config=pyaro_config,
             obs_id=obs_id,
             obs_vars=obs_vars,
             ts_type=ts_type,
@@ -489,25 +489,25 @@ class ColocationSetup(BaseModel):
         return str(p)
 
     @model_validator(mode="after")
-    def validate_obs_config(self):
-        if self.obs_config is None:
+    def validate_pyaro_config(self):
+        if self.pyaro_config is None:
             return self
-        if self.obs_config.name != self.obs_id:
+        if self.pyaro_config.name != self.obs_id:
             logger.info(
-                f"Data ID in Pyaro config {self.obs_config.name} does not match obs_id {self.obs_id}. Setting Pyaro config to None!"
+                f"Data ID in Pyaro config {self.pyaro_config.name} does not match obs_id {self.obs_id}. Setting Pyaro config to None!"
             )
-            self.obs_config = None
-        if self.obs_config is not None:
-            if isinstance(self.obs_config, dict):
-                logger.info("Obs config was given as dict. Will try to convert to PyaroConfig")
-                self.obs_config = PyaroConfig(**self.obs_config)
-            if self.obs_config.name != self.obs_id:
+            self.pyaro_config = None
+        if self.pyaro_config is not None:
+            if isinstance(self.pyaro_config, dict):
+                logger.info("pyaro config was given as dict. Will try to convert to PyaroConfig")
+                self.pyaro_config = PyaroConfig(**self.pyaro_config)
+            if self.pyaro_config.name != self.obs_id:
                 logger.info(
-                    f"Data ID in Pyaro config {self.obs_config.name} does not match obs_id {self.obs_id}. Setting Obs ID to match Pyaro Config!"
+                    f"Data ID in Pyaro config {self.pyaro_config.name} does not match obs_id {self.obs_id}. Setting Obs ID to match Pyaro Config!"
                 )
-                self.obs_id = self.obs_config.name
+                self.obs_id = self.pyaro_config.name
             if self.obs_id is None:
-                self.obs_id = self.obs_config.name
+                self.obs_id = self.pyaro_config.name
         return self
 
     def add_glob_meta(self, **kwargs):

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -135,7 +135,7 @@ class Colocator:
         """
         bool: True if obs_id refers to an ungridded observation, else False
         """
-        if self.colocation_setup.obs_config is not None:
+        if self.colocation_setup.pyaro_config is not None:
             return True
 
         return True if self.colocation_setup.obs_id in get_all_supported_ids_ungridded() else False
@@ -196,7 +196,7 @@ class Colocator:
                     data_ids=[self.colocation_setup.obs_id],
                     data_dirs=self.colocation_setup.obs_data_dir,
                     configs=[
-                        self.colocation_setup.obs_config,
+                        self.colocation_setup.pyaro_config,
                     ],
                 )
             else:

--- a/pyaerocom/io/pyaro/pyaro_config.py
+++ b/pyaerocom/io/pyaro/pyaro_config.py
@@ -30,7 +30,7 @@ class PyaroConfig(BaseModel):
     ##########################
 
     name: str
-    data_id: str
+    reader_id: str
     filename_or_obj_or_url: str | list[str] | Path | list[Path]
     filters: dict[str, FilterArgs]
     name_map: dict[str, str] | None = None  # no Unit conversion option

--- a/pyaerocom/io/pyaro/read_pyaro.py
+++ b/pyaerocom/io/pyaro/read_pyaro.py
@@ -77,9 +77,9 @@ class ReadPyaro(ReadUngriddedBase):
 
     def _check_id(self):
         avail_readers = list_timeseries_engines()
-        if self.config.data_id not in avail_readers:
+        if self.config.reader_id not in avail_readers:
             logger.warning(
-                f"Could not find {self.config.data_id} in list of available Pyaro readers: {avail_readers}"
+                f"Could not find {self.config.reader_id} in list of available Pyaro readers: {avail_readers}"
             )
 
 
@@ -105,7 +105,7 @@ class PyaroToUngriddedData:
         self.reader: Reader = self._open_reader()
 
     def _open_reader(self) -> Reader:
-        data_id = self.config.data_id
+        reader_id = self.config.reader_id
         if self.config.model_extra is not None:
             kwargs = self.config.model_extra
         else:
@@ -113,7 +113,7 @@ class PyaroToUngriddedData:
 
         if self.config.name_map is None:
             return open_timeseries(
-                data_id,
+                reader_id,
                 self.config.filename_or_obj_or_url,
                 filters=self.config.filters,
                 **kwargs,
@@ -121,7 +121,7 @@ class PyaroToUngriddedData:
         else:
             return VariableNameChangingReader(
                 open_timeseries(
-                    data_id,
+                    reader_id,
                     self.config.filename_or_obj_or_url,
                     filters=self.config.filters,
                     **kwargs,
@@ -244,7 +244,7 @@ class PyaroToUngriddedData:
         for var in vars_to_retrieve:
             if var not in allowed_vars:
                 logger.warning(
-                    f"Variable {var} not in list over allowed variabes for {self.config.data_id}: {allowed_vars}"
+                    f"Variable {var} not in list over allowed variabes for {self.config.reader_id}: {allowed_vars}"
                 )
                 continue
 

--- a/pyaerocom/io/readungridded.py
+++ b/pyaerocom/io/readungridded.py
@@ -334,7 +334,7 @@ class ReadUngridded:
             reader = ReadPyaro(config=config)
             self._readers[name] = reader
             self._data_ids.append(name)
-            self.config_ids[name] = config.data_id
+            self.config_ids[name] = config.reader_id
             self.config_map[name] = config
             return reader
 

--- a/tests/colocation/test_colocator.py
+++ b/tests/colocation/test_colocator.py
@@ -452,7 +452,7 @@ def test_colocator_with_obs_data_dir_gridded(setup):
 
 def test_colocation_pyaro(pyaro_testconfig, fake_aod_MSCWCtm_data_monthly_2010, setup) -> None:
     config = pyaro_testconfig[0]
-    setup["obs_config"] = config
+    setup["pyaro_config"] = config
     setup["model_id"] = "EMEP"
     setup["gridded_reader_id"] = {"model": "ReadMscwCtm"}
     setup["model_data_dir"] = fake_aod_MSCWCtm_data_monthly_2010

--- a/tests/fixtures/pyaro.py
+++ b/tests/fixtures/pyaro.py
@@ -42,11 +42,11 @@ def make_csv_test_file(tmp_path: Path) -> Path:
 
 
 def testconfig(tmp_path: Path) -> PyaroConfig:
-    data_id = "csv_timeseries"
+    reader_id = "csv_timeseries"
 
     config1 = PyaroConfig(
         name="test",
-        data_id=data_id,
+        reader_id=reader_id,
         filename_or_obj_or_url=str(make_csv_test_file(tmp_path)),
         filters={},
         name_map={"SOx": "concso4", "AOD": "od550aer"},
@@ -54,7 +54,7 @@ def testconfig(tmp_path: Path) -> PyaroConfig:
 
     config2 = PyaroConfig(
         name="test2",
-        data_id=data_id,
+        reader_id=reader_id,
         filename_or_obj_or_url=str(make_csv_test_file(tmp_path)),
         filters={},
         name_map={"SOx": "concso4", "AOD": "od550aer"},
@@ -63,7 +63,7 @@ def testconfig(tmp_path: Path) -> PyaroConfig:
 
 
 def testconfig_kwargs(tmp_path: Path) -> PyaroConfig:
-    data_id = "csv_timeseries"
+    reader_id = "csv_timeseries"
     columns = {
         "variable": 0,
         "station": 1,
@@ -82,7 +82,7 @@ def testconfig_kwargs(tmp_path: Path) -> PyaroConfig:
 
     config = PyaroConfig(
         name="test",
-        data_id=data_id,
+        reader_id=reader_id,
         filename_or_obj_or_url=str(make_csv_test_file(tmp_path)),
         filters={},
         name_map={"SOx": "concso4"},

--- a/tests/io/pyaro/test_pyaro_config.py
+++ b/tests/io/pyaro/test_pyaro_config.py
@@ -10,7 +10,7 @@ from pyaerocom.io.pyaro.pyaro_config import PyaroConfig
 def get_test_config() -> PyaroConfig:
     config = PyaroConfig(
         name="test",
-        data_id="test",
+        reader_id="test",
         filename_or_obj_or_url="test",
         filters={},
         name_map={},
@@ -21,7 +21,7 @@ def get_test_config() -> PyaroConfig:
 def get_existing_config() -> PyaroConfig:
     config = PyaroConfig(
         name="aeronetsun_test",
-        data_id="test",
+        reader_id="test",
         filename_or_obj_or_url="test",
         filters={},
         name_map={},

--- a/tests/io/test_readungridded.py
+++ b/tests/io/test_readungridded.py
@@ -139,7 +139,7 @@ def test_supported_pyaro(pyaro_testconfig):
     reader = ReadUngridded(configs=pyaro_testconfig)
 
     assert ReadPyaro in reader.SUPPORTED_READERS
-    assert pyaro_testconfig[0].data_id in reader.supported_datasets
+    assert pyaro_testconfig[0].reader_id in reader.supported_datasets
 
 
 def test_read_pyaro_and_other(pyaro_testconfig):


### PR DESCRIPTION
## Change Summary

<!-- Please give a short summary of the changes. -->

It might be confusing having `obs_config` nested in `obs_cfg`, so I suggest we rename this inner field to the more descriptive `pyaro_config`.

`data_id` is also not very descriptive, `reader_id` might give a better idea that it is related to the entrypoint in `pyaro`?

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

Related to #1414 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
