### PR TITLE
Use tmpdir in all tests

### DIFF
--- a/tests/aeroval/test_bulkfraction_engine.py
+++ b/tests/aeroval/test_bulkfraction_engine.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import pytest
 import numpy as np
 from pathlib import Path
@@ -12,15 +13,23 @@ from tests.fixtures.aeroval import cfg_test_bulk
 
 
 @pytest.fixture
-def bulkengine_instance() -> BulkFractionEngine:
-    cfg = EvalSetup(**cfg_test_bulk.CFG)
-    bfe = BulkFractionEngine(cfg)
+def cfg(tmpdir) -> dict:
+    cfg = deepcopy(cfg_test_bulk.CFG)
+    cfg["json_basedir"] = f"{tmpdir}/data"
+    cfg["coldata_basedir"] = f"{tmpdir}/coldata"
+    return cfg
+
+
+@pytest.fixture
+def bulkengine_instance(cfg: dict) -> BulkFractionEngine:
+    setup = deepcopy(EvalSetup(**cfg))
+    bfe = BulkFractionEngine(setup)
     return bfe
 
 
-def test___init__():
-    cfg = EvalSetup(**cfg_test_bulk.CFG)
-    bfe = BulkFractionEngine(cfg)
+def test___init__(cfg: dict):
+    setup = EvalSetup(**cfg)
+    bfe = BulkFractionEngine(setup)
     assert isinstance(bfe, ProcessingEngine)
     assert isinstance(bfe, HasColocator)
 
@@ -204,10 +213,10 @@ def test_run(bulkengine_instance: BulkFractionEngine):
     assert Path(output.exp_dir).is_dir()
 
 
-def test_run_cfg():
+def test_run_cfg(cfg: dict):
     model_name = "TM5-AP3-CTRL"
-    cfg = EvalSetup(**cfg_test_bulk.CFG)
-    proc = ExperimentProcessor(cfg)
+    setup = EvalSetup(**cfg)
+    proc = ExperimentProcessor(setup)
     proc.exp_output.delete_experiment_data(also_coldata=True)
     proc.run(obs_name="AERONET-Sun", model_name="TM5-AP3-CTRL")
 

--- a/tests/aeroval/test_modelmaps_engine.py
+++ b/tests/aeroval/test_modelmaps_engine.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+import pathlib
 import pytest
 
 from pyaerocom.aeroval.modelmaps_engine import ModelMapsEngine
@@ -7,8 +9,17 @@ from pyaerocom import GriddedData
 from tests.fixtures.aeroval.cfg_test_exp1 import CFG
 
 
-def test__process_map_var():
-    stp = EvalSetup(**CFG)
+@pytest.fixture(scope="function")
+def cfg(tmpdir: pathlib.Path):
+    cfg = deepcopy(CFG)
+    cfg["json_basedir"] = f"{tmpdir}/data"
+    cfg["coldata_basedir"] = f"{tmpdir}/coldata"
+
+    return cfg
+
+
+def test__process_map_var(cfg: dict):
+    stp = EvalSetup(**cfg)
     engine = ModelMapsEngine(stp)
     with pytest.raises(ModelVarNotAvailable) as excinfo:
         engine._process_contour_map_var("LOTOS", "concco", False)
@@ -16,28 +27,27 @@ def test__process_map_var():
     assert "Cannot read data for model LOTOS" in str(excinfo.value)
 
 
-def test__run(caplog):
-    stp = EvalSetup(**CFG)
+def test__run(caplog, cfg: dict):
+    stp = EvalSetup(**cfg)
     engine = ModelMapsEngine(stp)
     engine.run(model_list=["TM5-AP3-CTRL"], var_list=["conco"])
     assert "no data for model TM5-AP3-CTRL, skipping" in caplog.text
 
 
-def test__run_working(caplog):
-    stp = EvalSetup(**CFG)
+def test__run_working(caplog, cfg: dict):
+    stp = EvalSetup(**cfg)
     engine = ModelMapsEngine(stp)
     files = engine.run(model_list=["TM5-AP3-CTRL"], var_list=["od550aer"])
-    assert "PATH_TO_AEROVAL_OUT/data/test/exp1/contour/od550aer_TM5-AP3-CTRL.geojson" in files
+    assert any([f.endswith("data/test/exp1/contour/od550aer_TM5-AP3-CTRL.geojson") for f in files])
 
 
 @pytest.mark.parametrize(
     "maps_freq, result",
     [("monthly", "monthly"), ("yearly", "yearly"), ("coarsest", "yearly")],
 )
-def test__get_maps_freq(maps_freq, result):
-    CFG2 = CFG.copy()
-    CFG2["maps_freq"] = maps_freq
-    stp = EvalSetup(**CFG2)
+def test__get_maps_freq(maps_freq, result, cfg: dict):
+    cfg["maps_freq"] = maps_freq
+    stp = EvalSetup(**cfg)
     engine = ModelMapsEngine(stp)
     freq = engine._get_maps_freq()
 
@@ -54,10 +64,9 @@ def test__get_maps_freq(maps_freq, result):
         ("coarsest", "daily", ["weekly", "daily"]),
     ],
 )
-def test__get_read_model_freq(maps_freq, result, ts_types):
-    CFG2 = CFG.copy()
-    CFG2["maps_freq"] = maps_freq
-    stp = EvalSetup(**CFG2)
+def test__get_read_model_freq(maps_freq, result, ts_types, cfg: dict):
+    cfg["maps_freq"] = maps_freq
+    stp = EvalSetup(**cfg)
     engine = ModelMapsEngine(stp)
     freq = engine._get_read_model_freq(ts_types)
 
@@ -74,21 +83,19 @@ def test__get_read_model_freq(maps_freq, result, ts_types):
         ),
     ],
 )
-def test__get_read_model_freq_error(maps_freq, ts_types, errormsg):
-    CFG2 = CFG.copy()
-    CFG2["maps_freq"] = maps_freq
-    stp = EvalSetup(**CFG2)
+def test__get_read_model_freq_error(maps_freq, ts_types, errormsg, cfg: dict):
+    cfg["maps_freq"] = maps_freq
+    stp = EvalSetup(**cfg)
     engine = ModelMapsEngine(stp)
 
     with pytest.raises(ValueError, match=errormsg):
         engine._get_read_model_freq(ts_types)
 
 
-def test__read_model_data():
+def test__read_model_data(cfg: dict):
     model_name = "TM5-AP3-CTRL"
     var_name = "od550aer"
-    CFG2 = CFG.copy()
-    stp = EvalSetup(**CFG2)
+    stp = EvalSetup(**cfg)
     engine = ModelMapsEngine(stp)
 
     data = engine._read_model_data(model_name, var_name)


### PR DESCRIPTION
## Change Summary

Changes the tests which write to pyaerocom root to use a tempdir.

## Related issue number

closes #1501

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
