### PR TITLE
fix logic to extract parameters from file names in the contour subfolder

### DIFF
--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -15,6 +15,7 @@ from pyaerocom._lowlevel_helpers import (
     TypeValidator,
     sort_dict_by_name,
 )
+from pyaerocom.aeroval import EvalSetup
 from pyaerocom.aeroval.collections import ObsCollection
 from pyaerocom.aeroval.glob_defaults import (
     VariableInfo,
@@ -28,7 +29,6 @@ from pyaerocom.aeroval.glob_defaults import (
 )
 from pyaerocom.aeroval.json_utils import round_floats
 from pyaerocom.aeroval.modelentry import ModelEntry
-from pyaerocom.aeroval import EvalSetup
 from pyaerocom.aeroval.varinfo_web import VarinfoWeb
 from pyaerocom.colocation.colocated_data import ColocatedData
 from pyaerocom.exceptions import EntryNotAvailable, VariableDefinitionError
@@ -339,18 +339,22 @@ class ExperimentOutput(ProjectOutput):
         str
             Time period
         """
-        spl = os.path.basename(file.name).split(file.suffix)[0].split("_")
+        suffix = file.suffix
+        spl = os.path.basename(file.name).split(suffix)[0].split("_")
 
-        if len(spl) == 3:  # png, webp
-            name = spl[0]
-            var_name = spl[1]
-            per = spl[2]
-            return (name, var_name, per)
-        elif len(spl) == 2:  # geojson
-            name = spl[1]
-            var_name = spl[0]
-            per = None
-            return (name, var_name, per)
+        if len(spl) == 3:
+            if suffix == ".png" or suffix == ".webp":
+                name = spl[0]
+                var_name = spl[1]
+                per = spl[2]
+                return (name, var_name, per)
+            elif suffix == ".geojson":
+                name = spl[1]
+                var_name = spl[0]
+                per = None
+                return (name, var_name, per)
+            else:
+                raise NotImplementedError(f"{suffix} file format not supported")
         else:
             raise ValueError(f"invalid contour filename: {file}")
 

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -343,12 +343,7 @@ class ExperimentOutput(ProjectOutput):
         spl = os.path.basename(file.name).split(suffix)[0].split("_")
 
         if len(spl) == 3:
-            if suffix == ".png" or suffix == ".webp":
-                name = spl[0]
-                var_name = spl[1]
-                per = spl[2]
-                return (name, var_name, per)
-            elif suffix == ".geojson":
+            if suffix == ".png" or suffix == ".webp" or suffix == ".geojson":
                 name = spl[1]
                 var_name = spl[0]
                 per = spl[2]

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -351,7 +351,7 @@ class ExperimentOutput(ProjectOutput):
             elif suffix == ".geojson":
                 name = spl[1]
                 var_name = spl[0]
-                per = None
+                per = spl[2]
                 return (name, var_name, per)
             else:
                 raise NotImplementedError(f"{suffix} file format not supported")

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
+import pathlib
 from pathlib import Path
 
 import aerovaldb
 import pytest
 
 from pyaerocom import const
-from pyaerocom.aeroval import ExperimentProcessor
+from pyaerocom.aeroval import EvalSetup, ExperimentProcessor
 from pyaerocom.aeroval.experiment_output import ExperimentOutput, ProjectOutput
 from pyaerocom.aeroval.json_utils import read_json, write_json
-from pyaerocom.aeroval import EvalSetup
-import pathlib
 
 BASEDIR_DEFAULT = Path(const.OUTPUTDIR) / "aeroval" / "data"
 
@@ -175,17 +174,23 @@ def test_ExperimentOutput__info_from_map_file_error(filename: str):
 
 
 def test_ExperimentOutput__info_from_contour_dir_file():
-    file = pathlib.PosixPath("path/to/name_vertical_period.txt")
+    file = pathlib.PosixPath("path/to/name_vertical_period.webp")
     output = ExperimentOutput._info_from_contour_dir_file(file)
-
     assert output == ("name", "vertical", "period")
 
 
 def test_ExperimentOutput__info_from_contour_dir_file_error():
-    file = pathlib.PosixPath("path/to/obs_vertical_model_period.txt")
+    file = pathlib.PosixPath("path/to/obs_vertical_model_period.geojson")
     with pytest.raises(ValueError) as e:
         ExperimentOutput._info_from_contour_dir_file(file)
     assert "invalid contour filename" in str(e.value)
+
+
+def test_ExperimentOutput__info_from_contour_dir_file_error_extension():
+    file = pathlib.PosixPath("path/to/name_vertical_period.txt")
+    with pytest.raises(NotImplementedError) as e:
+        ExperimentOutput._info_from_contour_dir_file(file)
+    assert ".txt file format not supported" in str(e.value)
 
 
 def test_ExperimentOutput__results_summary_EMPTY(dummy_expout: ExperimentOutput):

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -173,10 +173,16 @@ def test_ExperimentOutput__info_from_map_file_error(filename: str):
     )
 
 
-def test_ExperimentOutput__info_from_contour_dir_file():
+def test_ExperimentOutput__info_from_contour_dir_file_webp():
     file = pathlib.PosixPath("path/to/name_vertical_period.webp")
     output = ExperimentOutput._info_from_contour_dir_file(file)
     assert output == ("name", "vertical", "period")
+
+
+def test_ExperimentOutput__info_from_contour_dir_file_geojson():
+    file = pathlib.PosixPath("path/to/var_model_period.geojson")
+    output = ExperimentOutput._info_from_contour_dir_file(file)
+    assert output == ("model", "var", "period")
 
 
 def test_ExperimentOutput__info_from_contour_dir_file_error():

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -174,9 +174,9 @@ def test_ExperimentOutput__info_from_map_file_error(filename: str):
 
 
 def test_ExperimentOutput__info_from_contour_dir_file_webp():
-    file = pathlib.PosixPath("path/to/name_vertical_period.webp")
+    file = pathlib.PosixPath("path/to/var_name_period.webp")
     output = ExperimentOutput._info_from_contour_dir_file(file)
-    assert output == ("name", "vertical", "period")
+    assert output == ("name", "var", "period")
 
 
 def test_ExperimentOutput__info_from_contour_dir_file_geojson():


### PR DESCRIPTION
## Change Summary
extraction of parameters from file names in the contour folder cannot be discriminated anymore on the pure base of how many `_`-separated substrings they contain

## Related issue number 
fix #1509

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
