### PR TITLE
Fix xarray warning

### DIFF
--- a/pyaerocom/aeroval/config/emep/reporting_base.py
+++ b/pyaerocom/aeroval/config/emep/reporting_base.py
@@ -894,6 +894,7 @@ def get_CFG(reportyear, year, model_dir) -> dict:
             obs_vars=[
                 "concNno2",
                 "vmro3",
+                "vmrox",
             ],
             pyaro_config={
                 "name": "EEA-h-diurnal-rural",
@@ -924,6 +925,8 @@ def get_CFG(reportyear, year, model_dir) -> dict:
                 "post_processing": [
                     "concNno2_from_concno2",
                     "vmro3_from_conco3",
+                    "vmrno2_from_concno2",
+                    "vmrox_from_vmrno2_vmro3",
                 ],
                 "dataset": "verified",
                 "station_area": [
@@ -999,6 +1002,7 @@ def get_CFG(reportyear, year, model_dir) -> dict:
             obs_vars=[
                 "concNno2",
                 "vmro3",
+                "vmrox",
             ],
             pyaro_config={
                 "name": "EEA-h-diurnal-all",
@@ -1029,6 +1033,8 @@ def get_CFG(reportyear, year, model_dir) -> dict:
                 "post_processing": [
                     "concNno2_from_concno2",
                     "vmro3_from_conco3",
+                    "vmrno2_from_concno2",
+                    "vmrox_from_vmrno2_vmro3",
                 ],
                 "dataset": "verified",
             },

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -1031,7 +1031,7 @@ def correct_model_stp_coldata(coldata, p0=None, t0=273.15, inplace=False):
     mintemps = []
     maxtemps = []
     ps = []
-    with xr.open_dataset(const.ERA5_SURFTEMP_FILE)["t2m"] as temp:
+    with xr.open_dataset(const.ERA5_SURFTEMP_FILE, decode_timedelta=True)["t2m"] as temp:
         for i, (lat, lon, alt, name) in enumerate(coords):
             logger.info(name, ", Lat", lat, ", Lon", lon)
             p = pressure(alt)

--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -200,7 +200,7 @@ def check_files(paths: list[Path]) -> list[Path]:
 
     for p in tqdm(paths, disable=None):
         try:
-            with xr.open_dataset(p) as ds:
+            with xr.open_dataset(p, decode_timedelta=True) as ds:
                 if len(ds.time.data) < 2:
                     logger.warning(f"To few timestamps in {p}. Skipping file")
                     continue

--- a/pyaerocom/io/ghost/reader.py
+++ b/pyaerocom/io/ghost/reader.py
@@ -339,7 +339,7 @@ class ReadGhost(ReadUngriddedBase):
         if var_to_write is None:
             var_to_write = self.var_names_data_inv[var_to_read]
 
-        with xr.open_dataset(filename) as ds:
+        with xr.open_dataset(filename, decode_timedelta=True) as ds:
             if not {"station", "time"}.issubset(ds.dims):  # pragma: no cover
                 raise AttributeError("Missing dimensions")
             if "station_name" not in ds:  # pragma: no cover

--- a/pyaerocom/io/mscw_ctm/reader.py
+++ b/pyaerocom/io/mscw_ctm/reader.py
@@ -340,7 +340,7 @@ class ReadMscwCtm(GriddedReader):
     @staticmethod
     @functools.cache
     def _get_year_from_nc(filename: str) -> int:
-        with xr.open_dataset(filename) as nc:
+        with xr.open_dataset(filename, decode_timedelta=True) as nc:
             return np.mean(nc["time"][:]).data.astype("datetime64[Y]").astype(int) + 1970
 
     def _get_yrs_from_filepaths(self) -> list[str]:
@@ -589,7 +589,7 @@ class ReadMscwCtm(GriddedReader):
             start_date = None
             end_date = None
             for fp in fps:
-                with xr.open_dataset(fp) as nc:
+                with xr.open_dataset(fp, decode_timedelta=True) as nc:
                     file_start_date = nc["time"][:].data.min()
                     file_end_date = nc["time"][:].data.max()
 

--- a/pyaerocom/io/pyaro/postprocess.py
+++ b/pyaerocom/io/pyaro/postprocess.py
@@ -87,7 +87,7 @@ TRANSFORMATIONS = {
         REQ_VAR="concno2",
         IN_UNIT="ug m-3",
         OUT_UNIT="ppb",
-        SCALING_FACTOR=0.5011,  # 20C and 1013 hPa TODO: CHECK THIS
+        SCALING_FACTOR=0.5229,  # 20C and 1013 hPa
         OUT_VARNAME="vmrno2",
         NOTE="The vmrno2_from_conco3 transform is only valid at T=20C, p=1013hPa",
     ),

--- a/pyaerocom/io/pyaro/postprocess.py
+++ b/pyaerocom/io/pyaro/postprocess.py
@@ -1,5 +1,7 @@
 import dataclasses
 
+import numpy as np
+
 from pyaro.timeseries import (
     Reader,
     Data,
@@ -23,6 +25,19 @@ class VariableScaling:
     def out_varname(self) -> str:
         return self.OUT_VARNAME
 
+@dataclasses.dataclass
+class VariableCombiner:
+    REQ_VARS: tuple[str, str]
+    IN_UNITS: tuple[str, str]
+    OUT_UNIT: str
+    OUT_VARNAME: str
+    OP: str
+
+    def required_input_variables(self) -> list[str]:
+        return self.REQ_VARS
+
+    def out_varname(self) -> str:
+        return self.OUT_VARNAME
 
 M_N = 14.006
 M_O = 15.999
@@ -66,6 +81,21 @@ TRANSFORMATIONS = {
         OUT_VARNAME="vmro3max",
         NOTE="The vmro3max_from_conco3 transform is only valid at T=20C, p=1013hPa, and the transform requires the use of resample_how to obtain the daily maximum",
     ),
+    "vmrno2_from_concno2": VariableScaling(
+        REQ_VAR="concno2",
+        IN_UNIT="ug m-3",
+        OUT_UNIT="ppb",
+        SCALING_FACTOR=0.5011,  # 20C and 1013 hPa TODO: CHECK THIS
+        OUT_VARNAME="vmrno2",
+        NOTE="The vmrno2_from_conco3 transform is only valid at T=20C, p=1013hPa",
+    ),
+    "vmrox_from_vmrno2_vmro3": VariableCombiner(
+        REQ_VARS=("vmrno2", "vmro3"),
+        IN_UNITS=("nmol mol-1", "nmol mol-1"),
+        OUT_UNIT="nmol mol-1",
+        OUT_VARNAME="vmrox",
+        OP="ADD",
+    )
 }
 
 
@@ -151,6 +181,7 @@ class PostProcessingReader(Reader):
                     raise Exception(
                         f"The transformation {compute_var} requires variables which are not present, missing {missing}"
                     )
+                known_variables.append(transform.out_varname())
                 self.compute_vars[transform.out_varname()] = transform
 
     def data(self, varname: str) -> Data:
@@ -167,6 +198,48 @@ class PostProcessingReader(Reader):
                 return PostProcessingReaderData(
                     data, variable=varname, units=transform.OUT_UNIT, scaling=scaling
                 )
+            if isinstance(transform, VariableCombiner):
+                data = [self.data(var) for var in transform.REQ_VARS]
+                scalings = [get_unit_conversion_fac(from_unit=d.units, to_unit=out_unit) for d, out_unit in zip(data, transform.IN_UNITS)]
+
+                # Find unique shared data based on lat/lon and times
+                groupbys = [
+                    np.array((d.latitudes, d.longitudes, d.start_times.astype(int), d.end_times.astype(int))).transpose()
+                    for d in data
+                ]
+                uniqs = [
+                    set(map(tuple, np.unique(group, axis=0).tolist()))
+                    for group in groupbys
+                ]
+                shared = np.array(list(set.intersection(*uniqs)))
+
+                n = shared.shape[0]
+                newdata = {
+                    "latitudes": shared[:, 0],
+                    "longitudes": shared[:, 1],
+                    "start_times": shared[:, 2].astype("datetime64[ns]"),
+                    "end_times": shared[:, 3].astype("datetime64[ns]"),
+                    "stations": ["" for _ in range(n)],
+                    "altitudes": np.nan * np.zeros(n),
+                    "values": np.nan * np.zeros(n),
+                    "standard_deviations": np.nan * np.zeros(n),
+                    "flags": np.ones(n),
+                }
+
+                altitudes = data[0].altitudes
+                stations = data[0].stations
+                values0 = data[0].values
+                values1 = data[1].values
+
+                for i, val in enumerate(shared):
+                    ind0 = np.nonzero(np.all(groupbys[0] == val, axis=1))[0][0]
+                    ind1 = np.nonzero(np.all(groupbys[1] == val, axis=1))[0][0]
+
+                    newdata["stations"][i] = str(stations[ind0])
+                    newdata["altitudes"][i] = altitudes[ind0]
+                    newdata["values"][i] = scalings[0] * values0[ind0] + scalings[1] * values1[ind1]
+                    
+                return DictlikeData(newdata, variable=transform.out_varname(), units=transform.OUT_UNIT)
             else:
                 raise Exception(
                     f"Unknown transform {transform} encountered for variable {varname}"
@@ -183,3 +256,59 @@ class PostProcessingReader(Reader):
 
     def close(self) -> None:
         self.reader.close()
+
+        
+class DictlikeData(Data):
+    def __init__(self, data, variable: str, units: str):
+        self._variable = variable
+        self._units = units
+        self._data = data
+
+    def keys(self):
+        return {}.keys()
+
+    def slice(self, index):
+        return DictlikeData(
+            data=self._data()[index],
+            variable=self._variable,
+            units=self._units,
+        )
+
+    def __len__(self):
+        return len(self.values)
+
+    @property
+    def values(self):
+        return self._data["values"]
+
+    @property
+    def stations(self):
+        return self._data["stations"]
+
+    @property
+    def latitudes(self):
+        return self._data["latitudes"]
+
+    @property
+    def longitudes(self):
+        return self._data["longitudes"]
+
+    @property
+    def altitudes(self):
+        return self._data["altitudes"]
+
+    @property
+    def start_times(self):
+        return self._data["start_times"]
+
+    @property
+    def end_times(self):
+        return self._data["end_times"]
+
+    @property
+    def flags(self):
+        return self._data["flags"]
+
+    @property
+    def standard_deviations(self):
+        return self._data["standard_deviations"]

--- a/pyaerocom/io/pyaro/postprocess.py
+++ b/pyaerocom/io/pyaro/postprocess.py
@@ -1,6 +1,7 @@
 import dataclasses
 
 import numpy as np
+import numpy.typing as npt
 
 from pyaro.timeseries import (
     Reader,
@@ -274,7 +275,7 @@ class PostProcessingReader(Reader):
                     }
                 )
 
-                return DictlikeData(
+                return DictBackedData(
                     newdata, variable=transform.out_varname(), units=transform.OUT_UNIT
                 )
             else:
@@ -295,12 +296,11 @@ class PostProcessingReader(Reader):
         self.reader.close()
 
 
-def matching_indices(x, y):
+def matching_indices(x, y) -> tuple[npt.NDArray[int], npt.NDArray[int]]:
     """Returns indices of x and y such that x[xind] == y[yind]
     x and y must be monotonically increasing
     """
     x_indices, y_indices = list(), list()
-    # for (x, y) in left_and_right_matches(x, y):
     ix, iy = 0, 0
     while (ix < len(x)) and (iy < len(y)):
         le = x[ix]
@@ -318,7 +318,7 @@ def matching_indices(x, y):
     return x_indices, y_indices
 
 
-class DictlikeData(Data):
+class DictBackedData(Data):
     def __init__(self, data, variable: str, units: str):
         self._variable = variable
         self._units = units
@@ -328,7 +328,7 @@ class DictlikeData(Data):
         return {}.keys()
 
     def slice(self, index):
-        return DictlikeData(
+        return DictBackedData(
             data=self._data()[index],
             variable=self._variable,
             units=self._units,

--- a/pyaerocom/io/pyaro/postprocess.py
+++ b/pyaerocom/io/pyaro/postprocess.py
@@ -238,17 +238,20 @@ class PostProcessingReader(Reader):
                     lindex, rindex = matching_indices(start_times[0], start_times[1])
 
                     if not np.all(end_times[0][lindex] == end_times[1][rindex]):
-                        raise Exception("Different durations encountered")
+                        continue  # Different durations encountered, skip this station
 
-                    new_latitudes.append(lat*np.ones(len(lindex)))
-                    new_longitudes.append(lon*np.ones(len(lindex)))
+                    new_latitudes.append(lat * np.ones(len(lindex)))
+                    new_longitudes.append(lon * np.ones(len(lindex)))
                     new_starttimes.append(start_times[0][lindex])
                     new_endtimes.append(start_times[0][lindex])
                     new_stations.append(stations[lindex])
                     new_altitudes.append(altitudes[lindex])
 
                     if transform.OP == "ADD":
-                        values = data_subset[0].values[lindex] * scalings[0] + data_subset[1].values[rindex] * scalings[1]
+                        values = (
+                            data_subset[0].values[lindex] * scalings[0]
+                            + data_subset[1].values[rindex] * scalings[1]
+                        )
                     else:
                         raise Exception(f"Transform mode {transform.OP} is not supported")
                     new_values.append(values)
@@ -262,12 +265,14 @@ class PostProcessingReader(Reader):
                     "altitudes": np.concatenate(new_altitudes),
                     "values": np.concatenate(new_values),
                 }
-                
+
                 n = len(newdata["latitudes"])
-                newdata.update({
-                    "standard_deviations": np.nan * np.zeros(n),
-                    "flags": np.ones(n),
-                })
+                newdata.update(
+                    {
+                        "standard_deviations": np.nan * np.zeros(n),
+                        "flags": np.ones(n),
+                    }
+                )
 
                 return DictlikeData(
                     newdata, variable=transform.out_varname(), units=transform.OUT_UNIT

--- a/pyaerocom/io/read_earlinet.py
+++ b/pyaerocom/io/read_earlinet.py
@@ -226,7 +226,7 @@ class ReadEarlinet(ReadUngriddedBase):
         # Iterate over the lines of the file
         self.logger.debug(f"Reading file {filename}")
 
-        with xarray.open_dataset(filename, engine="netcdf4") as data_in:
+        with xarray.open_dataset(filename, engine="netcdf4", decode_timedelta=True) as data_in:
             for filter in self.CLOUD_FILTERS:
                 if filter in data_in.variables:
                     if data_in.variables[filter].item() == self.CLOUD_FILTERS[filter]:

--- a/pyaerocom/scripts/testdata-minimal/create_subsets_ghost.py
+++ b/pyaerocom/scripts/testdata-minimal/create_subsets_ghost.py
@@ -66,7 +66,7 @@ for dsname in datasets:
                 print(file_out)
                 assert os.path.exists(file_in)
 
-                with xr.open_dataset(file_in) as ds:
+                with xr.open_dataset(file_in, decode_timedelta=True) as ds:
                     subset = ds.isel(station=slice(0, numst))
                     if numts is not None:
                         subset = subset.isel(time=slice(0, numts))

--- a/scripts/aeolus2netcdf.py
+++ b/scripts/aeolus2netcdf.py
@@ -403,7 +403,7 @@ def main():
 
         # read topography since that needs to be added to the ground following height of the model
         obj.logger.info("reading topography file {}".format(options["topofile"]))
-        topo_data = xr.open_dataset(options["topofile"])
+        topo_data = xr.open_dataset(options["topofile"], decode_timedelta=True)
 
         # truncate Aeolus times to hour
 
@@ -431,7 +431,7 @@ def main():
             if file_name != last_netcdf_file:
                 obj.logger.info(f"reading and co-locating on model file {file_name}")
                 last_netcdf_file = file_name
-                nc_data = xr.open_dataset(file_name)
+                nc_data = xr.open_dataset(file_name, decode_timedelta=True)
                 nc_times = nc_data.time.data.astype("datetime64[h]")
                 nc_latitudes = nc_data["lat"].data
                 nc_longitudes = nc_data["lon"].data

--- a/tests/test_projection_info.py
+++ b/tests/test_projection_info.py
@@ -8,7 +8,9 @@ ROOT = TEST_DATA["MODELS"].path
 
 
 def test_projection_information():
-    with xarray.open_dataset(str(ROOT / "emep4no20240630" / "Base_hour.nc")) as ds:
+    with xarray.open_dataset(
+        str(ROOT / "emep4no20240630" / "Base_hour.nc"), decode_timedelta=True
+    ) as ds:
         pi = ProjectionInformation.from_xarray(ds, "SURF_ug_PM10_rh50")
         assert pi is not None
         assert pi.x_axis == "i"


### PR DESCRIPTION
## Change Summary

Missed an xarray warning in #1502 which didn't surface in the tests surprisingly enough.

```
FutureWarning: In a future version of xarray decode_timedelta will default to False rather than None. To silence this warning, set decode_timedelta to True, False, or a 'CFTimedeltaCoder' instance.
  with xr.open_mfdataset(list(UEMEP_PATH.glob("*.nc")), engine="netcdf4") as dt:
```

This sets `decode_timedelta` to true for all opendataset calls, which maintains the old behaviour.

## Related issue number

#1066

## Checklist

* [ ] Start with a draft-PR
* [ ] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
