### PR TITLE
Fixes for move of overlay out of contour

### DIFF
--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -133,8 +133,9 @@ class ExperimentOutput(ProjectOutput):
         """
         if self.exp_id not in os.listdir(self.proj_dir):
             return False
-        elif self.cfg.processing_opts.only_model_maps and not self._has_files(
-            self.out_dirs_json["contour"]
+        elif self.cfg.processing_opts.only_model_maps and not (
+            self._has_files(self.out_dirs_json["contour"])
+            or self._has_files(self.out_dirs_json["overlay"])
         ):
             return False
         elif (
@@ -357,7 +358,9 @@ class ExperimentOutput(ProjectOutput):
         if self.cfg.processing_opts.only_model_maps:
             infos = ["name", "ovar", "per"]
             res = [[], [], []]
-            files = self._get_output_files(self.out_dirs_json["contour"])
+            files = self._get_output_files(self.out_dirs_json["contour"]) + self._get_output_files(
+                self.out_dirs_json["overlay"]
+            )
             for file in files:
                 file_info = self._info_from_contour_dir_file(file)
                 for i, entry in enumerate(file_info):
@@ -824,7 +827,9 @@ class ExperimentOutput(ProjectOutput):
     def _create_menu_dict(self) -> dict:
         new = {}
         if self.cfg.processing_opts.only_model_maps:
-            files = self._get_output_files(self.out_dirs_json["contour"])
+            files = self._get_output_files(self.out_dirs_json["contour"]) + self._get_output_files(
+                self.out_dirs_json["overlay"]
+            )
             all_combinations = list(
                 itertools.product(
                     self.cfg.obs_cfg.keylist(),

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -277,16 +277,20 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         if self.cfg.processing_opts.only_model_maps:
             self._check_ts_for_only_model_maps(model_name, var, ts, data)
 
-        outdir = self.cfg.path_manager.get_json_output_dirs()["contour/overlay"]
+        outdir = self.cfg.path_manager.get_json_output_dirs()["overlay"]
 
         for i, date in enumerate(ts):
-            write_var_name = self.cfg.model_cfg.get_entry(model_name).model_rename_vars.get(
-                var, var
-            )
+            try:
+                write_var_name = self.cfg.model_cfg.get_entry(model_name).model_rename_vars.get(
+                    var, var
+                )
+            except EntryNotAvailable:
+                write_var_name = var
 
+            model_overlay_dir_name = write_var_name + "_" + model_name
             # Note this should match the output location defined in aerovaldb
             outname = f"{write_var_name}_{model_name}_{date}.{self.cfg.modelmaps_opts.overlay_save_format}"
-            fp_overlay = os.path.join(outdir, outname)
+            fp_overlay = os.path.join(outdir, model_overlay_dir_name, outname)
 
             if not reanalyse_existing:
                 if os.path.exists(fp_overlay):

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -82,7 +82,7 @@ class OutputPaths(BaseModel):
         "hm/ts",
         "contour",
         "profiles",
-        "contour/overlay",
+        "overlay",
     ]
     avdb_resource: Path | str | None = None
 


### PR DESCRIPTION
## Change Summary

`countour/overlay` -> `overlay` mean that a lot of the logic needed modify, especially in the `only_model_maps` case. These are fixes which seem to work, but more testing is needed to see  how this interacts when there are both contour and and overlay plots

## Related issue number

NA

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
