### PR TITLE
Set decode_timedelta=True to silence xarray warning

### DIFF
--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -1031,7 +1031,7 @@ def correct_model_stp_coldata(coldata, p0=None, t0=273.15, inplace=False):
     mintemps = []
     maxtemps = []
     ps = []
-    with xr.open_dataset(const.ERA5_SURFTEMP_FILE)["t2m"] as temp:
+    with xr.open_dataset(const.ERA5_SURFTEMP_FILE, decode_timedelta=True)["t2m"] as temp:
         for i, (lat, lon, alt, name) in enumerate(coords):
             logger.info(name, ", Lat", lat, ", Lon", lon)
             p = pressure(alt)

--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -200,7 +200,7 @@ def check_files(paths: list[Path]) -> list[Path]:
 
     for p in tqdm(paths, disable=None):
         try:
-            with xr.open_dataset(p) as ds:
+            with xr.open_dataset(p, decode_timedelta=True) as ds:
                 if len(ds.time.data) < 2:
                     logger.warning(f"To few timestamps in {p}. Skipping file")
                     continue

--- a/pyaerocom/io/cnemc/reader.py
+++ b/pyaerocom/io/cnemc/reader.py
@@ -181,7 +181,12 @@ class ReadCNEMC(ReadUngriddedBase):
 
     def _read_dataset(self, paths: list[Path]) -> xr.Dataset:
         ds = xr.open_mfdataset(
-            sorted(paths), concat_dim="time", combine="nested", parallel=True, decode_cf=True
+            sorted(paths),
+            concat_dim="time",
+            combine="nested",
+            parallel=True,
+            decode_cf=True,
+            decode_timedelta=True,
         )
         ds = ds.rename({v: k for k, v in self.VAR_MAPPING.items()})
         ds = ds.assign(

--- a/pyaerocom/io/ghost/reader.py
+++ b/pyaerocom/io/ghost/reader.py
@@ -339,7 +339,7 @@ class ReadGhost(ReadUngriddedBase):
         if var_to_write is None:
             var_to_write = self.var_names_data_inv[var_to_read]
 
-        with xr.open_dataset(filename) as ds:
+        with xr.open_dataset(filename, decode_timedelta=True) as ds:
             if not {"station", "time"}.issubset(ds.dims):  # pragma: no cover
                 raise AttributeError("Missing dimensions")
             if "station_name" not in ds:  # pragma: no cover

--- a/pyaerocom/io/icos/reader.py
+++ b/pyaerocom/io/icos/reader.py
@@ -171,6 +171,7 @@ class ReadICOS(ReadCNEMC):
             combine="nested",
             parallel=True,
             decode_cf=True,
+            decode_timedelta=True,
         )
 
     @classmethod

--- a/pyaerocom/io/mscw_ctm/reader.py
+++ b/pyaerocom/io/mscw_ctm/reader.py
@@ -602,7 +602,7 @@ class ReadMscwCtm(GriddedReader):
                 )
 
         logger.info(f"Opening {fps}")
-        ds = xr.open_mfdataset(fps, chunks={"time": 24})
+        ds = xr.open_mfdataset(fps, chunks={"time": 24}, decode_timedelta=True)
 
         self._private.filedata = ds
 

--- a/pyaerocom/io/mscw_ctm/reader.py
+++ b/pyaerocom/io/mscw_ctm/reader.py
@@ -340,7 +340,7 @@ class ReadMscwCtm(GriddedReader):
     @staticmethod
     @functools.cache
     def _get_year_from_nc(filename: str) -> int:
-        with xr.open_dataset(filename) as nc:
+        with xr.open_dataset(filename, decode_timedelta=True) as nc:
             return np.mean(nc["time"][:]).data.astype("datetime64[Y]").astype(int) + 1970
 
     def _get_yrs_from_filepaths(self) -> list[str]:
@@ -589,7 +589,7 @@ class ReadMscwCtm(GriddedReader):
             start_date = None
             end_date = None
             for fp in fps:
-                with xr.open_dataset(fp) as nc:
+                with xr.open_dataset(fp, decode_timedelta=True) as nc:
                     file_start_date = nc["time"][:].data.min()
                     file_end_date = nc["time"][:].data.max()
 

--- a/pyaerocom/io/read_earlinet.py
+++ b/pyaerocom/io/read_earlinet.py
@@ -226,7 +226,7 @@ class ReadEarlinet(ReadUngriddedBase):
         # Iterate over the lines of the file
         self.logger.debug(f"Reading file {filename}")
 
-        with xarray.open_dataset(filename, engine="netcdf4") as data_in:
+        with xarray.open_dataset(filename, engine="netcdf4", decode_timedelta=True) as data_in:
             for filter in self.CLOUD_FILTERS:
                 if filter in data_in.variables:
                     if data_in.variables[filter].item() == self.CLOUD_FILTERS[filter]:

--- a/pyaerocom/scripts/testdata-minimal/create_subsets_ghost.py
+++ b/pyaerocom/scripts/testdata-minimal/create_subsets_ghost.py
@@ -66,7 +66,7 @@ for dsname in datasets:
                 print(file_out)
                 assert os.path.exists(file_in)
 
-                with xr.open_dataset(file_in) as ds:
+                with xr.open_dataset(file_in, decode_timedelta=True) as ds:
                     subset = ds.isel(station=slice(0, numst))
                     if numts is not None:
                         subset = subset.isel(time=slice(0, numts))

--- a/scripts/aeolus2netcdf.py
+++ b/scripts/aeolus2netcdf.py
@@ -403,7 +403,7 @@ def main():
 
         # read topography since that needs to be added to the ground following height of the model
         obj.logger.info("reading topography file {}".format(options["topofile"]))
-        topo_data = xr.open_dataset(options["topofile"])
+        topo_data = xr.open_dataset(options["topofile"], decode_timedelta=True)
 
         # truncate Aeolus times to hour
 
@@ -431,7 +431,7 @@ def main():
             if file_name != last_netcdf_file:
                 obj.logger.info(f"reading and co-locating on model file {file_name}")
                 last_netcdf_file = file_name
-                nc_data = xr.open_dataset(file_name)
+                nc_data = xr.open_dataset(file_name, decode_timedelta=True)
                 nc_times = nc_data.time.data.astype("datetime64[h]")
                 nc_latitudes = nc_data["lat"].data
                 nc_longitudes = nc_data["lon"].data

--- a/tests/test_projection_info.py
+++ b/tests/test_projection_info.py
@@ -8,7 +8,9 @@ ROOT = TEST_DATA["MODELS"].path
 
 
 def test_projection_information():
-    with xarray.open_dataset(str(ROOT / "emep4no20240630" / "Base_hour.nc")) as ds:
+    with xarray.open_dataset(
+        str(ROOT / "emep4no20240630" / "Base_hour.nc"), decode_timedelta=True
+    ) as ds:
         pi = ProjectionInformation.from_xarray(ds, "SURF_ug_PM10_rh50")
         assert pi is not None
         assert pi.x_axis == "i"


### PR DESCRIPTION
## Change Summary

Missed an xarray warning in #1502 which didn't surface in the tests surprisingly enough.

```
FutureWarning: In a future version of xarray decode_timedelta will default to False rather than None. To silence this warning, set decode_timedelta to True, False, or a 'CFTimedeltaCoder' instance.
  with xr.open_mfdataset(list(UEMEP_PATH.glob("*.nc")), engine="netcdf4") as dt:
```

This sets `decode_timedelta` to true for all opendataset calls, which maintains the old behaviour.

## Related issue number

#1066

## Checklist

* [ ] Start with a draft-PR
* [ ] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
