### PR TITLE
Obs-only: check model_list to see if empty instead

### DIFF
--- a/pyaerocom/aeroval/collections.py
+++ b/pyaerocom/aeroval/collections.py
@@ -277,3 +277,29 @@ class ModelCollection(BaseCollection):
             return self._entries[key]
         else:
             raise EntryNotAvailable(f"no such entry {key}")
+
+    def keylist(self, name_or_pattern: str = None) -> list[str]:
+        """Find model / obs names that match input search pattern(s)
+
+        Parameters
+        ----------
+        name_or_pattern : str, optional
+            Name or pattern specifying search string.
+
+        Returns
+        -------
+        list
+            list of keys in collection that match input requirements. If
+            `name_or_pattern` is None, all keys will be returned.
+
+        Raises
+        ------
+        KeyError
+            if no matches can be found
+        """
+        # Special case where the model cfg is empty, used for obs-only
+        if list(self._entries.keys()) == []:
+            return []
+
+        else:
+            return super().keylist(name_or_pattern)

--- a/pyaerocom/aeroval/collections.py
+++ b/pyaerocom/aeroval/collections.py
@@ -87,6 +87,10 @@ class BaseCollection(abc.ABC):
         KeyError
             if no matches can be found
         """
+        # Special case where the model cfg is empty, used for obs-only
+        if self._entries.keys() == []:
+            return []
+
         if name_or_pattern is None:
             name_or_pattern = "*"
 
@@ -94,6 +98,9 @@ class BaseCollection(abc.ABC):
         for key in self._entries.keys():
             if fnmatch(key, name_or_pattern) and key not in matches:
                 matches.append(key)
+
+        if len(matches) == 0:
+            raise KeyError(f"No matches could be found that match input {name_or_pattern}")
         return matches
 
     @property

--- a/pyaerocom/aeroval/collections.py
+++ b/pyaerocom/aeroval/collections.py
@@ -94,8 +94,6 @@ class BaseCollection(abc.ABC):
         for key in self._entries.keys():
             if fnmatch(key, name_or_pattern) and key not in matches:
                 matches.append(key)
-        if len(matches) == 0:
-            raise KeyError(f"No matches could be found that match input {name_or_pattern}")
         return matches
 
     @property

--- a/pyaerocom/aeroval/experiment_processor.py
+++ b/pyaerocom/aeroval/experiment_processor.py
@@ -132,7 +132,8 @@ class ExperimentProcessor(ProcessingEngine, HasColocator):
         self.cfg._check_time_config()
 
         obs_list = self.cfg.obs_cfg.keylist(obs_name)
-        if not self.cfg.model_cfg:
+        model_list = self.cfg.model_cfg.keylist(model_name)
+        if not model_list:
             logger.info("No model found, will make dummy model data")
             self.cfg.webdisp_opts.hide_charts = ["scatterplot"]
             self.cfg.webdisp_opts.pages = ["evaluation", "infos"]
@@ -142,8 +143,6 @@ class ExperimentProcessor(ProcessingEngine, HasColocator):
         else:
             model_id = None
             use_dummy_model = False
-
-        model_list = self.cfg.model_cfg.keylist(model_name)
 
         logger.info("Start processing")
 

--- a/pyaerocom/aeroval/experiment_processor.py
+++ b/pyaerocom/aeroval/experiment_processor.py
@@ -138,6 +138,7 @@ class ExperimentProcessor(ProcessingEngine, HasColocator):
             self.cfg.webdisp_opts.hide_charts = ["scatterplot"]
             self.cfg.webdisp_opts.pages = ["evaluation", "infos"]
             model_id = make_dummy_model(obs_list, self.cfg)
+            model_list.append("dummy")
             self.cfg.processing_opts.obs_only = True
             use_dummy_model = True
         else:

--- a/pyaerocom/aeroval/experiment_processor.py
+++ b/pyaerocom/aeroval/experiment_processor.py
@@ -138,7 +138,7 @@ class ExperimentProcessor(ProcessingEngine, HasColocator):
             self.cfg.webdisp_opts.hide_charts = ["scatterplot"]
             self.cfg.webdisp_opts.pages = ["evaluation", "infos"]
             model_id = make_dummy_model(obs_list, self.cfg)
-            model_list.append("dummy")
+            model_list.append("dummy")  # Adds the dummy model to model list after adding it to cfg
             self.cfg.processing_opts.obs_only = True
             use_dummy_model = True
         else:

--- a/pyaerocom/aeroval/helpers.py
+++ b/pyaerocom/aeroval/helpers.py
@@ -191,7 +191,7 @@ def make_dummy_model(obs_list: list, cfg) -> str:
                 dummy_grid_yr.to_netcdf(outdir, savename=save_name)
 
     # Add dummy model to cfg
-    cfg.model_cfg.add_entry("dummy", ModelEntry(model_id="dummy_model"))
+    cfg.model_cfg.add_entry("dummy", ModelEntry(model_id="dummy_model", model_data_dir=outdir))
 
     return model_id
 

--- a/pyaerocom/helpers.py
+++ b/pyaerocom/helpers.py
@@ -1738,7 +1738,7 @@ def make_dummy_cube(
         raise ValueError(f"{freq} not a recognized frequency")
 
     start_str = f"{start_yr}-01-01 00:00"
-    stop_str = f"{int(stop_yr)}-12-31 00:00"
+    stop_str = f"{int(stop_yr)}-12-31 23:00"
     times = pd.date_range(start_str, stop_str, freq=TS_TYPE_TO_PANDAS_FREQ[freq])
 
     time_since_start = (times - times[0]) / np.timedelta64(1, TS_TYPE_TO_NUMPY_FREQ[freq])

--- a/pyaerocom/helpers.py
+++ b/pyaerocom/helpers.py
@@ -1738,7 +1738,7 @@ def make_dummy_cube(
         raise ValueError(f"{freq} not a recognized frequency")
 
     start_str = f"{start_yr}-01-01 00:00"
-    stop_str = f"{int(stop_yr)+1}-01-01 00:00"
+    stop_str = f"{int(stop_yr)}-12-31 00:00"
     times = pd.date_range(start_str, stop_str, freq=TS_TYPE_TO_PANDAS_FREQ[freq])
 
     time_since_start = (times - times[0]) / np.timedelta64(1, TS_TYPE_TO_NUMPY_FREQ[freq])
@@ -1781,11 +1781,11 @@ def make_dummy_cube(
         standard_name="time",
         long_name="Time",
         units=time_unit,
-    )[:-1]
+    )
 
     latdim.guess_bounds()
     londim.guess_bounds()
-    dummy = iris.cube.Cube(np.ones((len(times) - 1, len(lats), len(lons))), units=unit)
+    dummy = iris.cube.Cube(np.ones((len(times), len(lats), len(lons))), units=unit)
 
     dummy.add_dim_coord(latdim, 1)
     dummy.add_dim_coord(londim, 2)

--- a/pyaerocom/helpers.py
+++ b/pyaerocom/helpers.py
@@ -35,6 +35,8 @@ from pyaerocom.time_config import (
     TS_TYPE_DATETIME_CONV,
     TS_TYPE_SECS,
     TS_TYPE_TO_PANDAS_FREQ,
+    TS_TYPE_TO_FREQ_NAME,
+    TS_TYPE_TO_NUMPY_FREQ,
     day_units,
     hr_units,
     microsec_units,
@@ -247,11 +249,19 @@ def make_dummy_cube_latlon(
 
     lon_circ = check_coord_circular(lons, modulus=360)
     latdim = iris.coords.DimCoord(
-        lats, var_name="lat", standard_name="latitude", circular=False, units=Unit("degrees")
+        lats,
+        var_name="lat",
+        standard_name="latitude",
+        circular=False,
+        units=Unit("degrees"),
     )
 
     londim = iris.coords.DimCoord(
-        lons, var_name="lon", standard_name="longitude", circular=lon_circ, units=Unit("degrees")
+        lons,
+        var_name="lon",
+        standard_name="longitude",
+        circular=lon_circ,
+        units=Unit("degrees"),
     )
 
     latdim.guess_bounds()
@@ -787,7 +797,13 @@ def _check_stats_merge(statlist, var_name, pref_attr, fill_missing_nan):
 
 
 def _merge_stats_2d(
-    stats, var_name, sort_by_largest, pref_attr, add_meta_keys, resample_how, min_num_obs
+    stats,
+    var_name,
+    sort_by_largest,
+    pref_attr,
+    add_meta_keys,
+    resample_how,
+    min_num_obs,
 ):
     if pref_attr is not None:
         stats.sort(key=lambda s: s[pref_attr])
@@ -929,7 +945,13 @@ def merge_station_data(
         merged = _merge_stats_3d(stats, var_name, add_meta_keys, has_errs)
     else:
         merged = _merge_stats_2d(
-            stats, var_name, sort_by_largest, pref_attr, add_meta_keys, resample_how, min_num_obs
+            stats,
+            var_name,
+            sort_by_largest,
+            pref_attr,
+            add_meta_keys,
+            resample_how,
+            min_num_obs,
         )
 
     if fill_missing_nan:
@@ -1704,18 +1726,22 @@ def get_max_period_range(periods):
 
 
 def make_dummy_cube(
-    var_name: str, start_yr: int = 2000, stop_yr: int = 2020, freq: str = "daily", dtype=float
+    var_name: str,
+    start_yr: int = 2000,
+    stop_yr: int = 2020,
+    freq: str = "daily",
+    dtype=float,
 ) -> iris.cube.Cube:
-    startstr = f"days since {start_yr}-01-01 00:00"
+    startstr = f"{TS_TYPE_TO_FREQ_NAME[freq]} since {start_yr}-01-01 00:00"
 
     if freq not in TS_TYPE_TO_PANDAS_FREQ.keys():
         raise ValueError(f"{freq} not a recognized frequency")
 
     start_str = f"{start_yr}-01-01 00:00"
-    stop_str = f"{stop_yr}-12-31 00:00"
+    stop_str = f"{int(stop_yr)+1}-01-01 00:00"
     times = pd.date_range(start_str, stop_str, freq=TS_TYPE_TO_PANDAS_FREQ[freq])
 
-    days_since_start = (times - times[0]).days
+    time_since_start = (times - times[0]) / np.timedelta64(1, TS_TYPE_TO_NUMPY_FREQ[freq])
     unit = get_variable(var_name).units
 
     lat_range = (-90, 90)
@@ -1750,12 +1776,16 @@ def make_dummy_cube(
     )
 
     timedim = iris.coords.DimCoord(
-        days_since_start, var_name="time", standard_name="time", long_name="Time", units=time_unit
-    )
+        time_since_start,
+        var_name="time",
+        standard_name="time",
+        long_name="Time",
+        units=time_unit,
+    )[:-1]
 
     latdim.guess_bounds()
     londim.guess_bounds()
-    dummy = iris.cube.Cube(np.ones((len(times), len(lats), len(lons))), units=unit)
+    dummy = iris.cube.Cube(np.ones((len(times) - 1, len(lats), len(lons))), units=unit)
 
     dummy.add_dim_coord(latdim, 1)
     dummy.add_dim_coord(londim, 2)

--- a/pyaerocom/time_config.py
+++ b/pyaerocom/time_config.py
@@ -7,7 +7,16 @@ from datetime import datetime
 import pandas as pd
 from iris import coord_categorisation
 
-TS_TYPES = ["minutely", "hourly", "daily", "weekly", "monthly", "yearly", "native", "coarsest"]
+TS_TYPES = [
+    "minutely",
+    "hourly",
+    "daily",
+    "weekly",
+    "monthly",
+    "yearly",
+    "native",
+    "coarsest",
+]
 
 # The following import was removed and the information about available unit
 # strings was copied from the netCDF4 module directly here
@@ -46,6 +55,16 @@ PANDAS_RESAMPLE_OFFSETS = {
     "MS": pd.Timedelta(14, "d"),
     "D": pd.Timedelta(12, "h"),
     "h": pd.Timedelta(30, "m"),
+}
+
+TS_TYPE_TO_FREQ_NAME = {
+    "minutely": "minutes",
+    "hourly": "hours",
+    "daily": "days",
+    "weekly": "weeks",
+    "monthly": "months",  # Month start !
+    "season": "seasons",
+    "yearly": "years",
 }
 
 PANDAS_FREQ_TO_TS_TYPE = {v: k for k, v in TS_TYPE_TO_PANDAS_FREQ.items()}


### PR DESCRIPTION
## Change Summary

Change `if not self.cfg.model_cfg` in experiment_processor.py to instead look at `model_list`, which should evaluate to False if empty. Note `model_list` is created for every `model_name`, but will always be empty if no models are provided.

## Related issue number

N/A, chat with @dulte 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
