### PR TITLE
switch to pixelmaps for all models except IFS

### DIFF
--- a/pyaerocom/scripts/cams2_83/cli.py
+++ b/pyaerocom/scripts/cams2_83/cli.py
@@ -78,6 +78,8 @@ def make_config(
         periods=eval_type.periods(start_date, end_date),
         json_basedir=str(data_path),
         coldata_basedir=str(coldata_path),
+        plot_types = { f"{model.name}" : ["overlay" if model.name != "IFS" else "contour"] for model in models},
+        boundaries = {"west": -25.0, "east": 45.0, "south": 30.0, "north": 72.0},
     )
 
     if eval_type is not None:


### PR DESCRIPTION
## Change Summary

switch to pixelmaps for all models except IFS
the speed-up compared to contour is enough for this to be desirable for production  
the IFS model domain is different tho, so the boundaries that hold for the rest of the models cannot be applied to it, and we must stick to contour maps for the IFS... 
this might create some confusion on the user side, perhaps the default should be overlay then, can this be configurable?

## Checklist

* [x] Start with a draft-PR
* [ ] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [ ] Make PR ready to review
