### PR TITLE
Add post-processing of observations from pyaro

### DIFF
--- a/pyaerocom/config.py
+++ b/pyaerocom/config.py
@@ -615,7 +615,7 @@ class Config:
         obs_vars,
         obs_aux_requires,
         obs_merge_how,
-        obs_aux_funs: dict[str, str] | None=None,
+        obs_aux_funs: dict[str, str] | None = None,
         obs_aux_units=None,
         **kwargs,
     ):

--- a/pyaerocom/config.py
+++ b/pyaerocom/config.py
@@ -615,7 +615,7 @@ class Config:
         obs_vars,
         obs_aux_requires,
         obs_merge_how,
-        obs_aux_funs=None,
+        obs_aux_funs: dict[str, str] | None=None,
         obs_aux_units=None,
         **kwargs,
     ):
@@ -645,15 +645,14 @@ class Config:
             combine). For valid input args see
             :mod:`pyaerocom.combine_vardata_ungridded`. If value is string,
             then the same method is used for all variables.
-        obs_aux_funs : dict, optional
+        obs_aux_funs : dict[str, str], optional
             dictionary specifying computation methods for auxiliary variables
             that are supposed to be retrieved via `obs_merge_how='eval'`.
             Keys are variable names, values are respective computation methods
-            (which need to be strings as they will be evaluated via
-             :func:`pandas.DataFrame.eval` in
-             :mod:`pyaerocom.combine_vardata_ungridded`). This input is
-            optional, but mandatory if any of the `obs_vars` is
-            supposed to be retrieved via `merge_how='eval'`.
+            passed to :mod:`pyaerocom.combine_vardata_ungridded`.
+            The function only supports addition/multiplication/.. on two variables.
+            This input is optional, but mandatory if any of the `obs_vars`
+            is supposed to be retrieved via `merge_how='eval'`.
         obs_aux_units : dict, optional
             output units of auxiliary variables (only needed for varibales
             that are derived via `merge_how='eval'`)

--- a/pyaerocom/io/pyaro/postprocess.py
+++ b/pyaerocom/io/pyaro/postprocess.py
@@ -1,10 +1,11 @@
 import dataclasses
 
-from cf_units import Unit
 from pyaro.timeseries import (
     Reader,
     Data,
 )
+
+from pyaerocom.units_helpers import get_unit_conversion_fac
 
 
 @dataclasses.dataclass
@@ -157,9 +158,9 @@ class PostProcessingReader(Reader):
             transform = self.compute_vars[varname]
             if isinstance(transform, VariableScaling):
                 data = self.reader.data(transform.REQ_VAR)
-                original_unit = Unit(data.units)
-                unit_scaling = original_unit.convert(1, transform.IN_UNIT)
-                scaling = unit_scaling * transform.SCALING_FACTOR
+                scaling = transform.SCALING_FACTOR * get_unit_conversion_fac(
+                    from_unit=data.units, to_unit=transform.IN_UNIT, var_name=transform.REQ_VAR
+                )
                 return PostProcessingReaderData(
                     data, variable=varname, units=transform.OUT_UNIT, scaling=scaling
                 )

--- a/pyaerocom/io/pyaro/postprocess.py
+++ b/pyaerocom/io/pyaro/postprocess.py
@@ -55,7 +55,7 @@ TRANSFORMATIONS = {
         SCALING_FACTOR=0.493,  # STD atmosphere and concx_to_vmrx
         OUT_VARNAME="vmro3",
     ),
-    "vmro3max_from_conco3": VariableScaling(  # Requies `resample_how`
+    "vmro3max_from_conco3": VariableScaling(  # Requires `resample_how`
         REQ_VAR="conco3",
         IN_UNIT="µg m-3",
         OUT_UNIT="ppb",

--- a/pyaerocom/io/pyaro/postprocess.py
+++ b/pyaerocom/io/pyaro/postprocess.py
@@ -55,6 +55,13 @@ TRANSFORMATIONS = {
         SCALING_FACTOR=0.493,  # STD atmosphere and concx_to_vmrx
         OUT_VARNAME="vmro3",
     ),
+    "vmro3max_from_conco3": VariableScaling(  # Requies `resample_how`
+        REQ_VAR="conco3",
+        IN_UNIT="µg m-3",
+        OUT_UNIT="ppb",
+        SCALING_FACTOR=0.493,  # STD atmosphere and concx_to_vmrx
+        OUT_VARNAME="vmro3max",
+    ),
 }
 
 

--- a/pyaerocom/io/pyaro/postprocess.py
+++ b/pyaerocom/io/pyaro/postprocess.py
@@ -1,0 +1,140 @@
+import dataclasses
+
+from cf_units import Unit
+from pyaro.timeseries import (
+    Reader,
+    Data,
+)
+
+
+@dataclasses.dataclass
+class VariableScaling:
+    REQ_VAR: str
+    IN_UNIT: str
+    OUT_UNIT: str
+    SCALING_FACTOR: float
+
+
+M_N = 14.006
+M_O = 15.999
+
+TRANSFORMATIONS = {
+    "concNno_from_concno": VariableScaling(
+        REQ_VAR="concno",
+        IN_UNIT="ug m-3",
+        OUT_UNIT="ug N m-3",
+        SCALING_FACTOR=M_N / (M_N + M_O),
+    ),
+    "concNno2_from_concno2": VariableScaling(
+        REQ_VAR="concno2",
+        IN_UNIT="ug m-3",
+        OUT_UNIT="ug N m-3",
+        SCALING_FACTOR=M_N / (M_N + 2 * M_O),
+    ),
+}
+
+
+class PostProcessingReaderData(Data):
+    def __init__(self, data: Data, variable: str, units: str, scaling: float | None):
+        self._variable = variable
+        self._units = units
+        self.data = data
+        self.scaling = scaling
+
+    def keys(self):
+        return self.data.keys()
+
+    def slice(self, index):
+        return PostProcessingReaderData(
+            self.data.slice(index),
+            variable=self._variable,
+            units=self._units,
+            scaling=self.scaling,
+        )
+
+    def __len__(self):
+        return self.data.__len__()
+
+    @property
+    def values(self):
+        if self.scaling is None:
+            return self.data.values
+        else:
+            return self.data.values * self.scaling
+
+    @property
+    def stations(self):
+        return self.data.stations
+
+    @property
+    def latitudes(self):
+        return self.data.latitudes
+
+    @property
+    def longitudes(self):
+        return self.data.longitudes
+
+    @property
+    def altitudes(self):
+        return self.data.altitudes
+
+    @property
+    def start_times(self):
+        return self.data.start_times
+
+    @property
+    def end_times(self):
+        return self.data.end_times
+
+    @property
+    def flags(self):
+        return self.data.flags
+
+    @property
+    def standard_deviations(self):
+        return self.data.standard_deviations
+
+
+class PostProcessingReader(Reader):
+    def __init__(
+        self,
+        reader: Reader,
+        compute_vars: dict[str, str] | None = None,
+    ):
+        self.reader = reader
+
+        if compute_vars is None:
+            self.compute_vars = dict()
+        else:
+            self.compute_vars = compute_vars
+
+    def data(self, varname: str) -> Data:
+        if varname not in self.compute_vars:
+            data = self.reader.data(varname)
+            return data
+        else:
+            transform = TRANSFORMATIONS.get(self.compute_vars[varname])
+            if isinstance(transform, VariableScaling):
+                data = self.reader.data(transform.REQ_VAR)
+                original_unit = Unit(data.units)
+                unit_scaling = original_unit.convert(1, transform.IN_UNIT)
+                scaling = unit_scaling * transform.SCALING_FACTOR
+                return PostProcessingReaderData(
+                    data, variable=varname, units=transform.OUT_UNIT, scaling=scaling
+                )
+            else:
+                raise Exception(
+                    f"Unknown transform {transform} encountered for variable {varname}"
+                )
+
+    def variables(self) -> list[str]:
+        variables = list()
+        variables.extend(self.reader.variables())
+        variables.extend(self.compute_vars.keys())
+        return variables
+
+    def stations(self):
+        return self.reader.stations()
+
+    def close(self) -> None:
+        self.reader.close()

--- a/pyaerocom/io/pyaro/postprocess.py
+++ b/pyaerocom/io/pyaro/postprocess.py
@@ -15,6 +15,7 @@ class VariableScaling:
     OUT_UNIT: str
     SCALING_FACTOR: float
     OUT_VARNAME: str
+    NOTE: str | None = None
 
     def required_input_variables(self) -> list[str]:
         return [self.REQ_VAR]
@@ -53,15 +54,17 @@ TRANSFORMATIONS = {
         REQ_VAR="conco3",
         IN_UNIT="µg m-3",
         OUT_UNIT="ppb",
-        SCALING_FACTOR=0.493,  # STD atmosphere and concx_to_vmrx
+        SCALING_FACTOR=0.5011,  # 20C and 1013 hPa
         OUT_VARNAME="vmro3",
+        NOTE="The vmro3_from_conco3 transform is only valid at T=20C, p=1013hPa",
     ),
     "vmro3max_from_conco3": VariableScaling(  # Requires `resample_how`
         REQ_VAR="conco3",
         IN_UNIT="µg m-3",
         OUT_UNIT="ppb",
-        SCALING_FACTOR=0.493,  # STD atmosphere and concx_to_vmrx
+        SCALING_FACTOR=0.5011,  # 20C and 1013 hPa
         OUT_VARNAME="vmro3max",
+        NOTE="The vmro3max_from_conco3 transform is only valid at T=20C, p=1013hPa, and the transform requires the use of resample_how to obtain the daily maximum",
     ),
 }
 

--- a/pyaerocom/io/pyaro/postprocess.py
+++ b/pyaerocom/io/pyaro/postprocess.py
@@ -24,6 +24,7 @@ class VariableScaling:
 
 M_N = 14.006
 M_O = 15.999
+M_S = 32.065
 
 TRANSFORMATIONS = {
     "concNno_from_concno": VariableScaling(
@@ -39,6 +40,20 @@ TRANSFORMATIONS = {
         OUT_UNIT="ug N m-3",
         SCALING_FACTOR=M_N / (M_N + 2 * M_O),
         OUT_VARNAME="concNno2",
+    ),
+    "concSso2_from_concso2": VariableScaling(
+        REQ_VAR="concso2",
+        IN_UNIT="ug m-3",
+        OUT_UNIT="ug S m-3",
+        SCALING_FACTOR=M_S / (M_S + 2 * M_O),
+        OUT_VARNAME="concSso2",
+    ),
+    "vmro3_from_conco3": VariableScaling(
+        REQ_VAR="conco3",
+        IN_UNIT="µg m-3",
+        OUT_UNIT="ppb",
+        SCALING_FACTOR=0.493,  # STD atmosphere and concx_to_vmrx
+        OUT_VARNAME="vmro3",
     ),
 }
 

--- a/pyaerocom/io/pyaro/pyaro_config.py
+++ b/pyaerocom/io/pyaro/pyaro_config.py
@@ -34,6 +34,7 @@ class PyaroConfig(BaseModel):
     filename_or_obj_or_url: str | list[str] | Path | list[Path]
     filters: dict[str, FilterArgs]
     name_map: dict[str, str] | None = None  # no Unit conversion option
+    post_processing: dict[str, str] | None = None  # No post-processing
 
     ##########################
     #   Save and load methods

--- a/pyaerocom/io/pyaro/pyaro_config.py
+++ b/pyaerocom/io/pyaro/pyaro_config.py
@@ -34,7 +34,7 @@ class PyaroConfig(BaseModel):
     filename_or_obj_or_url: str | list[str] | Path | list[Path]
     filters: dict[str, FilterArgs]
     name_map: dict[str, str] | None = None  # no Unit conversion option
-    post_processing: dict[str, str] | None = None  # No post-processing
+    post_processing: list[str] | None = None  # List of variables to add through post-processing
 
     ##########################
     #   Save and load methods

--- a/pyaerocom/io/readungridded.py
+++ b/pyaerocom/io/readungridded.py
@@ -832,7 +832,7 @@ class ReadUngridded:
                 return svar
         raise ValueError()
 
-    def get_vars_supported(self, obs_id, vars_desired):  # , config: Optional[PyaroConfig] = None):
+    def get_vars_supported(self, obs_id: str, vars_desired: list[str]):
         """
         Filter input list of variables by supported ones for a certain data ID
 

--- a/tests/fixtures/pyaro.py
+++ b/tests/fixtures/pyaro.py
@@ -24,7 +24,7 @@ def make_csv_test_file(tmp_path: Path) -> Path:
     stations = ["NO0002", "GB0881"]
     countries = ["NO", "GB"]
     coords = [(58, 8), (60, -1)]
-    species = ["NOx", "SOx", "AOD"]
+    species = ["NOx", "SOx", "AOD", "NO"]
     area_type = ["Rural", "Urban"]
 
     with open(file, "w") as f:
@@ -34,14 +34,15 @@ def make_csv_test_file(tmp_path: Path) -> Path:
                     delta_t = ["1h", "3D", "2D", "2h"][
                         j % 4
                     ]  # Rotates over the freqs in a deterministic fashion
+                    unit = "Gg" if s != "NO" else "ng m-3"
                     f.write(
-                        f"{s}, {station}, {coords[i][1]}, {coords[i][0]}, {np.random.normal(10, 5)}, Gg, {date}, {date+pd.Timedelta(delta_t)},{countries[i]},{area_type[i]} \n"
+                        f"{s}, {station}, {coords[i][1]}, {coords[i][0]}, {np.random.normal(10, 5)}, {unit}, {date}, {date+pd.Timedelta(delta_t)},{countries[i]},{area_type[i]} \n"
                     )
 
     return file
 
 
-def testconfig(tmp_path: Path) -> PyaroConfig:
+def testconfig(tmp_path: Path) -> tuple[PyaroConfig, PyaroConfig]:
     reader_id = "csv_timeseries"
 
     config1 = PyaroConfig(

--- a/tests/io/pyaro/test_read_pyaro.py
+++ b/tests/io/pyaro/test_read_pyaro.py
@@ -98,9 +98,9 @@ def test_postprocessing(pyaro_test_data_file):
         name_map={
             "NO": "concno",
         },
-        post_processing={
-            "concNno": "concNno_from_concno",
-        },
+        post_processing=[
+            "concNno_from_concno",
+        ],
         filters=dict(),
     )
     reader = ReadPyaro(config)


### PR DESCRIPTION
## Change Summary

<!-- Please give a short summary of the changes. -->

Adds transformation of variables to go from e.g. `concno` to `concNno`, which were previously done using `AUX_FUNS`

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review

## Longer explanation/design considerations
Models and observations should be compared using the same kind of species, which means observations might have to be transformed to match the model or for fair comparison to runs from previous years. There exists some functionality for this already in `pyaerocom`, but this must be implemented per reader. The functionality of this PR tries to generalise a bit, and implements this as a pyaro `Reader` adaptive layer (sort of middleware) like `VariableNameChanger`.

This functionality has been added to `pyaerocom` instead of `pyaro` as it is tied to the convention (name/units) of variables defined in `pyaerocom`.

Adding it as a separate reader in `pyaro-readers` turned out to make the configuration very verbose.