### PR TITLE
Change overlay plots to use grayscale

### DIFF
--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -303,7 +303,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
 
             overlay_plot = plot_overlay_pixel_maps(
                 data[i],
-                cmap=varinfo.cmap,
+                cmap="grayscale",
                 cmap_bins=varinfo.cmap_bins,
                 format=self.cfg.modelmaps_opts.overlay_save_format,
             )

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -502,9 +502,9 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                     )
 
                     timeseries[model_name].setdefault("obs_var", var)
-                    if isinstance(data, GriddedData):
+                    if hasattr(data, "units"):
                         timeseries[model_name].setdefault("obs_unit", data.units)
-                    elif isinstance(data, xr.DataArray):
+                    elif hasattr(data, "var_units"):
                         timeseries[model_name].setdefault("obs_unit", data.var_units[1])
                     else:
                         raise ValueError("Can not determine obs units")
@@ -555,9 +555,9 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                     timeseries[name].setdefault("station_name", "ALL")
                     timeseries[name].setdefault("pyaerocom_version", __version__)
                     timeseries[name].setdefault("mod_var", var)
-                    if isinstance(data, GriddedData):
+                    if hasattr(data, "units"):
                         timeseries[name].setdefault("mod_unit", data.units)
-                    elif isinstance(data, xr.DataArray):
+                    elif hasattr(data, "var_units"):
                         timeseries[name].setdefault("mod_unit", data.var_units[0])
                     else:
                         raise ValueError("Can not determine model units")

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -303,7 +303,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
 
             overlay_plot = plot_overlay_pixel_maps(
                 data[i],
-                cmap="grayscale",
+                cmap="gray",
                 cmap_bins=varinfo.cmap_bins,
                 format=self.cfg.modelmaps_opts.overlay_save_format,
             )

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -184,6 +184,7 @@ def plot_overlay_pixel_maps(
             format=format,
             pad_inches=0,
         )
+
         buffer.seek(0)
         image_data = buffer.getvalue()
 

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -19,8 +19,6 @@ from pyaerocom.aeroval.coldatatojson_helpers import _get_jsdate
 from pyaerocom.helpers import make_datetime_index
 from pyaerocom.tstype import TsType
 
-from PIL import Image
-
 
 # names of modelmaps type options
 CONTOUR = "contour"
@@ -186,16 +184,11 @@ def plot_overlay_pixel_maps(
         )
 
         buffer.seek(0)
-        image_data = buffer.getvalue()
-
-        image = Image.open(io.BytesIO(image_data)).convert("L")
-        img_byte_arr = io.BytesIO()
-        image.save(img_byte_arr, format=format)
-        img_byte_arr = img_byte_arr.getvalue()
+        image = buffer.getvalue()
 
     plt.close("all")
 
-    return img_byte_arr
+    return image
 
 
 def find_netcdf_files(directory, strings):

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -19,6 +19,8 @@ from pyaerocom.aeroval.coldatatojson_helpers import _get_jsdate
 from pyaerocom.helpers import make_datetime_index
 from pyaerocom.tstype import TsType
 
+from PIL import Image
+
 
 # names of modelmaps type options
 CONTOUR = "contour"
@@ -183,11 +185,16 @@ def plot_overlay_pixel_maps(
             pad_inches=0,
         )
         buffer.seek(0)
-        image = buffer.getvalue()
+        image_data = buffer.getvalue()
+
+        image = Image.open(io.BytesIO(image_data)).convert("L")
+        img_byte_arr = io.BytesIO()
+        image.save(img_byte_arr, format=format)
+        img_byte_arr = img_byte_arr.getvalue()
 
     plt.close("all")
 
-    return image
+    return img_byte_arr
 
 
 def find_netcdf_files(directory, strings):


### PR DESCRIPTION
## Change Summary

- output overlays in grayscale
- more robust checking on data types to create time series used in `only_model_maps`

## Related issue number

NA, private communication

Documentation will be more thoroughly addressed in #1488

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
