### PR TITLE
Use keylist() to check if not models are provided 

### DIFF
--- a/pyaerocom/colocation/colocated_data.py
+++ b/pyaerocom/colocation/colocated_data.py
@@ -1653,10 +1653,22 @@ class ColocatedData(BaseModel):
                 "Filtering longitude over 180 deg edge is not yet possible in "
                 "3D ColocatedData..."
             )
+
         if not isinstance(lat_range, slice):
             lat_range = slice(lat_range[0], lat_range[1])
         if not isinstance(lon_range, slice):
             lon_range = slice(lon_range[0], lon_range[1])
+
+        buffer = 1e-5  # didn't work
+        lat_range = slice(
+            max((arr.latitude.min(), lat_range.start)) - buffer,
+            min((arr.latitude.max(), lat_range.stop)) + buffer,
+        )
+
+        lon_range = slice(
+            max((arr.longitude.min(), lon_range.start)) - buffer,
+            min((arr.longitude.max(), lon_range.stop)) + buffer,
+        )
 
         return arr.sel(dict(latitude=lat_range, longitude=lon_range))
 


### PR DESCRIPTION
## Change Summary

 in experiment_processor.py  change `if not self.cfg.model_cfg` to `if not self.cfg.model_cfg.keylist()`which should evaluate to false if empty

## Related issue number

N/A, chat with Daniel

## Checklist

* [ ] Start with a draft-PR
* [ ] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
