### PR TITLE
fairmode calculated only for meaningful var/freq combinations

### DIFF
--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1001,7 +1001,7 @@ def _process_map_and_scat(
                         if use_fairmode and freq != "yearly" and not np.isnan(obs_vals).all():
                             stats["mb"] = np.nanmean(mod_vals - obs_vals)
 
-                            stats["fairmode"] = fairmode_stats(obs_var, stats)
+                            stats["fairmode"] = fairmode_stats(obs_var, stats, freq)
 
                         #  Code for the calculation of trends
                         if add_trends and freq != "daily":

--- a/pyaerocom/aeroval/fairmode_stats.py
+++ b/pyaerocom/aeroval/fairmode_stats.py
@@ -14,7 +14,6 @@ import numpy as np
 
 SPECIES = dict(
     concno2=dict(UrRV=0.24, RV=200, alpha=0.2),
-    conco3=dict(UrRV=0.18, RV=120, alpha=0.79),
     conco3mda8=dict(UrRV=0.18, RV=120, alpha=0.79),
     concpm10=dict(UrRV=0.28, RV=50, alpha=0.25),
     concpm25=dict(UrRV=0.36, RV=25, alpha=0.5),
@@ -53,9 +52,17 @@ def _mqi(rms: float, rmsu: float, *, beta: float) -> float:
     return rms / (rmsu * beta)
 
 
-def fairmode_stats(obs_var: str, stats: dict) -> dict:
+def fairmode_stats(obs_var: str, stats: dict, freq: str) -> dict:
     if obs_var not in SPECIES or np.isnan(list(stats.values())).any():
         return {}
+
+    # compute only what it makes sense to compute
+    if obs_var == "concno2":
+        if freq != "hourly":
+            return {}
+    else:
+        if freq != "daily":
+            return {}
 
     mean = stats["refdata_mean"]
     obs_std = stats["refdata_std"]

--- a/tests/aeroval/test_fairmode_stats.py
+++ b/tests/aeroval/test_fairmode_stats.py
@@ -9,67 +9,87 @@ FAIRMODE_KEYS = {"RMSU", "sign", "crms", "bias", "rms", "alpha", "UrRV", "RV", "
 
 
 @pytest.mark.parametrize(
-    "obs_var,stats",
+    "obs_var,stats,freq",
     [
         pytest.param(
             "concno2",
             dict(refdata_mean=0, refdata_std=1, data_std=1, R=1, mb=0, rms=0),
-            id="dummy vars",
-        )
+            "hourly",
+            id="dummy_no2",
+        ),
+        pytest.param(
+            "conco3mda8",
+            dict(refdata_mean=0, refdata_std=1, data_std=1, R=1, mb=0, rms=0),
+            "daily",
+            id="dummy_o3mda8",
+        ),
     ],
 )
-def test_fairmode_stats(obs_var: str, stats: dict):
-    fairmode = fairmode_stats(obs_var, stats)
+def test_fairmode_stats(obs_var: str, stats: dict, freq: str):
+    fairmode = fairmode_stats(obs_var, stats, freq)
     assert set(fairmode) == FAIRMODE_KEYS
 
 
 @pytest.mark.parametrize(
-    "obs_var,stats",
+    "obs_var,stats,freq",
     [
         pytest.param(
-            "not_a_species",
+            "conco3",
             dict(refdata_mean=0, refdata_std=1, data_std=1, R=1, mb=0, rms=0),
-            id="unknown obs variable",
+            "daily",
+            id="not a valid species",
         ),
         pytest.param(
-            "vmro3",
+            "concno2",
+            dict(refdata_mean=0, refdata_std=1, data_std=1, R=1, mb=0, rms=0),
+            "daily",
+            id="wrong frequency",
+        ),
+        pytest.param(
+            "concpm10",
             dict(refdata_mean=np.nan, refdata_std=1, data_std=1, R=1, mb=0, rms=0),
+            "daily",
             id="NaN mean",
         ),
         pytest.param(
-            "conco3",
+            "concpm10",
             dict(refdata_mean=0, refdata_std=np.nan, data_std=1, R=1, mb=0, rms=0),
+            "daily",
             id="NaN obs_std",
         ),
         pytest.param(
-            "conco3",
+            "concpm10",
             dict(refdata_mean=0, refdata_std=1, data_std=np.nan, R=1, mb=0, rms=0),
+            "daily",
             id="NaN mod_std",
         ),
         pytest.param(
-            "conco3",
+            "concpm10",
             dict(refdata_mean=0, refdata_std=1, data_std=1, R=np.nan, mb=0, rms=0),
+            "daily",
             id="NaN R",
         ),
         pytest.param(
-            "conco3",
+            "concpm10",
             dict(refdata_mean=0, refdata_std=1, data_std=1, R=1, mb=np.nan, rms=0),
+            "daily",
             id="NaN bias",
         ),
         pytest.param(
-            "vmro3",
+            "concpm10",
             dict(refdata_mean=0, refdata_std=1, data_std=1, R=1, mb=1, rms=np.nan),
+            "daily",
             id="NaN rms",
         ),
     ],
 )
-def test_empty_stats(obs_var: str, stats: dict):
-    fairmode = fairmode_stats(obs_var, stats)
+def test_empty_stats(obs_var: str, stats: dict, freq: str):
+    fairmode = fairmode_stats(obs_var, stats, freq)
     assert not fairmode
 
 
 @pytest.mark.parametrize(
-    "obs_var,stats,error",
+    "obs_var,stats,freq,error",
     [
         pytest.param(
             "concpm10",
@@ -81,6 +101,7 @@ def test_empty_stats(obs_var: str, stats: dict):
                 "mb": 1,
                 "rms": 1,
             },
+            "daily",
             "negative obs_std=-1",
             id="obs_std",
         ),
@@ -94,6 +115,7 @@ def test_empty_stats(obs_var: str, stats: dict):
                 "mb": 1,
                 "rms": 1,
             },
+            "daily",
             "negative mod_std=-1",
             id="mod_std",
         ),
@@ -107,12 +129,13 @@ def test_empty_stats(obs_var: str, stats: dict):
                 "mb": 1,
                 "rms": 1,
             },
+            "daily",
             "out of range R=10",
             id="R",
         ),
     ],
 )
-def test_fairmode_error(obs_var: str, stats: dict, error: str):
+def test_fairmode_error(obs_var: str, stats: dict, freq: str, error: str):
     with pytest.raises(AssertionError) as e:
-        fairmode_stats(obs_var, stats)
+        fairmode_stats(obs_var, stats, freq)
     assert str(e.value) == error

--- a/tests/aeroval/test_fairmode_stats.py
+++ b/tests/aeroval/test_fairmode_stats.py
@@ -43,7 +43,13 @@ def test_fairmode_stats(obs_var: str, stats: dict, freq: str):
             "concno2",
             dict(refdata_mean=0, refdata_std=1, data_std=1, R=1, mb=0, rms=0),
             "daily",
-            id="wrong frequency",
+            id="wrong frequency no2",
+        ),
+        pytest.param(
+            "concpm10",
+            dict(refdata_mean=0, refdata_std=1, data_std=1, R=1, mb=0, rms=0),
+            "hourly",
+            id="wrong frequency pm10",
         ),
         pytest.param(
             "concpm10",


### PR DESCRIPTION
fairmode stats limited to the variable/frequency combinations that make sense:  
the list of species for which they are defined is hard-coded together with the related relevant parameters  
```
SPECIES = dict(
    concno2=dict(UrRV=0.24, RV=200, alpha=0.2),
    conco3mda8=dict(UrRV=0.18, RV=120, alpha=0.79),
    concpm10=dict(UrRV=0.28, RV=50, alpha=0.25),
    concpm25=dict(UrRV=0.36, RV=25, alpha=0.5),
)
```
o3 has been removed because it was wrong to have it, the relevant variable for fairmode is o3mda8   
the correct frequency for concno2 is hourly, while for the other three variables it's daily

## Related issue number

low-hanging fruit for #1003

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
