### PR TITLE
Optimize computation of timeseries statistics through multiprocessing

### DIFF
--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -6,7 +6,7 @@ from numpy.typing import ArrayLike
 import multiprocessing
 import os
 
-from pyaerocom import ColocatedData, TsType
+from pyaerocom import ColocatedData, TsType, const
 from pyaerocom.aeroval._processing_base import ProcessingEngine
 from pyaerocom.aeroval.coldatatojson_helpers import (
     _apply_annual_constraint,
@@ -27,9 +27,6 @@ from pyaerocom.aeroval.exceptions import ConfigError
 from pyaerocom.aeroval.json_utils import round_floats
 
 logger = logging.getLogger(__name__)
-
-
-pyaerocom_num_workers = "PYAEROCOM_NUM_WORKERS"
 
 
 class ColdataToJsonEngine(ProcessingEngine):
@@ -387,7 +384,7 @@ class ColdataToJsonEngine(ProcessingEngine):
             )
             for reg in regnames
         ]
-        num_workers = os.getenv(pyaerocom_num_workers, "1")
+        num_workers = os.getenv(const.PYAEROCOM_NUM_WORKERS, "1")
 
         with multiprocessing.Pool(processes=int(num_workers)) as pool:
             results = pool.starmap(_process_statistics_timeseries_single_region, args)

--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -4,7 +4,6 @@ from time import time
 from cf_units import Unit
 from numpy.typing import ArrayLike
 import multiprocessing
-import os
 
 from pyaerocom import ColocatedData, TsType
 from pyaerocom.aeroval._processing_base import ProcessingEngine
@@ -27,9 +26,6 @@ from pyaerocom.aeroval.exceptions import ConfigError
 from pyaerocom.aeroval.json_utils import round_floats
 
 logger = logging.getLogger(__name__)
-
-
-pyaerocom_num_workers = "PYAEROCOM_NUM_WORKERS"
 
 
 class ColdataToJsonEngine(ProcessingEngine):
@@ -387,9 +383,8 @@ class ColdataToJsonEngine(ProcessingEngine):
             )
             for reg in regnames
         ]
-        num_workers = os.getenv(pyaerocom_num_workers, "1")
 
-        with multiprocessing.Pool(processes=int(num_workers)) as pool:
+        with multiprocessing.Pool(processes=self.cfg.processing_opts.num_workers) as pool:
             results = pool.starmap(_process_statistics_timeseries_single_region, args)
 
         for stats_ts, region, obs_name, var_name_web, vert_code, model_name, model_var in results:

--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -12,7 +12,7 @@ from pyaerocom.aeroval.coldatatojson_helpers import (
     _init_data_default_frequencies,
     _init_meta_glob,
     _process_heatmap_data,
-    _process_map_and_scat_single_period,
+    _process_map_and_scat,
     _process_regional_timeseries,
     _process_sites,
     _process_sites_weekly_ts,
@@ -440,14 +440,14 @@ class ColdataToJsonEngine(ProcessingEngine):
 
         logger.info("Processing map and scat data by period")
 
-        # Prepare arguments for parallel processing
-        args = [
-            (
-                period,
+        for period in periods:
+            # compute map_data and scat_data just for this period
+            map_data, scat_data = _process_map_and_scat(
                 data,
                 map_meta,
                 site_indices,
-                scatter_freq,
+                [period],
+                str(scatter_freq),
                 stats_min_num,
                 seasons,
                 add_trends,
@@ -456,63 +456,32 @@ class ColdataToJsonEngine(ProcessingEngine):
                 use_fairmode,
                 obs_var,
                 drop_stats,
-                self.avdb,
-                self.exp_output,
-                obs_name,
-                var_name_web,
-                vert_code,
-                model_name,
-                model_var,
             )
-            for period in periods
-        ]
 
-        # Use multiprocessing to parallelize the processing
-        with multiprocessing.Pool(processes=multiprocessing.cpu_count()) as pool:
-            pool.starmap(_process_map_and_scat_single_period, args)
+            with self.avdb.lock():
+                self.avdb.put_map(
+                    map_data,
+                    self.exp_output.proj_id,
+                    self.exp_output.exp_id,
+                    obs_name,
+                    var_name_web,
+                    vert_code,
+                    model_name,
+                    model_var,
+                    period.replace("/", ""),  # Remove slashes in CAMS2_83 period.
+                )
 
-        # for period in periods:
-        #     # compute map_data and scat_data just for this period
-        #     map_data, scat_data = _process_map_and_scat(
-        #         data,
-        #         map_meta,
-        #         site_indices,
-        #         [period],
-        #         str(scatter_freq),
-        #         stats_min_num,
-        #         seasons,
-        #         add_trends,
-        #         trends_min_yrs,
-        #         avg_over_trends,
-        #         use_fairmode,
-        #         obs_var,
-        #         drop_stats,
-        #     )
-
-        #     with self.avdb.lock():
-        #         self.avdb.put_map(
-        #             map_data,
-        #             self.exp_output.proj_id,
-        #             self.exp_output.exp_id,
-        #             obs_name,
-        #             var_name_web,
-        #             vert_code,
-        #             model_name,
-        #             model_var,
-        #             period.replace("/", ""),  # Remove slashes in CAMS2_83 period.
-        #         )
-
-        #         self.avdb.put_scatter(
-        #             scat_data,
-        #             self.exp_output.proj_id,
-        #             self.exp_output.exp_id,
-        #             obs_name,
-        #             var_name_web,
-        #             vert_code,
-        #             model_name,
-        #             model_var,
-        #             period.replace("/", ""),  # Remove slashes in CAMS2_83 period.
-        #         )
+                self.avdb.put_scatter(
+                    scat_data,
+                    self.exp_output.proj_id,
+                    self.exp_output.exp_id,
+                    obs_name,
+                    var_name_web,
+                    vert_code,
+                    model_name,
+                    model_var,
+                    period.replace("/", ""),  # Remove slashes in CAMS2_83 period.
+                )
 
     def _process_diurnal_profiles(
         self,

--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -3,6 +3,7 @@ from time import time
 
 from cf_units import Unit
 from numpy.typing import ArrayLike
+import multiprocessing
 
 from pyaerocom import ColocatedData, TsType
 from pyaerocom.aeroval._processing_base import ProcessingEngine
@@ -15,7 +16,7 @@ from pyaerocom.aeroval.coldatatojson_helpers import (
     _process_regional_timeseries,
     _process_sites,
     _process_sites_weekly_ts,
-    _process_statistics_timeseries,
+    _process_statistics_timeseries_single_region,
     _remove_less_covered,
     init_regions_web,
     process_profile_data_for_regions,
@@ -23,7 +24,6 @@ from pyaerocom.aeroval.coldatatojson_helpers import (
 )
 from pyaerocom.aeroval.exceptions import ConfigError
 from pyaerocom.aeroval.json_utils import round_floats
-from pyaerocom.exceptions import TemporalResolutionError
 
 logger = logging.getLogger(__name__)
 
@@ -338,48 +338,58 @@ class ColdataToJsonEngine(ProcessingEngine):
 
     def _process_stats_timeseries_for_all_regions(
         self,
-        data: dict[str, ColocatedData] = None,
-        coldata: ColocatedData = None,
-        main_freq: str = None,
-        regnames=None,
+        data: dict[str, ColocatedData] | None = None,
+        coldata: ColocatedData | None = None,
+        main_freq: str | None = None,
+        regnames: dict | None = None,
         use_weights: bool = True,
         drop_stats: tuple = (),
         use_country: bool = False,
-        obs_name: str = None,
+        obs_name: str | None = None,
         obs_var: str = None,
-        var_name_web: str = None,
-        out_dirs: dict = None,
-        vert_code: str = None,
-        model_name: str = None,
-        model_var: str = None,
-        meta_glob: dict = None,
-        periods: tuple[str, ...] = None,
-        seasons: tuple[str, ...] = None,
+        var_name_web: str | None = None,
+        out_dirs: dict | None = None,
+        vert_code: str | None = None,
+        model_name: str | None = None,
+        model_var: str | None = None,
+        meta_glob: dict | None = None,
+        periods: tuple[str, ...] | None = None,
+        seasons: tuple[str, ...] | None = None,
         add_trends: bool = False,
         trends_min_yrs: int = 7,
         regions_how: str = "default",
-        regs: dict = None,
+        regs: dict | None = None,
         stats_min_num: int = 1,
         use_fairmode: bool = False,
         avg_over_trends: bool = False,
     ):
         input_freq = self.cfg.statistics_opts.stats_tseries_base_freq
-        for reg in regnames:
-            try:
-                stats_ts = _process_statistics_timeseries(
-                    data=data,
-                    freq=main_freq,
-                    region_ids={reg: regnames[reg]},
-                    use_weights=use_weights,
-                    drop_stats=drop_stats,
-                    use_country=use_country,
-                    data_freq=input_freq,
-                )
 
-            except TemporalResolutionError:
-                stats_ts = {}
+        # Prepare arguments for parallel processing
+        args = [
+            (
+                reg,
+                regnames,
+                data,
+                main_freq,
+                use_weights,
+                drop_stats,
+                use_country,
+                input_freq,
+                obs_name,
+                var_name_web,
+                vert_code,
+                model_name,
+                model_var,
+            )
+            for reg in regnames
+        ]
+        # Use multiprocessing to parallelize the processing
+        with multiprocessing.Pool(processes=multiprocessing.cpu_count()) as pool:
+            results = pool.starmap(_process_statistics_timeseries_single_region, args)
 
-            region = regnames[reg]
+        # Process the results
+        for stats_ts, region, obs_name, var_name_web, vert_code, model_name, model_var in results:
             self.exp_output.add_heatmap_timeseries_entry(
                 stats_ts,
                 region,

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -11,8 +11,6 @@ from typing import Literal
 import numpy as np
 import pandas as pd
 import xarray as xr
-import aerovaldb
-
 
 from pyaerocom import ColocatedData
 from pyaerocom._warnings import ignore_warnings
@@ -1763,68 +1761,3 @@ def _process_statistics_timeseries_single_region(
 
     region = regnames[reg]
     return (stats_ts, region, obs_name, var_name_web, vert_code, model_name, model_var)
-
-
-def _process_map_and_scat_single_period(
-    period: str,
-    data: dict[str, ColocatedData],
-    map_meta: list[dict],
-    site_indices: list[int],
-    scatter_freq: str,
-    stats_min_num: int,
-    seasons: tuple[str, ...],
-    add_trends: bool,
-    trends_min_yrs: int,
-    avg_over_trends: bool,
-    use_fairmode: bool,
-    obs_var: str,
-    drop_stats: tuple,
-    avdb: aerovaldb.AerovalDB,
-    exp_output,
-    obs_name: str,
-    var_name_web: str,
-    vert_code: str,
-    model_name: str,
-    model_var: str,
-):
-    # Compute map_data and scat_data just for this period
-    map_data, scat_data = _process_map_and_scat(
-        data,
-        map_meta,
-        site_indices,
-        [period],
-        str(scatter_freq),
-        stats_min_num,
-        seasons,
-        add_trends,
-        trends_min_yrs,
-        avg_over_trends,
-        use_fairmode,
-        obs_var,
-        drop_stats,
-    )
-
-    with avdb.lock():
-        avdb.put_map(
-            map_data,
-            exp_output.proj_id,
-            exp_output.exp_id,
-            obs_name,
-            var_name_web,
-            vert_code,
-            model_name,
-            model_var,
-            period.replace("/", ""),  # Remove slashes in CAMS2_83 period.
-        )
-
-        avdb.put_scatter(
-            scat_data,
-            exp_output.proj_id,
-            exp_output.exp_id,
-            obs_name,
-            var_name_web,
-            vert_code,
-            model_name,
-            model_var,
-            period.replace("/", ""),  # Remove slashes in CAMS2_83 period.
-        )

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -11,6 +11,8 @@ from typing import Literal
 import numpy as np
 import pandas as pd
 import xarray as xr
+import aerovaldb
+
 
 from pyaerocom import ColocatedData
 from pyaerocom._warnings import ignore_warnings
@@ -1761,3 +1763,68 @@ def _process_statistics_timeseries_single_region(
 
     region = regnames[reg]
     return (stats_ts, region, obs_name, var_name_web, vert_code, model_name, model_var)
+
+
+def _process_map_and_scat_single_period(
+    period: str,
+    data: dict[str, ColocatedData],
+    map_meta: list[dict],
+    site_indices: list[int],
+    scatter_freq: str,
+    stats_min_num: int,
+    seasons: tuple[str, ...],
+    add_trends: bool,
+    trends_min_yrs: int,
+    avg_over_trends: bool,
+    use_fairmode: bool,
+    obs_var: str,
+    drop_stats: tuple,
+    avdb: aerovaldb.AerovalDB,
+    exp_output,
+    obs_name: str,
+    var_name_web: str,
+    vert_code: str,
+    model_name: str,
+    model_var: str,
+):
+    # Compute map_data and scat_data just for this period
+    map_data, scat_data = _process_map_and_scat(
+        data,
+        map_meta,
+        site_indices,
+        [period],
+        str(scatter_freq),
+        stats_min_num,
+        seasons,
+        add_trends,
+        trends_min_yrs,
+        avg_over_trends,
+        use_fairmode,
+        obs_var,
+        drop_stats,
+    )
+
+    with avdb.lock():
+        avdb.put_map(
+            map_data,
+            exp_output.proj_id,
+            exp_output.exp_id,
+            obs_name,
+            var_name_web,
+            vert_code,
+            model_name,
+            model_var,
+            period.replace("/", ""),  # Remove slashes in CAMS2_83 period.
+        )
+
+        avdb.put_scatter(
+            scat_data,
+            exp_output.proj_id,
+            exp_output.exp_id,
+            obs_name,
+            var_name_web,
+            vert_code,
+            model_name,
+            model_var,
+            period.replace("/", ""),  # Remove slashes in CAMS2_83 period.
+        )

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1729,3 +1729,35 @@ def _get_yrs_from_season_yrs(season_yrs: dict) -> np.ndarray:
             yrs.append(y)
 
     return np.array(yrs)
+
+
+def _process_statistics_timeseries_single_region(
+    reg: str,
+    regnames: dict,
+    data: dict[str, ColocatedData],
+    main_freq: str,
+    use_weights: bool,
+    drop_stats: tuple,
+    use_country: bool,
+    input_freq: str,
+    obs_name: str,
+    var_name_web: str,
+    vert_code: str,
+    model_name: str,
+    model_var: str,
+):
+    try:
+        stats_ts = _process_statistics_timeseries(
+            data=data,
+            freq=main_freq,
+            region_ids={reg: regnames[reg]},
+            use_weights=use_weights,
+            drop_stats=drop_stats,
+            use_country=use_country,
+            data_freq=input_freq,
+        )
+    except TemporalResolutionError:
+        stats_ts = {}
+
+    region = regnames[reg]
+    return (stats_ts, region, obs_name, var_name_web, vert_code, model_name, model_var)

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -313,7 +313,7 @@ class EvalRunOptions(BaseModel):
     #: If True, process only maps (skip obs evaluation)
     only_model_maps: bool = False
     obs_only: bool = False
-    num_workers: int = 1  # number of parallel workers
+    num_workers: int = 1  #: Number of parallel workers to utilize when parallel processing is available. Currently implemented in :func:`pyaerocom.aeroval.coldatatojson_helpers.py::_process_stats_timeseries_for_all_regions`
 
 
 class ProjectInfo(BaseModel):

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -313,7 +313,8 @@ class EvalRunOptions(BaseModel):
     #: If True, process only maps (skip obs evaluation)
     only_model_maps: bool = False
     obs_only: bool = False
-    num_workers: int = 1  #: Number of parallel workers to utilize when parallel processing is available. Currently implemented in :func:`pyaerocom.aeroval.coldatatojson_helpers.py::_process_stats_timeseries_for_all_regions`
+    num_workers: int = 1
+    #: Number of parallel workers to utilize when parallel processing is available. Currently implemented in :func:`pyaerocom.aeroval.coldatatojson_helpers.py::_process_stats_timeseries_for_all_regions`
 
 
 class ProjectInfo(BaseModel):

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -313,6 +313,7 @@ class EvalRunOptions(BaseModel):
     #: If True, process only maps (skip obs evaluation)
     only_model_maps: bool = False
     obs_only: bool = False
+    num_workers: int = 1  # number of parallel workers
 
 
 class ProjectInfo(BaseModel):

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -313,8 +313,8 @@ class EvalRunOptions(BaseModel):
     #: If True, process only maps (skip obs evaluation)
     only_model_maps: bool = False
     obs_only: bool = False
-    num_workers: int = 1
     #: Number of parallel workers to utilize when parallel processing is available. Currently implemented in :func:`pyaerocom.aeroval.coldatatojson_helpers.py::_process_stats_timeseries_for_all_regions`
+    num_workers: int = 1
 
 
 class ProjectInfo(BaseModel):

--- a/pyaerocom/config.py
+++ b/pyaerocom/config.py
@@ -172,6 +172,9 @@ class Config:
     #: accessed
     SERVER_CHECK_TIMEOUT = 1  # s
 
+    #: Environment variable to delcare the number of parallel workers to utilize when parallel processing is available. Currently implemented in :func:`pyaerocom.aeroval.coldatatojson_helpers.py::_process_stats_timeseries_for_all_regions`
+    PYAEROCOM_NUM_WORKERS = "PYAEROCOM_NUM_WORKERS"
+
     def __init__(self, config_file=None, try_infer_environment=True):
         # Directories
         self._outputdir = None
@@ -782,8 +785,7 @@ class Config:
 
         if not os.path.isfile(config_file):
             raise FileNotFoundError(
-                f"Configuration file paths.ini at {config_file} does not exist "
-                f"or is not a file"
+                f"Configuration file paths.ini at {config_file} does not exist or is not a file"
             )
 
         if init_obslocs_ungridded:

--- a/pyaerocom/config.py
+++ b/pyaerocom/config.py
@@ -172,7 +172,7 @@ class Config:
     #: accessed
     SERVER_CHECK_TIMEOUT = 1  # s
 
-    #: Environment variable to delcare the number of parallel workers to utilize when parallel processing is available. Currently implemented in :func:`pyaerocom.aeroval.coldatatojson_helpers.py::_process_stats_timeseries_for_all_regions`
+    #: Environment variable to declare the number of parallel workers to use when parallel processing is available. Currently implemented in :func:`pyaerocom.aeroval.coldatatojson_helpers.py::_process_stats_timeseries_for_all_regions`
     PYAEROCOM_NUM_WORKERS = "PYAEROCOM_NUM_WORKERS"
 
     def __init__(self, config_file=None, try_infer_environment=True):


### PR DESCRIPTION
## Change Summary

Timeseries were computed independently and in serial by looping over the regions. This PR parallelizes this for loop using multiprocessing. To that end, implements a function in `pyaerocom/aeroval/coldatatojson_helpers.py`, `_process_statistics_timeseries_single_region`, to compute the timeseries for a specific region, and uses multiprocessing in `pyaerocom/aeroval/coldatatojson_engine.py` to call this function. I also corrected some type hints.


## Related issue number
Partly addresses #1277

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
