### PR TITLE
Reduce warnings in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,7 @@ pytest.ini
 
 # can store scripts etc. locally for testing and dev purposes
 playground/
+
+PATH_TO_AEROVAL_OUT/
+coldata/
+data/

--- a/pyaerocom/__init__.py
+++ b/pyaerocom/__init__.py
@@ -11,7 +11,12 @@ import iris
 # Enable new iris functionality to suppress deprecation warning.
 # https://scitools-iris.readthedocs.io/en/latest/generated/api/iris.html#iris.FUTURE
 iris.FUTURE.save_split_attrs = True
-iris.FUTURE.date_microseconds = True
+
+try:
+    iris.FUTURE.date_microseconds = True
+except AttributeError:
+    # Old iris version that doesn't support this override. Use old behaviour.
+    pass
 
 from .config import Config
 

--- a/pyaerocom/__init__.py
+++ b/pyaerocom/__init__.py
@@ -6,6 +6,13 @@ from ._warnings import ignore_basemap_warning, ignore_earth_radius_warning
 
 __version__ = metadata.version(__package__)
 
+import iris
+
+# Enable new iris functionality to suppress deprecation warning.
+# https://scitools-iris.readthedocs.io/en/latest/generated/api/iris.html#iris.FUTURE
+iris.FUTURE.save_split_attrs = True
+iris.FUTURE.date_microseconds = True
+
 from .config import Config
 
 # Instantiate default configuration


### PR DESCRIPTION
## Change Summary

Reduces warnings in tests by explicitly setting flags to enable new iris functionality.

## Related issue number

closes #1490
related to #1066 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
