### PR TITLE
Add stats_order_menu to allowing custom ordering of statistics

### DIFF
--- a/pyaerocom/_lowlevel_helpers.py
+++ b/pyaerocom/_lowlevel_helpers.py
@@ -7,6 +7,7 @@ import logging
 import os
 from collections.abc import MutableMapping
 from pathlib import Path
+from typing import TypeVar
 
 import numpy as np
 from typing_extensions import TypedDict
@@ -568,7 +569,10 @@ def list_to_shortstr(lst, indent=0):
     return s
 
 
-def sort_dict_by_name(d, pref_list: list = None) -> dict:
+T = TypeVar("T")
+
+
+def sort_dict_by_name(d: dict[str, T], pref_list: list[str] | None = None) -> dict[str, T]:
     """Sort entries of input dictionary by their names and return ordered
 
     Parameters

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -649,6 +649,10 @@ class ExperimentOutput(ProjectOutput):
                     stats_info.update(statistics_mean_trend)
                     stats_info.update(statistics_median_trend)
 
+        if self.cfg.webdisp_opts.stats_order_menu:
+            stats_info = sort_dict_by_name(
+                stats_info, pref_list=self.cfg.webdisp_opts.stats_order_menu
+            )
         with self.avdb.lock():
             self.avdb.put_statistics(stats_info, self.proj_id, self.exp_id)
 

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -299,6 +299,7 @@ class WebDisplaySetup(BaseModel):
     obsorder_from_config: bool = True
     var_order_menu: tuple[str, ...] = ()
     obs_order_menu: tuple[str, ...] = ()
+    stats_order_menu: tuple[str, ...] = ()
     model_order_menu: tuple[str, ...] = ()
     hide_charts: tuple[str, ...] = ()
     hide_pages: tuple[str, ...] = ()

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -350,3 +350,18 @@ def test_Experiment_Output_drop_stats_and_decimals(
     statistics_json = read_json(path / "statistics.json")
     assert all([stat not in statistics_json for stat in drop_stats])
     assert all([statistics_json[stat]["decimals"] == stats_decimals for stat in statistics_json])
+
+
+@pytest.mark.parametrize("cfg", ["cfgexp1"])
+def test_Experiment_Output_stats_reorder(eval_config: dict):
+    cfg = EvalSetup(**eval_config)
+    requested_keys = ("fge", "R_spatial_mean", "mnmb", "nmb")
+    cfg.webdisp_opts.stats_order_menu = requested_keys
+    proc = ExperimentProcessor(cfg)
+    proc.run()
+    path = Path(proc.exp_output.exp_dir)
+    statistics_json = read_json(path / "statistics.json")
+
+    retrieved_keys = list(statistics_json.keys())
+
+    assert tuple(retrieved_keys[:4]) == requested_keys


### PR DESCRIPTION
## Change Summary

<!-- Please give a short summary of the changes. -->
Adds option to change order of statistics

## Related issue number

Fixes #1059 
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
