### PR TITLE
only_model_maps=True & pixel maps fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,5 +24,5 @@ pyaerocom
 .. |Coverage| image:: https://codecov.io/gh/metno/pyaerocom/branch/main-dev/graph/badge.svg?token=A0AdX8YciZ
     :target: https://codecov.io/gh/metno/pyaerocom
 
-.. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.14100736.svg
-  :target: https://doi.org/10.5281/zenodo.14100736
+.. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.10374180.svg
+  :target: https://doi.org/10.5281/zenodo.10374180

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -338,7 +338,8 @@ class ExperimentOutput(ProjectOutput):
 
         return MapInfo(obs_network, obs_var, vert_code, mod_id, mod_var, time_period)
 
-    def _info_from_contour_dir_file(self, file: pathlib.PosixPath):
+    @staticmethod
+    def _info_from_contour_dir_file(file: pathlib.PosixPath):
         """
         Separate map filename into meta info on obs and model content
 
@@ -366,9 +367,9 @@ class ExperimentOutput(ProjectOutput):
 
         if len(spl) != 3:
             raise ValueError(
-                f"invalid map filename: {file}. Must "
+                f"invalid contour filename: {file}. Must "
                 f"contain exactly 2 underscores _ to separate "
-                f"obsinfo, vertical, model info, and periods"
+                f"name, vertical, and periods"
             )
         name = spl[0]
         var_name = spl[1]

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -162,7 +162,7 @@ class ExperimentOutput(ProjectOutput):
             return False
         elif (
             not len(self._get_json_output_files("map")) > 0
-            and not self.cfg.processing_opts.only_model_maps  # LB: Come back to this
+            and not self.cfg.processing_opts.only_model_maps
         ):
             return False
         return True

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -868,8 +868,8 @@ class ExperimentOutput(ProjectOutput):
                 obs_var, mod_var = var_name, var_name
 
                 if mod_name in self.cfg.obs_cfg.keylist():
-                    vert_code = self.cfg.obs_cfg.get_entry(mod_name).obs_vert_type
                     obs_name = mod_name
+                    vert_code = self.cfg.obs_cfg.get_entry(obs_name).obs_vert_type
                     first_with_obs_name = next(
                         (
                             item

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -237,6 +237,16 @@ class ExperimentOutput(ProjectOutput):
         with self.avdb.lock():
             menu = self.avdb.get_menu(self.proj_id, self.exp_id, default={})
             all_regions = self.avdb.get_regions(self.proj_id, self.exp_id, default={})
+            if not all_regions and self.cfg.processing_opts.only_model_maps:
+                all_regions = {
+                    "ALL": {
+                        "minLat": self.cfg.modelmaps_opts.boundaries.south,
+                        "maxLat": self.cfg.modelmaps_opts.boundaries.north,
+                        "minLon": self.cfg.modelmaps_opts.boundaries.west,
+                        "maxLon": self.cfg.modelmaps_opts.boundaries.east,
+                    }
+                }
+                self.avdb.put_regions(all_regions, self.proj_id, self.exp_id)
             for uri in self.avdb.list_glob_stats(
                 self.proj_id, self.exp_id, access_type=aerovaldb.AccessType.URI
             ):

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -890,6 +890,7 @@ class ExperimentOutput(ProjectOutput):
                 (obs_name, obs_var, vert_code, mod_name, mod_var, per) = self._info_from_map_file(
                     file
                 )
+
             if self._is_part_of_experiment(obs_name, obs_var, mod_name, mod_var):
                 mcfg = self.cfg.model_cfg.get_entry(mod_name)
                 var = mcfg.get_varname_web(mod_var, obs_var)

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -358,7 +358,7 @@ class ExperimentOutput(ProjectOutput):
             raise ValueError(
                 f"invalid map filename: {file}. Must "
                 f"contain exactly 2 underscores _ to separate "
-                f"obsinfo, vertical, model info, and periods"  # LB: this needs to be checked
+                f"obsinfo, vertical, model info, and periods"
             )
         name = spl[0]
         var_name = spl[1]

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -156,7 +156,14 @@ class ExperimentOutput(ProjectOutput):
         """
         if self.exp_id not in os.listdir(self.proj_dir):
             return False
-        elif not len(self._get_json_output_files("map")) > 0:
+        elif self.cfg.processing_opts.only_model_maps and not self._has_files(
+            self.out_dirs_json["contour"]
+        ):
+            return False
+        elif (
+            not len(self._get_json_output_files("map")) > 0
+            and not self.cfg.processing_opts.only_model_maps  # LB: Come back to this
+        ):
             return False
         return True
 
@@ -532,6 +539,13 @@ class ExperimentOutput(ProjectOutput):
     def _get_json_output_files(self, dirname) -> list[str]:
         dirloc = self.out_dirs_json[dirname]
         return glob.glob(f"{dirloc}/*.json")
+
+    def _has_files(self, directory: str):
+        """
+        Checks if a directory contains any files.
+        The contour directory may contains files, but these are not json files (geojson, webp, png)
+        """
+        return any(p.is_file() for p in pathlib.Path(directory).rglob("*"))
 
     def _get_cmap_info(self, var) -> dict[str, str | list[float]]:
         var_ranges_defaults = self.cfg.var_scale_colmap

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -856,11 +856,11 @@ class ExperimentOutput(ProjectOutput):
         for file in files:
             if self.cfg.processing_opts.only_model_maps:
                 # Hack to build menu.json
-                # Key issue we need to get around is that the ExperimentOutput class
-                # expects that at this point in the processing, all information it needs
-                # to describe an experiment has been written to disc, traditionally in the map directory
-                # if only_model_maps = True, then we do not do colocation, and so the maps dir is empty,
-                # however menu.json is still needed
+                # The key issue we need to get around is that the ExperimentOutput class
+                # expects that at this point of the processing, all information it needs
+                # to describe an experiment has been written to disc, traditionally in the map directory.
+                # If only_model_maps = True, then we do not do colocation, and so the map dir is empty,
+                # however menu.json is still needed.
                 if not all_combinations:
                     break
 
@@ -890,7 +890,7 @@ class ExperimentOutput(ProjectOutput):
                             vert_code = self.cfg.obs_cfg.get_entry(o).obs_vert_type
                     if not vert_code:
                         raise ValueError(
-                            "Failed to infer vert_code in a only_model_maps experiment"
+                            "Failed to infer vert_code in an only_model_maps experiment"
                         )
                     first_with_mod_name = next(
                         (
@@ -905,7 +905,7 @@ class ExperimentOutput(ProjectOutput):
                     obs_name = first_with_mod_name[0]
                     all_combinations.remove(first_with_mod_name)
                 else:
-                    raise ValueError("Failed to infer vert_code in a only_model_maps experiment")
+                    raise ValueError("Failed to infer vert_code in an only_model_maps experiment")
 
             else:
                 (obs_name, obs_var, vert_code, mod_name, mod_var, per) = self._info_from_map_file(

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -70,7 +70,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         return all_vars
 
     def _get_obs_vars_to_process(self, obs_name, var_list):
-        ovars = self.cfg.obs_cfg.get(obs_name).get_all_vars()
+        ovars = self.cfg.obs_cfg.get_entry(obs_name).get_all_vars()
         all_vars = sorted(list(set(ovars)))
         if var_list is not None:
             all_vars = [var for var in var_list if var in all_vars]

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -58,6 +58,10 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                 logger.warning(f"no data for model {model}, skipping")
                 continue
             all_files.extend(files)
+
+        self.cfg.modelmaps_opts.maps_freq = (
+            self._get_maps_freq()
+        )  # reassign "coarsest" to actual coarsest frequency
         return files
 
     def _get_vars_to_process(self, model_name, var_list):
@@ -307,16 +311,12 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         if maps_freq == "coarsest":  # TODO: Implement this in terms of a TsType object. #1267
             freq = min(TsType(fq) for fq in self.cfg.time_cfg.freqs)
             freq = min(freq, self.cfg.time_cfg.main_freq)
-            self.cfg.modelmaps_opts.maps_freq = str(
-                freq
-            )  # reassign "coarsest" to actual coarsest frequency
-        else:
             freq = maps_freq
         return freq
 
     def _get_read_model_freq(self, model_ts_types: list) -> TsType:
         """
-        Tries to find the best TS type to read. Checks for available ts types with the following priority
+        Tries to find the best TsType to read. Checks for available ts types with the following priority
 
         1. If the freq from _get_maps_freq is available
         2. If maps_freq is explicitly given, and is available

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -294,7 +294,6 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                 format=self.cfg.modelmaps_opts.overlay_save_format,
             )
 
-            # TODO: https://github.com/metno/aerovaldb/issues/96
             with self.avdb.lock():
                 self.avdb.put_map_overlay(
                     overlay_plot,

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -307,6 +307,9 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         if maps_freq == "coarsest":  # TODO: Implement this in terms of a TsType object. #1267
             freq = min(TsType(fq) for fq in self.cfg.time_cfg.freqs)
             freq = min(freq, self.cfg.time_cfg.main_freq)
+            self.cfg.modelmaps_opts.maps_freq = str(
+                freq
+            )  # reassign "coarsest" to actual coarsest frequency
         else:
             freq = maps_freq
         return freq

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -460,10 +460,6 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                     self.cfg.obs_cfg.get_entry(name).obs_vert_type,
                     default={},
                 )
-                # loop thourgh the models
-                # check to see if contained in timeseries
-                # if not, add it with dates and dummy_data
-                # otherwise skip
                 for model_name in self.cfg.model_cfg.keylist():
                     if model_name in timeseries:
                         continue
@@ -483,12 +479,6 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                     self.cfg.obs_cfg.get_entry(name).obs_vert_type,
                 )
         if name in self.cfg.model_cfg.keylist():
-            # loop over obs networks
-            # get corresponding time series
-            # check if name is contained within this time series
-            # if not, add dummy dates and and maybe modelv alues (or NaNs)
-            # write updated timeseries to disc
-            # if name is already in timeseries, skip
             with self.avdb.lock():
                 for obs_name in self.cfg.obs_cfg.keylist():
                     timeseries = self.avdb.get_timeseries(

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -61,7 +61,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
 
         self.cfg.modelmaps_opts.maps_freq = (
             self._get_maps_freq()
-        )  # reassign "coarsest" to actual coarsest frequency
+        )  # if needed, reassign "coarsest" to actual coarsest frequency
         return files
 
     def _get_vars_to_process(self, model_name, var_list):
@@ -286,6 +286,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                 format=self.cfg.modelmaps_opts.overlay_save_format,
             )
 
+            # TODO: https://github.com/metno/aerovaldb/issues/96
             with self.avdb.lock():
                 self.avdb.put_map_overlay(
                     overlay_plot,

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -311,7 +311,6 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         if maps_freq == "coarsest":  # TODO: Implement this in terms of a TsType object. #1267
             freq = min(TsType(fq) for fq in self.cfg.time_cfg.freqs)
             freq = min(freq, self.cfg.time_cfg.main_freq)
-            freq = maps_freq
         else:
             freq = maps_freq
         return freq

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -312,6 +312,8 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
             freq = min(TsType(fq) for fq in self.cfg.time_cfg.freqs)
             freq = min(freq, self.cfg.time_cfg.main_freq)
             freq = maps_freq
+        else:
+            freq = maps_freq
         return freq
 
     def _get_read_model_freq(self, model_ts_types: list) -> TsType:

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -116,12 +116,13 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                     _files = self._process_contour_map_var(
                         model_name, var, self.reanalyse_existing
                     )
-                    files.extend(_files)
+                    files.append(_files)
                 if self.cfg.modelmaps_opts.plot_types == {OVERLAY} or make_overlay:
                     # create overlay (pixel) plots
                     _files = self._process_overlay_map_var(
                         model_name, var, self.reanalyse_existing
                     )
+                    files.extend(_files)
 
             except ModelVarNotAvailable as ex:
                 logger.warning(f"{ex}")
@@ -262,6 +263,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
 
         tst = _jsdate_list(data)
         data = data.to_xarray()
+        files = []
         for i, date in enumerate(tst):
             outname = f"{model_name}_{var}_{date}"
 
@@ -289,6 +291,8 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                     var,
                     date,
                 )
+            files.append(fp_overlay + "." + self.cfg.modelmaps_opts.overlay_save_format)
+        return files
 
     def _get_maps_freq(self) -> TsType:
         """

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -447,7 +447,9 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
 
         return data
 
-    def _check_ts_for_only_model_maps(self, name: str, var: str, dates: list[int]):
+    def _check_ts_for_only_model_maps(
+        self, name: str, var: str, dates: list[int]
+    ):  # pragma: no cover
         maps_freq = str(self._get_maps_freq())
         if name in self.cfg.obs_cfg.keylist():
             with self.avdb.lock():

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -110,11 +110,12 @@ def plot_overlay_pixel_maps(
 ):  # pragma: no cover
     plt.close("all")
     matplotlib.use("Agg")
+    proj = ccrs.epsg(3857)
 
     fig, axis = plt.subplots(
         1,
         1,
-        subplot_kw=dict(projection=ccrs.Mercator()),
+        subplot_kw=dict(projection=proj),
         figsize=(8, 8),
     )
 
@@ -127,6 +128,7 @@ def plot_overlay_pixel_maps(
         vmax=cmap_bins[-1],
         cmap=cmap,
     )
+
     with io.BytesIO() as buffer:  # use buffer memory
         plt.savefig(
             buffer,

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -127,13 +127,13 @@ def plot_overlay_pixel_maps(
         vmax=cmap_bins[-1],
         cmap=cmap,
     )
-
     with io.BytesIO() as buffer:  # use buffer memory
         plt.savefig(
             buffer,
             bbox_inches="tight",
             transparent=True,
             format=format,
+            pad_inches=0,
         )
         buffer.seek(0)
         image = buffer.getvalue()

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -126,7 +126,6 @@ class OutputPaths(BaseModel):
 
 class ModelMapsSetup(BaseModel):
     maps_freq: Literal["hourly", "daily", "monthly", "yearly", "coarsest"] = "coarsest"
-    maps_res_deg: PositiveInt = 5
     plot_types: dict[str, str | set[str]] | set[str] = {CONTOUR}
     boundaries: BoundingBox | None = None
     map_observations_only_in_right_menu: bool = False

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -127,7 +127,7 @@ class OutputPaths(BaseModel):
 class ModelMapsSetup(BaseModel):
     maps_freq: Literal["hourly", "daily", "monthly", "yearly", "coarsest"] = "coarsest"
     maps_res_deg: PositiveInt = 5
-    plot_types: dict[str, str | set[str, str]] | set[str] = {CONTOUR}
+    plot_types: dict[str, str | set[str, ...]] | set[str] = {CONTOUR}
     boundaries: BoundingBox | None = None
     map_observations_only_in_right_menu: bool = False
     overlay_save_format: Literal["webp", "png"] = "webp"

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -127,7 +127,7 @@ class OutputPaths(BaseModel):
 class ModelMapsSetup(BaseModel):
     maps_freq: Literal["hourly", "daily", "monthly", "yearly", "coarsest"] = "coarsest"
     maps_res_deg: PositiveInt = 5
-    plot_types: dict[str, str | set[str, ...]] | set[str] = {CONTOUR}
+    plot_types: dict[str, str | set[str]] | set[str] = {CONTOUR}
     boundaries: BoundingBox | None = None
     map_observations_only_in_right_menu: bool = False
     overlay_save_format: Literal["webp", "png"] = "webp"

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -80,6 +80,7 @@ class OutputPaths(BaseModel):
         "hm/ts",
         "contour",
         "profiles",
+        "contour/overlay",
     ]
     avdb_resource: Path | str | None = None
 
@@ -126,7 +127,7 @@ class OutputPaths(BaseModel):
 class ModelMapsSetup(BaseModel):
     maps_freq: Literal["hourly", "daily", "monthly", "yearly", "coarsest"] = "coarsest"
     maps_res_deg: PositiveInt = 5
-    plot_types: dict[str, str | tuple[str, str]] | set[str] = {CONTOUR}
+    plot_types: dict[str, str | set[str, str]] | set[str] = {CONTOUR}
     boundaries: BoundingBox | None = None
     map_observations_only_in_right_menu: bool = False
     overlay_save_format: Literal["webp", "png"] = "webp"
@@ -136,12 +137,10 @@ class ModelMapsSetup(BaseModel):
         if isinstance(v, dict):
             for m in v:
                 if not isinstance(v[m], set):
-                    if isinstance(v[m], str):
-                        v[m] = set([v[m]])
-                    else:
-                        v[m] = set([*v[m]])
+                    v[m] = set([v[m]])  # v[m] must be a string
                 if v[m] not in PLOT_TYPE_OPTIONS:
                     raise ConfigError("Model maps set up given a non-valid plot type.")
+            return v
         if isinstance(v, str):
             v = set([v])
         if isinstance(v, list):  # can occur when reading a serialized config

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -23,6 +23,7 @@ from pydantic import (
     ConfigDict,
     Field,
     PositiveInt,
+    NonNegativeInt,
     computed_field,
     field_serializer,
     field_validator,
@@ -224,7 +225,7 @@ class StatisticsSetup(BaseModel, extra="allow"):
     avg_over_trends: bool = (
         False  # Adds calculation of avg over trends of time series of stations in region
     )
-    obs_min_yrs: PositiveInt = 0  # Removes stations with less than this number of years of valid data (a year with data points in all four seasons) Should in most cases be the same as stats_min_yrs
+    obs_min_yrs: NonNegativeInt = 0  # Removes stations with less than this number of years of valid data (a year with data points in all four seasons) Should in most cases be the same as stats_min_yrs
     stats_min_yrs: PositiveInt = obs_min_yrs  # Calculates trends if number of valid years are equal or more than this. Should in most cases be the same as obs_min_yrs
     sequential_yrs: bool = False  # Whether or not the min_yrs should be sequential
 

--- a/pyaerocom/colocation/colocation_setup.py
+++ b/pyaerocom/colocation/colocation_setup.py
@@ -69,7 +69,7 @@ class ColocationSetup(BaseModel):
     model_id : str
         ID of model to be used.
 
-    obs_config: PyaroConfig
+    pyaro_config: PyaroConfig
         In the case Pyaro is used, a config must be provided. In that case obs_id(see below)
         is ignored and only the config is used.
     obs_id : str
@@ -335,7 +335,7 @@ class ColocationSetup(BaseModel):
         if isinstance(v, str):
             return pd.Timestamp(v)
 
-    obs_config: PyaroConfig | None = None
+    pyaro_config: PyaroConfig | None = None
 
     ###############################
     # Attributes with defaults
@@ -450,7 +450,7 @@ class ColocationSetup(BaseModel):
     def __init__(
         self,
         model_id: str | None = None,
-        obs_config: PyaroConfig | None = None,
+        pyaro_config: PyaroConfig | None = None,
         obs_id: str | None = None,
         obs_vars: tuple[str, ...] | None = (),
         ts_type: str = "monthly",
@@ -462,7 +462,7 @@ class ColocationSetup(BaseModel):
     ) -> None:
         super().__init__(
             model_id=model_id,
-            obs_config=obs_config,
+            pyaro_config=pyaro_config,
             obs_id=obs_id,
             obs_vars=obs_vars,
             ts_type=ts_type,
@@ -489,25 +489,25 @@ class ColocationSetup(BaseModel):
         return str(p)
 
     @model_validator(mode="after")
-    def validate_obs_config(self):
-        if self.obs_config is None:
+    def validate_pyaro_config(self):
+        if self.pyaro_config is None:
             return self
-        if self.obs_config.name != self.obs_id:
+        if self.pyaro_config.name != self.obs_id:
             logger.info(
-                f"Data ID in Pyaro config {self.obs_config.name} does not match obs_id {self.obs_id}. Setting Pyaro config to None!"
+                f"Data ID in Pyaro config {self.pyaro_config.name} does not match obs_id {self.obs_id}. Setting Pyaro config to None!"
             )
-            self.obs_config = None
-        if self.obs_config is not None:
-            if isinstance(self.obs_config, dict):
-                logger.info("Obs config was given as dict. Will try to convert to PyaroConfig")
-                self.obs_config = PyaroConfig(**self.obs_config)
-            if self.obs_config.name != self.obs_id:
+            self.pyaro_config = None
+        if self.pyaro_config is not None:
+            if isinstance(self.pyaro_config, dict):
+                logger.info("pyaro config was given as dict. Will try to convert to PyaroConfig")
+                self.pyaro_config = PyaroConfig(**self.pyaro_config)
+            if self.pyaro_config.name != self.obs_id:
                 logger.info(
-                    f"Data ID in Pyaro config {self.obs_config.name} does not match obs_id {self.obs_id}. Setting Obs ID to match Pyaro Config!"
+                    f"Data ID in Pyaro config {self.pyaro_config.name} does not match obs_id {self.obs_id}. Setting Obs ID to match Pyaro Config!"
                 )
-                self.obs_id = self.obs_config.name
+                self.obs_id = self.pyaro_config.name
             if self.obs_id is None:
-                self.obs_id = self.obs_config.name
+                self.obs_id = self.pyaro_config.name
         return self
 
     def add_glob_meta(self, **kwargs):

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -135,7 +135,7 @@ class Colocator:
         """
         bool: True if obs_id refers to an ungridded observation, else False
         """
-        if self.colocation_setup.obs_config is not None:
+        if self.colocation_setup.pyaro_config is not None:
             return True
 
         return True if self.colocation_setup.obs_id in get_all_supported_ids_ungridded() else False
@@ -196,7 +196,7 @@ class Colocator:
                     data_ids=[self.colocation_setup.obs_id],
                     data_dirs=self.colocation_setup.obs_data_dir,
                     configs=[
-                        self.colocation_setup.obs_config,
+                        self.colocation_setup.pyaro_config,
                     ],
                 )
             else:

--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -32,7 +32,7 @@ AEROCOM_NAMES = dict(
 )
 
 FULL_NAMES = dict(
-    co_conc="mass_concentration_of_carbon_monoxide_in_air",
+    co_conc="Carbon Monoxide",
     no2_conc="Nitrogen Dioxide",
     o3_conc="Ozone",
     pm10_conc="PM10 Aerosol",
@@ -41,7 +41,7 @@ FULL_NAMES = dict(
 )
 
 STANDARD_NAMES = dict(
-    co_conc="Carbon Monoxide",
+    co_conc="mass_concentration_of_carbon_monoxide_in_air",
     no2_conc="mass_concentration_of_nitrogen_dioxide_in_air",
     o3_conc="mass_concentration_of_ozone_in_air",
     pm10_conc="mass_concentration_of_pm10_ambient_aerosol_in_air",

--- a/pyaerocom/io/pyaro/pyaro_config.py
+++ b/pyaerocom/io/pyaro/pyaro_config.py
@@ -30,7 +30,7 @@ class PyaroConfig(BaseModel):
     ##########################
 
     name: str
-    data_id: str
+    reader_id: str
     filename_or_obj_or_url: str | list[str] | Path | list[Path]
     filters: dict[str, FilterArgs]
     name_map: dict[str, str] | None = None  # no Unit conversion option

--- a/pyaerocom/io/pyaro/read_pyaro.py
+++ b/pyaerocom/io/pyaro/read_pyaro.py
@@ -88,7 +88,7 @@ def _calculate_ts_type(
 ) -> npt.NDArray[TsType]:
     seconds = (end - start).astype("timedelta64[s]").astype(np.int32)
 
-    @np.vectorize
+    @np.vectorize(otypes=[TsType])
     @functools.lru_cache(maxsize=128)
     def memoized_ts_type(x: np.int32) -> TsType:
         if x == 0:

--- a/pyaerocom/io/pyaro/read_pyaro.py
+++ b/pyaerocom/io/pyaro/read_pyaro.py
@@ -77,9 +77,9 @@ class ReadPyaro(ReadUngriddedBase):
 
     def _check_id(self):
         avail_readers = list_timeseries_engines()
-        if self.config.data_id not in avail_readers:
+        if self.config.reader_id not in avail_readers:
             logger.warning(
-                f"Could not find {self.config.data_id} in list of available Pyaro readers: {avail_readers}"
+                f"Could not find {self.config.reader_id} in list of available Pyaro readers: {avail_readers}"
             )
 
 
@@ -105,7 +105,7 @@ class PyaroToUngriddedData:
         self.reader: Reader = self._open_reader()
 
     def _open_reader(self) -> Reader:
-        data_id = self.config.data_id
+        reader_id = self.config.reader_id
         if self.config.model_extra is not None:
             kwargs = self.config.model_extra
         else:
@@ -113,7 +113,7 @@ class PyaroToUngriddedData:
 
         if self.config.name_map is None:
             return open_timeseries(
-                data_id,
+                reader_id,
                 self.config.filename_or_obj_or_url,
                 filters=self.config.filters,
                 **kwargs,
@@ -121,7 +121,7 @@ class PyaroToUngriddedData:
         else:
             return VariableNameChangingReader(
                 open_timeseries(
-                    data_id,
+                    reader_id,
                     self.config.filename_or_obj_or_url,
                     filters=self.config.filters,
                     **kwargs,
@@ -244,7 +244,7 @@ class PyaroToUngriddedData:
         for var in vars_to_retrieve:
             if var not in allowed_vars:
                 logger.warning(
-                    f"Variable {var} not in list over allowed variabes for {self.config.data_id}: {allowed_vars}"
+                    f"Variable {var} not in list over allowed variabes for {self.config.reader_id}: {allowed_vars}"
                 )
                 continue
 

--- a/pyaerocom/io/readungridded.py
+++ b/pyaerocom/io/readungridded.py
@@ -334,7 +334,7 @@ class ReadUngridded:
             reader = ReadPyaro(config=config)
             self._readers[name] = reader
             self._data_ids.append(name)
-            self.config_ids[name] = config.data_id
+            self.config_ids[name] = config.reader_id
             self.config_map[name] = config
             return reader
 

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -9,7 +9,7 @@ dependencies:
   - matplotlib-base >=3.7.1
   - scipy >=1.10.1
   - pandas >=1.5.3
-  - numpy >=1.24.4, <2.0.0
+  - numpy >=1.25.0, <2.0.0
   - seaborn >=0.12.2
   - dask
   - geonum ==1.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "matplotlib>=3.7.1",
     "scipy>=1.10.1",
     "pandas>=1.5.3",
-    "numpy>=1.24.4",
+    "numpy>=1.25.0",
     "seaborn>=0.12.2",
     "dask",
     "geonum==1.5.0",
@@ -219,7 +219,7 @@ deps =
     cartopy ==0.21.1; python_version < "3.11"
     matplotlib ==3.7.1; python_version < "3.11"
     scipy ==1.10.1; python_version < "3.11"
-    numpy ==1.24.4; python_version < "3.11"
+    numpy ==1.25.0; python_version < "3.11"
     seaborn ==0.12.2; python_version < "3.11"
     geonum ==1.5.0; python_version < "3.11"
     typer ==0.7.0; python_version < "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "pyaerocom"
-version = "0.25.0"
+version = "0.26.0.dev0"
 authors = [{ name = "MET Norway" }]
 description = "pyaerocom model evaluation software"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "pyaerocom"
-version = "0.25.0.dev0"
+version = "0.25.0"
 authors = [{ name = "MET Norway" }]
 description = "pyaerocom model evaluation software"
 classifiers = [
@@ -111,7 +111,7 @@ filterwarnings = [
     # Ignore self-deprecation warnings related to plotting
     'ignore:matplotlib based plotting is no longer directly supported. This (function|class) may be removed in future versions\.:DeprecationWarning:(pyaerocom|tests):',
     # and not on this list
-    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:",  # Issue #1394
+    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:", # Issue #1394
 ]
 
 [tool.coverage.run]

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -11,6 +11,7 @@ from pyaerocom.aeroval.experiment_output import ExperimentOutput, ProjectOutput
 from pyaerocom.aeroval.json_utils import read_json, write_json
 from pyaerocom.aeroval import EvalSetup
 from tests.conftest import geojson_unavail
+import pathlib
 
 BASEDIR_DEFAULT = Path(const.OUTPUTDIR) / "aeroval" / "data"
 
@@ -195,6 +196,20 @@ def test_ExperimentOutput__info_from_map_file_error(filename: str):
         f"invalid map filename: {filename}. "
         "Must contain exactly 3 underscores _ to separate obsinfo, vertical, model info, and periods"
     )
+
+
+def test_ExperimentOutput__info_from_contour_dir_file():
+    file = pathlib.PosixPath("path/to/name_vertical_period.txt")
+    output = ExperimentOutput._info_from_contour_dir_file(file)
+
+    assert output == ("name", "vertical", "period")
+
+
+def test_ExperimentOutput__info_from_contour_dir_file_error():
+    file = pathlib.PosixPath("path/to/obs_vertical_model_period.txt")
+    with pytest.raises(ValueError) as e:
+        ExperimentOutput._info_from_contour_dir_file(file)
+    assert "invalid contour filename" in str(e.value)
 
 
 def test_ExperimentOutput__results_summary_EMPTY(dummy_expout: ExperimentOutput):

--- a/tests/aeroval/test_setup_classes.py
+++ b/tests/aeroval/test_setup_classes.py
@@ -126,19 +126,17 @@ def test_EvalSetup__check_time_config(
     "update",
     (
         pytest.param(None, id="defaults"),
-        pytest.param(dict(maps_freq="yearly", maps_res_deg=10), id="custom"),
+        pytest.param(dict(maps_freq="yearly"), id="custom"),
     ),
 )
 def test_EvalSetup_ModelMapsSetup(eval_setup: EvalSetup, cfg_exp1: dict, update: dict):
     modelmaps_opts = eval_setup.modelmaps_opts
     if update:
         assert modelmaps_opts.maps_freq == cfg_exp1["maps_freq"] == update["maps_freq"]
-        assert modelmaps_opts.maps_res_deg == cfg_exp1["maps_res_deg"] == update["maps_res_deg"]
     else:  # defaults
         assert "maps_freq" not in cfg_exp1
         assert modelmaps_opts.maps_freq == "coarsest"
         assert "maps_res_deg" not in cfg_exp1
-        assert modelmaps_opts.maps_res_deg == 5
         assert modelmaps_opts.plot_types == {CONTOUR}
         assert modelmaps_opts.overlay_save_format == "webp"
 

--- a/tests/colocation/test_colocator.py
+++ b/tests/colocation/test_colocator.py
@@ -452,7 +452,7 @@ def test_colocator_with_obs_data_dir_gridded(setup):
 
 def test_colocation_pyaro(pyaro_testconfig, fake_aod_MSCWCtm_data_monthly_2010, setup) -> None:
     config = pyaro_testconfig[0]
-    setup["obs_config"] = config
+    setup["pyaro_config"] = config
     setup["model_id"] = "EMEP"
     setup["gridded_reader_id"] = {"model": "ReadMscwCtm"}
     setup["model_data_dir"] = fake_aod_MSCWCtm_data_monthly_2010

--- a/tests/fixtures/pyaro.py
+++ b/tests/fixtures/pyaro.py
@@ -42,11 +42,11 @@ def make_csv_test_file(tmp_path: Path) -> Path:
 
 
 def testconfig(tmp_path: Path) -> PyaroConfig:
-    data_id = "csv_timeseries"
+    reader_id = "csv_timeseries"
 
     config1 = PyaroConfig(
         name="test",
-        data_id=data_id,
+        reader_id=reader_id,
         filename_or_obj_or_url=str(make_csv_test_file(tmp_path)),
         filters={},
         name_map={"SOx": "concso4", "AOD": "od550aer"},
@@ -54,7 +54,7 @@ def testconfig(tmp_path: Path) -> PyaroConfig:
 
     config2 = PyaroConfig(
         name="test2",
-        data_id=data_id,
+        reader_id=reader_id,
         filename_or_obj_or_url=str(make_csv_test_file(tmp_path)),
         filters={},
         name_map={"SOx": "concso4", "AOD": "od550aer"},
@@ -63,7 +63,7 @@ def testconfig(tmp_path: Path) -> PyaroConfig:
 
 
 def testconfig_kwargs(tmp_path: Path) -> PyaroConfig:
-    data_id = "csv_timeseries"
+    reader_id = "csv_timeseries"
     columns = {
         "variable": 0,
         "station": 1,
@@ -82,7 +82,7 @@ def testconfig_kwargs(tmp_path: Path) -> PyaroConfig:
 
     config = PyaroConfig(
         name="test",
-        data_id=data_id,
+        reader_id=reader_id,
         filename_or_obj_or_url=str(make_csv_test_file(tmp_path)),
         filters={},
         name_map={"SOx": "concso4"},

--- a/tests/io/pyaro/test_pyaro_config.py
+++ b/tests/io/pyaro/test_pyaro_config.py
@@ -10,7 +10,7 @@ from pyaerocom.io.pyaro.pyaro_config import PyaroConfig
 def get_test_config() -> PyaroConfig:
     config = PyaroConfig(
         name="test",
-        data_id="test",
+        reader_id="test",
         filename_or_obj_or_url="test",
         filters={},
         name_map={},
@@ -21,7 +21,7 @@ def get_test_config() -> PyaroConfig:
 def get_existing_config() -> PyaroConfig:
     config = PyaroConfig(
         name="aeronetsun_test",
-        data_id="test",
+        reader_id="test",
         filename_or_obj_or_url="test",
         filters={},
         name_map={},

--- a/tests/io/test_readungridded.py
+++ b/tests/io/test_readungridded.py
@@ -139,7 +139,7 @@ def test_supported_pyaro(pyaro_testconfig):
     reader = ReadUngridded(configs=pyaro_testconfig)
 
     assert ReadPyaro in reader.SUPPORTED_READERS
-    assert pyaro_testconfig[0].data_id in reader.supported_datasets
+    assert pyaro_testconfig[0].reader_id in reader.supported_datasets
 
 
 def test_read_pyaro_and_other(pyaro_testconfig):


### PR DESCRIPTION
## Change Summary

- Allows to run `only_model_maps=True` without having run a previous experiment. This allows us to just show maps in cases where collocation and computation of statistics is computationally prohibitive, such as can be the case in CAMS2_82. Requires many changes in the code to create `menu.json`, `ranges.json`, `regions.json`, and fill `ts` with the necessary model and obs data to be able to slide through time series. Overall `ExperimentOutput` had far too high of a reliance on the `map` directory, so this work attempts to generalize the processing to be able to work when this does not exist.
- fixes misleading warning from #1426
- pixel maps are fixed up to correct projection (ESPG: 3857)
- fixes "coarsest" showing up in final config json for `maps_freq`
- fixes validators for `plot_types` to expect sets
- Minor clean up / corrections where I saw them.

## Related issue number

Although not the primary reason this PR will close https://github.com/metno/pyaerocom/issues/1426

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
