### PR TITLE
Give boundaries a default in setup_classes

### DIFF
--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -128,7 +128,7 @@ class OutputPaths(BaseModel):
 class ModelMapsSetup(BaseModel):
     maps_freq: Literal["hourly", "daily", "monthly", "yearly", "coarsest"] = "coarsest"
     plot_types: dict[str, str | set[str]] | set[str] = {CONTOUR}
-    boundaries: BoundingBox | None = None
+    boundaries: BoundingBox = BoundingBox(west=-180, east=180, north=90, south=-90)
     map_observations_only_in_right_menu: bool = False
     overlay_save_format: Literal["webp", "png"] = "webp"
 


### PR DESCRIPTION
## Change Summary

Changed `ModelMapsSetup.boundaries` from a default of `None` to `BoundingBox(west=-180, east=180, north=90, south=-90)`.

## Related issue number

NA, see chat

## Checklist

* [ ] Start with a draft-PR
* [ ] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
