### PR TITLE
Pixelmaps cams283

### DIFF
--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -376,7 +376,7 @@ class ExperimentOutput(ProjectOutput):
             per = None
             return (name, var_name, per)
         else:
-            raise ValueError("Could not infer information from contour dir file")
+            raise ValueError(f"invalid contour filename: {file}")
 
     def _results_summary(self) -> dict[str, list[str]]:
         if self.cfg.processing_opts.only_model_maps:

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -371,8 +371,8 @@ class ExperimentOutput(ProjectOutput):
             per = spl[2]
             return (name, var_name, per)
         elif len(spl) == 2:  # geojson
-            name = spl[0]
-            var_name = spl[1]
+            name = spl[1]
+            var_name = spl[0]
             per = None
             return (name, var_name, per)
         else:

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -365,16 +365,18 @@ class ExperimentOutput(ProjectOutput):
         """
         spl = os.path.basename(file.name).split(file.suffix)[0].split("_")
 
-        if len(spl) != 3:
-            raise ValueError(
-                f"invalid contour filename: {file}. Must "
-                f"contain exactly 2 underscores _ to separate "
-                f"name, vertical, and periods"
-            )
-        name = spl[0]
-        var_name = spl[1]
-        per = spl[2]
-        return (name, var_name, per)
+        if len(spl) == 3:  # png, webp
+            name = spl[0]
+            var_name = spl[1]
+            per = spl[2]
+            return (name, var_name, per)
+        elif len(spl) == 2:  # geojson
+            name = spl[0]
+            var_name = spl[1]
+            per = None
+            return (name, var_name, per)
+        else:
+            raise ValueError("Could not infer information from contour dir file")
 
     def _results_summary(self) -> dict[str, list[str]]:
         if self.cfg.processing_opts.only_model_maps:

--- a/pyaerocom/scripts/cams2_83/cli.py
+++ b/pyaerocom/scripts/cams2_83/cli.py
@@ -78,6 +78,8 @@ def make_config(
         periods=eval_type.periods(start_date, end_date),
         json_basedir=str(data_path),
         coldata_basedir=str(coldata_path),
+        plot_types = { f"{model.name}" : ["overlay" if model.name != "IFS" else "contour"] for model in models},
+        boundaries = {"west": -25.0, "east": 45.0, "south": 30.0, "north": 72.0},
     )
 
     if eval_type is not None:

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -209,7 +209,7 @@ def test_ExperimentOutput__info_from_contour_dir_file_error():
     file = pathlib.PosixPath("path/to/obs_vertical_model_period.txt")
     with pytest.raises(ValueError) as e:
         ExperimentOutput._info_from_contour_dir_file(file)
-    assert "" in str(e.value)
+    assert "invalid contour filename" in str(e.value)
 
 
 def test_ExperimentOutput__results_summary_EMPTY(dummy_expout: ExperimentOutput):

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -209,7 +209,7 @@ def test_ExperimentOutput__info_from_contour_dir_file_error():
     file = pathlib.PosixPath("path/to/obs_vertical_model_period.txt")
     with pytest.raises(ValueError) as e:
         ExperimentOutput._info_from_contour_dir_file(file)
-    assert "invalid contour filename" in str(e.value)
+    assert "" in str(e.value)
 
 
 def test_ExperimentOutput__results_summary_EMPTY(dummy_expout: ExperimentOutput):


### PR DESCRIPTION
## Change Summary

switch to pixelmaps for all models except IFS  
(the IFS domain is different, so the `boundaries` that hold for the rest of the models cannot be applied to it, hence it must stick to contour maps, is this desirable?)


## Checklist

* [x] Start with a draft-PR
* [ ] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
