### PR TITLE
Reduce test warnings

### DIFF
--- a/pyaerocom/io/read_earlinet.py
+++ b/pyaerocom/io/read_earlinet.py
@@ -369,7 +369,8 @@ class ReadEarlinet(ReadUngriddedBase):
                     wvlg = var_info[var].wavelength_nm
                     wvlg_str = self.META_NAMES_FILE["wavelength_emis"]
 
-                    if not wvlg == float(data_in[wvlg_str]):
+                    assert data_in[wvlg_str].shape == (1,)
+                    if not wvlg == float(data_in[wvlg_str][0]):
                         self.logger.info("No wavelength match")
                         continue
 

--- a/pyaerocom/stats/mda8/mda8.py
+++ b/pyaerocom/stats/mda8/mda8.py
@@ -109,6 +109,6 @@ def _rolling_average_8hr(arr: xr.DataArray) -> xr.DataArray:
 
 
 def _daily_max(arr: xr.DataArray) -> xr.DataArray:
-    return arr.resample(time="24H", origin="start_day", label="left", offset="1h").reduce(
+    return arr.resample(time="24h", origin="start_day", label="left", offset="1h").reduce(
         lambda x, axis: np.apply_along_axis(min_periods_max, 1, x, min_periods=18)
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,15 +103,15 @@ testpaths = ["tests"]
 filterwarnings = [
     # treat warnings as errors
     "error",
-    "ignore::pytest.PytestUnraisableExceptionWarning",
-    # except deprecation and future warnings ouside this packege
-    'ignore::PendingDeprecationWarning:^(?!pyaerocom|tests).*:',
-    'ignore::DeprecationWarning:^(?!pyaerocom|tests).*:',
-    'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
-    # Ignore self-deprecation warnings related to plotting
-    'ignore:matplotlib based plotting is no longer directly supported. This (function|class) may be removed in future versions\.:DeprecationWarning:(pyaerocom|tests):',
-    # and not on this list
-    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:", # Issue #1394
+#    "ignore::pytest.PytestUnraisableExceptionWarning",
+#    # except deprecation and future warnings ouside this packege
+#    'ignore::PendingDeprecationWarning:^(?!pyaerocom|tests).*:',
+#    'ignore::DeprecationWarning:^(?!pyaerocom|tests).*:',
+#    'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
+#    # Ignore self-deprecation warnings related to plotting
+#    'ignore:matplotlib based plotting is no longer directly supported. This (function|class) may be removed in future versions\.:DeprecationWarning:(pyaerocom|tests):',
+#    # and not on this list
+#    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:", # Issue #1394
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,15 +103,15 @@ testpaths = ["tests"]
 filterwarnings = [
     # treat warnings as errors
     "error",
-#    "ignore::pytest.PytestUnraisableExceptionWarning",
-#    # except deprecation and future warnings ouside this packege
-#    'ignore::PendingDeprecationWarning:^(?!pyaerocom|tests).*:',
-#    'ignore::DeprecationWarning:^(?!pyaerocom|tests).*:',
-#    'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
-#    # Ignore self-deprecation warnings related to plotting
-#    'ignore:matplotlib based plotting is no longer directly supported. This (function|class) may be removed in future versions\.:DeprecationWarning:(pyaerocom|tests):',
-#    # and not on this list
-#    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:", # Issue #1394
+    "ignore::pytest.PytestUnraisableExceptionWarning",
+    # except deprecation and future warnings ouside this packege
+    'ignore::PendingDeprecationWarning:^(?!pyaerocom|tests).*:',
+    'ignore::DeprecationWarning:^(?!pyaerocom|tests).*:',
+    'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
+    # Ignore self-deprecation warnings related to plotting
+    'ignore:matplotlib based plotting is no longer directly supported. This (function|class) may be removed in future versions\.:DeprecationWarning:(pyaerocom|tests):',
+    # and not on this list
+    "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:", # Issue #1394
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Change Summary

Fixes issues that lead to the following warnings:
- `ResourceWarning` due to a unclosed file handle.
- `DeprecationWarning` due to not indexing 1d array before converting to scalar.

After these changes the only warnings remaining are the matplotlib related ones, and the iris default sphere ones we decided to ignore in https://github.com/metno/pyaerocom/issues/1394

## Related issue number

#1066 (Remember to push this forward two milestones when merging)

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally (except #1455 )
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
