### PR TITLE
Model maps with ColocatedData objects

### DIFF
--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -565,7 +565,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                 f"{name=} not is not in either {self.cfg.obs_cfg.keylist()=} nor {self.cfg.model_cfg.keylist()=}"
             )
 
-    def _process_only_json(self, model_name, var):
+    def _process_only_json(self, model_name, var):  # pragma: no cover
         """Process data from ColocatedData for overlay map for if only_json = True."""
         try:
             preprocessed_coldata_dir = glob.escape(

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -270,7 +270,6 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
             data = data.drop_vars("data_source")
             data = data.transpose("time", "latitude", "longitude")
             data = data.sortby(["latitude", "longitude"])
-            # data = GriddedData(data.to_iris())
         else:
             try:
                 data = self.read_gridded_obsdata(model_name, var)
@@ -559,8 +558,8 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
 
                     if (
                         name in timeseries
-                        and timeseries[name].get(maps_freq + "_mod", False) is not None
-                        and timeseries[name].get(maps_freq + "_obs", False) is not None
+                        and timeseries[name].get(maps_freq + "_mod", False)
+                        and timeseries[name].get(maps_freq + "_obs", False)
                     ):
                         continue
 

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -240,11 +240,15 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
 
         if self.cfg.processing_opts.only_json:  # we have colocated data
             try:
-                preprocessed_coldata_dir = self.cfg.model_cfg.get_entry(model_name).model_data_dir
+                preprocessed_coldata_dir = glob.escape(
+                    self.cfg.model_cfg.get_entry(model_name).model_data_dir
+                )
                 mask = f"{preprocessed_coldata_dir}/*.nc"
                 file_to_convert = glob.glob(mask)
             except KeyError:
-                preprocessed_coldata_dir = self.cfg.obs_cfg.get_entry(model_name).coldata_dir
+                preprocessed_coldata_dir = glob.escape(
+                    self.cfg.obs_cfg.get_entry(model_name).coldata_dir
+                )
                 mask = f"{preprocessed_coldata_dir}/{model_name}/*.nc"
                 matching_files = (
                     search_directory_recursively_for_netcdf_filenames_containing_strings(

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -157,10 +157,10 @@ def plot_overlay_pixel_maps(
     return image
 
 
-def search_directory_recursively_for_netcdf_filenames_containing_strings(directory, strings):
+def find_netcdf_files(directory, strings):
     matching_files = []
     # Use glob to find all NetCDF files recursively
-    for nc_file in glob.iglob(os.path.join(directory, "**", "*.nc"), recursive=True):
+    for nc_file in glob.escape(glob.iglob(os.path.join(directory, "**", "*.nc"), recursive=True)):
         # Check if all specified strings are in the filename
         if all(s in os.path.basename(nc_file) for s in strings):
             matching_files.append(nc_file)

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -160,7 +160,7 @@ def plot_overlay_pixel_maps(
 def find_netcdf_files(directory, strings):
     matching_files = []
     # Use glob to find all NetCDF files recursively
-    for nc_file in glob.escape(glob.iglob(os.path.join(directory, "**", "*.nc"), recursive=True)):
+    for nc_file in glob.iglob(os.path.join(glob.escape(directory), "**", "*.nc"), recursive=True):
         # Check if all specified strings are in the filename
         if all(s in os.path.basename(nc_file) for s in strings):
             matching_files.append(nc_file)

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -8,6 +8,8 @@ from seaborn import color_palette
 import io
 import xarray
 import pandas as pd
+import glob
+import os
 
 try:
     from geojsoncontour import contourf_to_geojson
@@ -153,3 +155,13 @@ def plot_overlay_pixel_maps(
     plt.close("all")
 
     return image
+
+
+def search_directory_recursively_for_netcdf_filenames_containing_strings(directory, strings):
+    matching_files = []
+    # Use glob to find all NetCDF files recursively
+    for nc_file in glob.iglob(os.path.join(directory, "**", "*.nc"), recursive=True):
+        # Check if all specified strings are in the filename
+        if all(s in os.path.basename(nc_file) for s in strings):
+            matching_files.append(nc_file)
+    return matching_files

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -7,12 +7,14 @@ from matplotlib.colors import ListedColormap, to_hex
 from seaborn import color_palette
 import io
 import xarray
+import pandas as pd
 
 try:
     from geojsoncontour import contourf_to_geojson
 except ModuleNotFoundError:
     contourf_to_geojson = None
 
+from pyaerocom import GriddedData
 from pyaerocom.aeroval.coldatatojson_helpers import _get_jsdate
 from pyaerocom.helpers import make_datetime_index
 from pyaerocom.tstype import TsType
@@ -25,7 +27,15 @@ OVERLAY = "overlay"
 
 def _jsdate_list(data):
     tst = TsType(data.ts_type)
-    idx = make_datetime_index(data.start, data.stop, tst.to_pandas_freq())
+    if isinstance(data, GriddedData):
+        start_yr = data.start
+        stop_yr = data.stop
+    elif isinstance(data, xarray.DataArray):
+        start_yr = pd.Timestamp(data.time.min().values).year
+        stop_yr = pd.Timestamp(data.time.max().values).year
+    else:
+        raise ValueError("data not correct type")
+    idx = make_datetime_index(start_yr, stop_yr, tst.to_pandas_freq())
     return _get_jsdate(idx.values).tolist()
 
 

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -129,7 +129,7 @@ class ModelMapsSetup(BaseModel):
     maps_freq: Literal["hourly", "daily", "monthly", "yearly", "coarsest"] = "coarsest"
     plot_types: dict[str, str | set[str]] | set[str] = {CONTOUR}
     boundaries: BoundingBox = BoundingBox(west=-180, east=180, north=90, south=-90)
-    map_observations_only_in_right_menu: bool = False
+    right_menu: tuple[str, ...] | None = None
     overlay_save_format: Literal["webp", "png"] = "webp"
 
     @field_validator("plot_types")


### PR DESCRIPTION
## Change Summary
Implements the functionality to make "model" maps from a ColocatedData object.

The way to do this is to 

- provide the `model_data_dir` in the model entry, ensuring that the path contains the model name at the end. (i.e., `"/lustre/storeB/users/lewisb/projects/CAMS2_82/coldata_testing2x2_180/ECMWF-OSUITE"`)
- provide the `coldata_dir` in the obs entry, ensuring that the model name *does not* appear at the end (i.e., "/lustre/storeB/users/lewisb/projects/CAMS2_82/coldata_testing2x2_180")
- set `add_model_maps=True` and optionally (depending on the resolution of the colocated data object) `only_model_maps=True`
- optionally set `pages = ("maps",)` if you only want to show maps
- declare which obserations and/or models should be shown in the right menu on the maps page. (e.g.,  right_menu = ("MODIS-TERRA", ))
- depending on the resolution you may want to use overlay maps. The preferred way to do this is to specify this for each model and observation network. (e.g., `plot_types = {"ECMWF-OSUITE": "overlay", "MODIS-TERRA": "overlay"}`)

![image](https://github.com/user-attachments/assets/ffcc5b7b-2c75-442e-8581-83c335bf0a07)


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
