### PR TITLE
Pin matplotlib

### DIFF
--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -7,6 +7,7 @@ dependencies:
   - xarray >=2022.12.0
   - cartopy >=0.21.1
   - matplotlib-base >=3.7.1
+  - matplotlib-base <3.10.0
   - scipy >=1.10.1
   - pandas >=1.5.3
   - numpy >=1.25.0, <2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "xarray>=2022.12.0",
     "cartopy>=0.21.1",
     "matplotlib>=3.7.1",
+    "matplotlib<3.10.0", # geojsoncontour bug with .collections deprecation in matplotlib, see #1462
     "scipy>=1.10.1",
     "pandas>=1.5.3",
     "numpy>=1.25.0",


### PR DESCRIPTION
## Change Summary

<!-- Please give a short summary of the changes. -->
We are hitting an issue with `geojsoncontour` erroring since `.collections` for contours has been deprecated https://matplotlib.org/devdocs/api/next_api_changes/removals/28767-REC.html. This PR pins matplotlib while we find a workaround/fix the upstream package


## Related issue number

#1462 
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Start with a draft-PR
* [ ] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
