### PR TITLE
fix broken paths and remove unused returns in ModelMapsEngine 

### DIFF
--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -175,7 +175,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         try:
             data = self._read_model_data(model_name, var)
         except Exception as e:
-            raise VarNotAvailableError(
+            raise ModelVarNotAvailable(
                 f"Cannot read data for model {model_name} (variable {var}): {e}"
             )
 

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -1,32 +1,31 @@
 import glob
 import logging
 import os
+
 import xarray as xr
 
-
-from pyaerocom import GriddedData, TsType, const, __version__, ColocatedData
+from pyaerocom import ColocatedData, GriddedData, TsType, __version__, const
 from pyaerocom.aeroval._processing_base import DataImporter, ProcessingEngine
+from pyaerocom.aeroval.json_utils import round_floats
 from pyaerocom.aeroval.modelmaps_helpers import (
-    calc_contour_json,
-    plot_overlay_pixel_maps,
-    _jsdate_list,
     CONTOUR,
     OVERLAY,
+    _jsdate_list,
+    calc_contour_json,
     find_netcdf_files,
+    plot_overlay_pixel_maps,
 )
-from pyaerocom.aeroval.json_utils import round_floats
-from pyaerocom.colocation.colocator import Colocator
-
 from pyaerocom.aeroval.varinfo_web import VarinfoWeb
+from pyaerocom.colocation.colocator import Colocator
 from pyaerocom.exceptions import (
     DataCoverageError,
     DataDimensionError,
     DataQueryError,
+    EntryNotAvailable,
     ModelVarNotAvailable,
     TemporalResolutionError,
     VariableDefinitionError,
     VarNotAvailableError,
-    EntryNotAvailable,
 )
 
 logger = logging.getLogger(__name__)
@@ -53,22 +52,21 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
     def run(self, **kwargs):
         model_list, var_list = self._get_run_kwargs(**kwargs)
 
-        all_files = []
         for model in model_list:
+            success = True
             try:
-                files = self._run_model(model, var_list)
+                self._run_model(model, var_list)
             except VarNotAvailableError:
-                files = []
-            if not files:
+                success = False
+            if not success:
                 logger.warning(f"no data for model {model}, skipping")
                 continue
-            all_files.extend(files)
 
         self.cfg.modelmaps_opts.maps_freq = (
             self._get_maps_freq()
         )  # if needed, reassign "coarsest" to actual coarsest frequency
 
-        return files
+        return
 
     def _get_vars_to_process(self, model_name, var_list):
         mvars = self.cfg.model_cfg.get_entry(model_name).get_vars_to_process(
@@ -108,8 +106,8 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
             var_list = self._get_vars_to_process(model_name, var_list)
         except EntryNotAvailable:
             var_list = self._get_obs_vars_to_process(model_name, var_list)
-
-        files = []
+        if not var_list:
+            raise VarNotAvailableError("List of variables is empty.")
         for var in var_list:
             logger.info(f"Processing model maps for {model_name} ({var})")
 
@@ -123,21 +121,11 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                         model_name, False
                     )
                 if self.cfg.modelmaps_opts.plot_types == {CONTOUR} or make_contour:
-                    _files = self._process_contour_map_var(
-                        model_name, var, self.reanalyse_existing
-                    )
+                    self._process_contour_map_var(model_name, var, self.reanalyse_existing)
 
-                    if isinstance(_files, str):
-                        _files = [_files]
-                    files.extend(_files)
                 if self.cfg.modelmaps_opts.plot_types == {OVERLAY} or make_overlay:
                     # create overlay (pixel) plots
-                    _files = self._process_overlay_map_var(
-                        model_name, var, self.reanalyse_existing
-                    )
-                    if isinstance(_files, str):
-                        _files = [_files]
-                    files.extend(_files)
+                    self._process_overlay_map_var(model_name, var, self.reanalyse_existing)
 
             except ModelVarNotAvailable as ex:
                 logger.warning(f"{ex}")
@@ -150,8 +138,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                 if self.raise_exceptions:
                     raise
                 logger.warning(f"Failed to process maps for {model_name} {var} data. Reason: {e}.")
-
-        return files
+        return
 
     def _check_dimensions(self, data: GriddedData) -> "GriddedData":
         if not data.has_latlon_dims:
@@ -188,7 +175,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         try:
             data = self._read_model_data(model_name, var)
         except Exception as e:
-            raise ModelVarNotAvailable(
+            raise VarNotAvailableError(
                 f"Cannot read data for model {model_name} (variable {var}): {e}"
             )
 
@@ -202,15 +189,6 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
 
         data = self._check_dimensions(data)
 
-        outdir = self.cfg.path_manager.get_json_output_dirs()["contour"]
-        outname = f"{var}_{model_name}"
-        fp_geojson = os.path.join(outdir, f"{outname}.geojson")
-
-        if not reanalyse_existing:
-            if os.path.exists(fp_geojson):
-                logger.info(f"Skipping contour processing of {outname}: data already exists.")
-                return []
-
         freq = self._get_maps_freq()
         tst = TsType(data.ts_type)
 
@@ -220,6 +198,22 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
             data = data.resample_time(str(freq))
 
         data.check_unit()
+
+        if not reanalyse_existing:
+            # check if all files have already been produced
+            # if even just one is missing, all is gonna be recomputed
+            ts = _jsdate_list(data)
+            fps_geojson = []
+            outdir = self.cfg.path_manager.get_json_output_dirs()["contour"]
+            for i, date in enumerate(ts):
+                outname = f"{var}_{model_name}/{var}_{model_name}_{date}"
+                fps_geojson.append(os.path.join(outdir, f"{outname}.geojson"))
+            if all(os.path.exists(fp) for fp in fps_geojson):
+                logger.info(
+                    f"Skipping contour processing of {var}_{model_name}: data already exists {fps_geojson}."
+                )
+                return
+
         # first calcualate and save geojson with contour levels
         contourjson = calc_contour_json(data, cmap=varinfo.cmap, cmap_bins=varinfo.cmap_bins)
 
@@ -233,8 +227,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                     model_name,
                     timestep=time,
                 )
-
-        return fp_geojson
+        return
 
     def _process_overlay_map_var(self, model_name, var, reanalyse_existing):  # pragma: no cover
         """Process overlay map (pixels) for either model or obserations
@@ -270,8 +263,6 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         if not self.cfg.processing_opts.only_json:
             data = self._check_dimensions(data)
 
-        outdir = self.cfg.path_manager.get_json_output_dirs()["contour/overlay"]
-
         freq = self._get_maps_freq()
 
         tst = TsType(data.ts_type)
@@ -284,21 +275,23 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
             elif isinstance(data, xr.DataArray):
                 data = data.resample(time=str(freq)[0].capitalize()).mean()
 
-        tst = _jsdate_list(data)
+        ts = _jsdate_list(data)
         if isinstance(data, GriddedData):
             data.check_unit()
             data = data.to_xarray().load()
-        files = []
 
         if self.cfg.processing_opts.only_model_maps:
-            self._check_ts_for_only_model_maps(model_name, var, tst, data)
-        for i, date in enumerate(tst):
+            self._check_ts_for_only_model_maps(model_name, var, ts, data)
+
+        outdir = self.cfg.path_manager.get_json_output_dirs()["contour/overlay"]
+
+        for i, date in enumerate(ts):
             write_var_name = self.cfg.model_cfg.get_entry(model_name).model_rename_vars.get(
                 var, var
             )
-            outname = f"{model_name}_{write_var_name}_{date}"
 
-            # Note should matche the output location defined in aerovaldb
+            # Note this should match the output location defined in aerovaldb
+            outname = f"{write_var_name}_{model_name}_{date}.{self.cfg.modelmaps_opts.overlay_save_format}"
             fp_overlay = os.path.join(outdir, outname)
 
             if not reanalyse_existing:
@@ -322,8 +315,7 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                     write_var_name,
                     date,
                 )
-            files.append(fp_overlay + "." + self.cfg.modelmaps_opts.overlay_save_format)
-        return files
+        return
 
     def _get_maps_freq(self) -> TsType:
         """

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -63,8 +63,6 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
             self._get_maps_freq()
         )  # if needed, reassign "coarsest" to actual coarsest frequency
 
-        return
-
     def _get_vars_to_process(self, model_name, var_list):
         mvars = self.cfg.model_cfg.get_entry(model_name).get_vars_to_process(
             self.cfg.obs_cfg.get_all_vars()

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -53,12 +53,9 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         model_list, var_list = self._get_run_kwargs(**kwargs)
 
         for model in model_list:
-            success = True
             try:
                 self._run_model(model, var_list)
             except VarNotAvailableError:
-                success = False
-            if not success:
                 logger.warning(f"no data for model {model}, skipping")
                 continue
 
@@ -227,7 +224,6 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                     model_name,
                     timestep=time,
                 )
-        return
 
     def _process_overlay_map_var(self, model_name, var, reanalyse_existing):  # pragma: no cover
         """Process overlay map (pixels) for either model or obserations
@@ -315,7 +311,6 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                     write_var_name,
                     date,
                 )
-        return
 
     def _get_maps_freq(self) -> TsType:
         """

--- a/tests/aeroval/test_modelmaps_engine.py
+++ b/tests/aeroval/test_modelmaps_engine.py
@@ -105,5 +105,3 @@ def test__read_model_data(cfg: dict):
     data = engine._read_model_data(model_name, var_name)
 
     assert isinstance(data, GriddedData)
-    assert isinstance(data, GriddedData)
-    assert isinstance(data, GriddedData)

--- a/tests/aeroval/test_modelmaps_engine.py
+++ b/tests/aeroval/test_modelmaps_engine.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 from copy import deepcopy
 
+import aerovaldb
 import pytest
 
 from pyaerocom import GriddedData
@@ -45,23 +46,18 @@ def test__run_reanalysefalse(tmp_path, caplog, cfg: dict):
     cfg["periods"] = ["20100615"]
     cfg["main_freq"] = "daily"
 
+    json_basedir = tmp_path / "data"
+    cfg["json_basedir"] = json_basedir
     # create expected geojson output file (empty file is ok:
     # in the case reanalyse_existing=False content is not checked, only existence)
-    json_basedir = tmp_path / "data"
-    output_file = (
-        json_basedir
-        / "test/exp1/contour/od550aer_TM5-AP3-CTRL/od550aer_TM5-AP3-CTRL_1277942400000.geojson"
-    )
-    output_file.mkdir(parents=True)
-    output_file.touch()
-    cfg["json_basedir"] = json_basedir
+    with aerovaldb.open(f"json_files:{json_basedir}") as db:
+        db.put_contour("", "test", "exp1", "od550aer", "TM5-AP3-CTRL", timestep="1277942400000")
 
     stp = EvalSetup(**cfg)
     engine = ModelMapsEngine(stp)
     engine.run(model_list=["TM5-AP3-CTRL"], var_list=["od550aer"])
     assert (
-        f"Skipping contour processing of od550aer_TM5-AP3-CTRL: data already exists ['{output_file}']"
-        in caplog.text
+        "Skipping contour processing of od550aer_TM5-AP3-CTRL: data already exists" in caplog.text
     )
 
 

--- a/tests/aeroval/test_modelmaps_engine.py
+++ b/tests/aeroval/test_modelmaps_engine.py
@@ -40,9 +40,8 @@ def test__run_working(cfg: dict):
     stp = EvalSetup(**cfg)
     engine = ModelMapsEngine(stp)
     engine.run(model_list=["TM5-AP3-CTRL"], var_list=["od550aer"])
-    assert os.path.exists(
-        f"{stp.path_manager.get_json_output_dirs()["contour"]}/od550aer_TM5-AP3-CTRL/"
-    )
+    outdirbase = stp.path_manager.get_json_output_dirs()["contour"]
+    assert os.path.exists(f"{outdirbase}/od550aer_TM5-AP3-CTRL/")
 
 
 @pytest.mark.parametrize(

--- a/tests/aeroval/test_modelmaps_engine.py
+++ b/tests/aeroval/test_modelmaps_engine.py
@@ -1,11 +1,13 @@
-from copy import deepcopy
+import os
 import pathlib
+from copy import deepcopy
+
 import pytest
 
-from pyaerocom.aeroval.modelmaps_engine import ModelMapsEngine
-from pyaerocom.aeroval import EvalSetup
-from pyaerocom.exceptions import ModelVarNotAvailable
 from pyaerocom import GriddedData
+from pyaerocom.aeroval import EvalSetup
+from pyaerocom.aeroval.modelmaps_engine import ModelMapsEngine
+from pyaerocom.exceptions import ModelVarNotAvailable
 from tests.fixtures.aeroval.cfg_test_exp1 import CFG
 
 
@@ -34,11 +36,13 @@ def test__run(caplog, cfg: dict):
     assert "no data for model TM5-AP3-CTRL, skipping" in caplog.text
 
 
-def test__run_working(caplog, cfg: dict):
+def test__run_working(cfg: dict):
     stp = EvalSetup(**cfg)
     engine = ModelMapsEngine(stp)
-    files = engine.run(model_list=["TM5-AP3-CTRL"], var_list=["od550aer"])
-    assert any([f.endswith("data/test/exp1/contour/od550aer_TM5-AP3-CTRL.geojson") for f in files])
+    engine.run(model_list=["TM5-AP3-CTRL"], var_list=["od550aer"])
+    assert os.path.exists(
+        f"{stp.path_manager.get_json_output_dirs()["contour"]}/od550aer_TM5-AP3-CTRL/"
+    )
 
 
 @pytest.mark.parametrize(
@@ -100,4 +104,6 @@ def test__read_model_data(cfg: dict):
 
     data = engine._read_model_data(model_name, var_name)
 
+    assert isinstance(data, GriddedData)
+    assert isinstance(data, GriddedData)
     assert isinstance(data, GriddedData)

--- a/tests/aeroval/test_modelmaps_engine.py
+++ b/tests/aeroval/test_modelmaps_engine.py
@@ -36,6 +36,32 @@ def test__run(caplog, cfg: dict):
     assert "no data for model TM5-AP3-CTRL, skipping" in caplog.text
 
 
+def test__run_reanalysefalse(tmp_path, caplog, cfg: dict):
+    cfg["reanalyse_existing"] = False
+    cfg["ts_type"] = "daily"
+    cfg["periods"] = ["20100615"]
+    cfg["main_freq"] = "daily"
+
+    # create expected geojson output file (empty, reanalyse_existing does not check for content, only existence)
+    json_basedir = tmp_path / "data"
+    output_file = (
+        json_basedir
+        / "test/exp1/contour/od550aer_TM5-AP3-CTRL/od550aer_TM5-AP3-CTRL_1277942400000.geojson"
+    )
+    output_file.mkdir(parents=True)
+    output_file.touch()
+    cfg["json_basedir"] = json_basedir
+
+    stp = EvalSetup(**cfg)
+    # breakpoint()
+    engine = ModelMapsEngine(stp)
+    engine.run(model_list=["TM5-AP3-CTRL"], var_list=["od550aer"])
+    assert (
+        f"Skipping contour processing of od550aer_TM5-AP3-CTRL: data already exists ['{output_file}']"
+        in caplog.text
+    )
+
+
 def test__run_working(cfg: dict):
     stp = EvalSetup(**cfg)
     engine = ModelMapsEngine(stp)

--- a/tests/aeroval/test_modelmaps_engine.py
+++ b/tests/aeroval/test_modelmaps_engine.py
@@ -37,12 +37,16 @@ def test__run(caplog, cfg: dict):
 
 
 def test__run_reanalysefalse(tmp_path, caplog, cfg: dict):
+    """Test the case reanalyse_existing=False for plot type contour"""
+
     cfg["reanalyse_existing"] = False
+    # modify the config so to have just one output map geojson file, for simplicity
     cfg["ts_type"] = "daily"
     cfg["periods"] = ["20100615"]
     cfg["main_freq"] = "daily"
 
-    # create expected geojson output file (empty, reanalyse_existing does not check for content, only existence)
+    # create expected geojson output file (empty file is ok:
+    # in the case reanalyse_existing=False content is not checked, only existence)
     json_basedir = tmp_path / "data"
     output_file = (
         json_basedir
@@ -53,7 +57,6 @@ def test__run_reanalysefalse(tmp_path, caplog, cfg: dict):
     cfg["json_basedir"] = json_basedir
 
     stp = EvalSetup(**cfg)
-    # breakpoint()
     engine = ModelMapsEngine(stp)
     engine.run(model_list=["TM5-AP3-CTRL"], var_list=["od550aer"])
     assert (


### PR DESCRIPTION
## Change Summary

output paths are hardcoded in `_process_contour_map_var` and `_process_overlay_map_var` in order to be able to use the `reanalyse_existing=False` option (which implies checking that files have been produced)  

these paths were broken after recent aerovaldb changes and are now fixed, but the way of checking existing files, especially for `_process_contour_map_var` where the contours computation is not broken up timestep by timestep, is not very elegant... 
this can be improved at some point if https://github.com/metno/aerovaldb/issues/117 is tackled

the return of  various "files" object  has been removed because it is anyway broken as long as the paths are wrong
it does not appear to be used for anything else than raising exceptions that can be handled differently  

note: the behavior of the option `reanalyse_existing=False` is different for `_process_contour_map_var` and `_process_overlay_map_var` regarding the existence of files:   
for the latter the calculation is done time by time, i.e. `plot_overlay_pixel_maps` is invoked in a loop over timesteps, which allows for recalculating only the specific times missing among the output var_name_[time].webp   
for the former if even just one time is missing among the expected output var_name_[time].geojson files, all are recalculated  
changing this to be coherent with the overlays requires changing the behavior of `calc_contour_json`, which is beyond the scope of this PR

## Related issue number
try tackle #1513 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
