### PR TITLE
remove tox dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,24 +215,6 @@ extras =
     test
 setenv =
     UDUNITS2_XML_PATH=/usr/share/xml/udunits/udunits2-common.xml
-deps =
-    scitools-iris ==3.11.0; python_version < "3.11"
-    cartopy ==0.21.1; python_version < "3.11"
-    matplotlib ==3.7.1; python_version < "3.11"
-    scipy ==1.10.1; python_version < "3.11"
-    numpy ==1.25.0; python_version < "3.11"
-    seaborn ==0.12.2; python_version < "3.11"
-    geonum ==1.5.0; python_version < "3.11"
-    typer ==0.7.0; python_version < "3.11"
-    tomli ==2.0.1; python_version < "3.11"
-    importlib-resources ==5.10; python_version < "3.11"
-    typing-extensions ==4.6.1; python_version < "3.11"
-    cf-units ==3.3.0; python_version < "3.11"
-    pydantic ==2.7.1; python_version < "3.11"
-    pyaro == 0.1.1; python_version < "3.11"
-    pooch ==1.7.0; python_version < "3.11"
-    xarray ==2022.12.0; python_version < "3.11"
-    pandas ==1.5.3; python_version < "3.11"
 
 [testenv:lint]
 skip_install = True


### PR DESCRIPTION
## Change Summary

<!-- Please give a short summary of the changes. -->

Some dependencies were explicitely pinned for the tox testing environment for python versions below 3.11. I assume this was done at some point to circumvent dependency problems, but it might not be necessary to pin all of them

## Related issue number

Fixes failing CI which resulted from #1474 and incompatible dependency

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
