### PR TITLE
Removes some file path references in exp output which are no longer needed.

### DIFF
--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -127,30 +127,6 @@ class ExperimentOutput(ProjectOutput):
         return fp
 
     @property
-    def regions_file(self) -> str:
-        """json file containing region specifications"""
-        fp = os.path.join(self.exp_dir, "regions.json")
-        return fp
-
-    @property
-    def statistics_file(self) -> str:
-        """json file containing region specifications"""
-        fp = os.path.join(self.exp_dir, "statistics.json")
-        return fp
-
-    @property
-    def var_ranges_file(self) -> str:
-        """json file containing region specifications"""
-        fp = os.path.join(self.exp_dir, "ranges.json")
-        return fp
-
-    @property
-    def menu_file(self) -> str:
-        """json file containing region specifications"""
-        fp = os.path.join(self.exp_dir, "menu.json")
-        return fp
-
-    @property
     def results_available(self) -> bool:
         """
         bool: True if results are available for this experiment, else False

--- a/tests/aeroval/test_aeroval_HIGHLEV.py
+++ b/tests/aeroval/test_aeroval_HIGHLEV.py
@@ -66,12 +66,12 @@ def test_ExperimentOutput__FILES(eval_config: dict, chk_files: dict):
     output: ExperimentOutput = proc.exp_output
     assert Path(output.exp_dir).is_dir()
     assert Path(output.experiments_file).exists()
-    assert Path(output.var_ranges_file).exists()
-    assert Path(output.statistics_file).exists()
-    assert Path(output.menu_file).exists()
 
-    json_path = Path(output.exp_dir) / f"cfg_{cfg.proj_id}_{cfg.exp_id}.json"
-    assert json_path.exists()
+    output.avdb.get_statistics(output.proj_id, output.exp_id)
+    output.avdb.get_menu(output.proj_id, output.exp_id)
+    output.avdb.get_ranges(output.proj_id, output.exp_id)
+
+    output.avdb.get_config(output.proj_id, output.exp_id)
 
     for key, path in cfg.path_manager.get_json_output_dirs().items():
         path = Path(path)

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -124,38 +124,15 @@ def test_ExperimentOutput_exp_dir(dummy_expout: ExperimentOutput, tmp_path: Path
     assert Path(dummy_expout.exp_dir) == tmp_path / "proj" / "exp"
 
 
-def test_ExperimentOutput_regions_file(dummy_expout: ExperimentOutput):
-    path = Path(dummy_expout.regions_file)
-    assert str(path.parent) == dummy_expout.exp_dir
-    assert path.name == "regions.json"
-
-
-def test_ExperimentOutput_statistics_file(dummy_expout: ExperimentOutput):
-    path = Path(dummy_expout.statistics_file)
-    assert str(path.parent) == dummy_expout.exp_dir
-    assert path.name == "statistics.json"
-
-
-def test_ExperimentOutput_var_ranges_file(dummy_expout: ExperimentOutput):
-    path = Path(dummy_expout.var_ranges_file)
-    assert str(path.parent) == dummy_expout.exp_dir
-    assert path.name == "ranges.json"
-
-
-def test_ExperimentOutput_menu_file(dummy_expout: ExperimentOutput):
-    path = Path(dummy_expout.menu_file)
-    assert str(path.parent) == dummy_expout.exp_dir
-    assert path.name == "menu.json"
-
-
 def test_ExperimentOutput_results_available_False(dummy_expout: ExperimentOutput):
     assert not dummy_expout.results_available
 
 
 def test_ExperimentOutput_update_menu_EMPTY(dummy_expout: ExperimentOutput):
     dummy_expout.update_menu()
-    assert Path(dummy_expout.menu_file).exists()
-    assert read_json(dummy_expout.menu_file) == {}
+
+    data = dummy_expout.avdb.get_menu(dummy_expout.proj_id, dummy_expout.exp_id)
+    assert data == {}
 
 
 def test_ExperimentOutput_update_interface_EMPTY(dummy_expout: ExperimentOutput):


### PR DESCRIPTION
## Change Summary

- Removes output file definitions which are no longer needed.
- Rewrites tests to test file existence via aerovaldb.

## Related issue number

closes #1480

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
