### PR TITLE
station_type in output

### DIFF
--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -490,7 +490,7 @@ def _init_site_coord_arrays(data):
             if "station_type" in cd.data.coords:
                 sites_types = cd.data.station_type.values
             else:
-                sites_types = [None] * len(sites)
+                sites_types = [""] * len(sites)
             lats = cd.data.latitude.values.astype(np.float64)
             lons = cd.data.longitude.values.astype(np.float64)
             if "altitude" in cd.data.coords:

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -487,6 +487,10 @@ def _init_site_coord_arrays(data):
             continue
         elif not found:
             sites = cd.data.station_name.values
+            if "station_type" in cd.data.coords:
+                sites_types = cd.data.station_type.values
+            else:
+                sites_types = [None] * len(sites)
             lats = cd.data.latitude.values.astype(np.float64)
             lons = cd.data.longitude.values.astype(np.float64)
             if "altitude" in cd.data.coords:
@@ -502,7 +506,7 @@ def _init_site_coord_arrays(data):
         else:
             assert all(cd.data.station_name.values == sites)
         jsdates[freq] = cd.data.jsdate.values.tolist()
-    return (sites, lats, lons, alts, countries, jsdates)
+    return (sites, sites_types, lats, lons, alts, countries, jsdates)
 
 
 def _get_stat_regions(lats, lons, regions, **kwargs):
@@ -516,7 +520,7 @@ def _get_stat_regions(lats, lons, regions, **kwargs):
 
 def _process_sites(data, regions, regions_how, meta_glob):
     freqs = list(data)
-    (sites, lats, lons, alts, countries, jsdates) = _init_site_coord_arrays(data)
+    (sites, site_types, lats, lons, alts, countries, jsdates) = _init_site_coord_arrays(data)
     if regions_how == "country":
         regs = countries
     elif regions_how == "htap":
@@ -532,6 +536,7 @@ def _process_sites(data, regions, regions_how, meta_glob):
         # init empty timeseries data object
         site_meta = {
             "station_name": str(site),
+            "station_type": site_types[i],
             "latitude": lats[i],
             "longitude": lons[i],
             "altitude": alts[i],

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -835,6 +835,7 @@ def colocate_gridded_ungridded(
     lats = [np.nan] * stat_num
     alts = [np.nan] * stat_num
     station_names = [""] * stat_num
+    station_types = [""] * stat_num
 
     data_ref_unit = None
     ts_type_src_ref = None
@@ -850,6 +851,7 @@ def colocate_gridded_ungridded(
         lats[i] = obs_stat.latitude
         alts[i] = obs_stat.altitude
         station_names[i] = obs_stat.station_name
+        station_types[i] = obs_stat.station_type
 
         # ToDo: consider removing to keep ts_type_src_ref (this was probably
         # introduced for EBAS were the original data frequency is not constant
@@ -977,6 +979,7 @@ def colocate_gridded_ungridded(
         "data_source": meta["data_source"],
         "time": time_idx,
         "station_name": station_names,
+        "station_type": ("station_name", station_types),
         "latitude": ("station_name", lats),
         "longitude": ("station_name", lons),
         "altitude": ("station_name", alts),

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -851,7 +851,9 @@ def colocate_gridded_ungridded(
         lats[i] = obs_stat.latitude
         alts[i] = obs_stat.altitude
         station_names[i] = obs_stat.station_name
-        station_types[i] = obs_stat.station_type
+        station_types[i] = None
+        if hasattr(obs_stat, "station_type"):
+            station_types[i] = obs_stat.station_type
 
         # ToDo: consider removing to keep ts_type_src_ref (this was probably
         # introduced for EBAS were the original data frequency is not constant

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -13,8 +13,8 @@ from geonum.atmosphere import pressure
 
 from pyaerocom import __version__ as pya_ver
 from pyaerocom import const
-from pyaerocom.climatology_config import ClimatologyConfig
 from pyaerocom._lowlevel_helpers import RegridResDeg
+from pyaerocom.climatology_config import ClimatologyConfig
 from pyaerocom.exceptions import (
     DataUnitError,
     DimensionOrderError,
@@ -859,9 +859,7 @@ def colocate_gridded_ungridded(
         lats[i] = obs_stat.latitude
         alts[i] = obs_stat.altitude
         station_names[i] = obs_stat.station_name
-        station_types[i] = None
-        if hasattr(obs_stat, "station_type"):
-            station_types[i] = obs_stat.station_type
+        station_types[i] = getattr(obs_stat, "station_type", "")
 
         # ToDo: consider removing to keep ts_type_src_ref (this was probably
         # introduced for EBAS were the original data frequency is not constant
@@ -978,7 +976,7 @@ def colocate_gridded_ungridded(
         "from_files": files,
         "from_files_ref": None,
         "colocate_time": colocate_time,
-        "obs_is_clim": True if isinstance(use_climatology_ref, ClimatologyConfig) else False,
+        "obs_is_clim": (True if isinstance(use_climatology_ref, ClimatologyConfig) else False),
         "pyaerocom": pya_ver,
         "min_num_obs": min_num_obs,
         "resample_how": resample_how,

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -4,6 +4,7 @@ Methods and / or classes to perform colocation
 
 import logging
 import os
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -32,8 +33,6 @@ from pyaerocom.helpers import (
 )
 from pyaerocom.time_resampler import TimeResampler
 from pyaerocom.tstype import TsType
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pyaerocom.ungriddeddata import UngriddedData
@@ -843,7 +842,6 @@ def colocate_gridded_ungridded(
         data_unit = str(data.units)
     else:
         data_unit = None
-
     # loop over all stations and append to colocated data object
     for i, obs_stat in enumerate(obs_stat_data):
         # Add coordinates to arrays required for xarray.DataArray below

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -1041,13 +1041,13 @@ class Colocator:
         # check if the station_type key has been passed to the ungridded data object
         # (not all readers may do that, currently only the CAMS2_83 reader does)
         if isinstance(obs_data, UngriddedData):
-            are_there_station_types = set(
-                ["station_type" in dict.keys() for dict in obs_data.metadata.values()]
-            )
-            if are_there_station_types == {True}:  # all true, all have station_type
-                args.update(add_meta_keys=["station_type"])
-            elif len(are_there_station_types) == 2:
+            are_there_station_types = {
+                "station_type" in dict for dict in obs_data.metadata.values()
+            }
+            if are_there_station_types == {True, False}:
                 raise ValueError("some stations have `station_type` metadata while others do not")
+            if are_there_station_types == {True}:  # all have station_type
+                args.update(add_meta_keys=["station_type"])
 
         if self.obs_is_ungridded:
             ts_type = self._get_colocation_ts_type(model_data.ts_type)

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -1041,18 +1041,6 @@ class Colocator:
         # check if the station_type key has been passed to the ungridded data object
         # (not all readers may do that, currently only the CAMS2_83 reader does)
         if isinstance(obs_data, UngriddedData):
-            #             match {
-            #                set(
-            #                    "station_type" in dict.keys() for dict in obs_data.metadata.values()
-            #                )
-            #            }:
-            #                case True:  # all stations have `station_type`
-            #                    args.update(add_meta_keys=["station_type"])
-            #                case [True, False]:
-            #                    raise ValueError(
-            #                        "some stations have `station_type` metadata while others do not"
-            #                    ) """
-
             if all("station_type" in dict.keys() for dict in obs_data.metadata.values()):
                 args.update(add_meta_keys=["station_type"])
             elif any("station_type" in dict.keys() for dict in obs_data.metadata.values()):

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -1041,8 +1041,22 @@ class Colocator:
         # check if the station_type key has been passed to the ungridded data object
         # (not all readers may do that, currently only the CAMS2_83 reader does)
         if isinstance(obs_data, UngriddedData):
+            #             match {
+            #                set(
+            #                    "station_type" in dict.keys() for dict in obs_data.metadata.values()
+            #                )
+            #            }:
+            #                case True:  # all stations have `station_type`
+            #                    args.update(add_meta_keys=["station_type"])
+            #                case [True, False]:
+            #                    raise ValueError(
+            #                        "some stations have `station_type` metadata while others do not"
+            #                    ) """
+
             if all("station_type" in dict.keys() for dict in obs_data.metadata.values()):
                 args.update(add_meta_keys=["station_type"])
+            elif any("station_type" in dict.keys() for dict in obs_data.metadata.values()):
+                raise ValueError("some stations have `station_type` metadata while others do not")
 
         if self.obs_is_ungridded:
             ts_type = self._get_colocation_ts_type(model_data.ts_type)

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -1041,12 +1041,12 @@ class Colocator:
         # check if the station_type key has been passed to the ungridded data object
         # (not all readers may do that, currently only the CAMS2_83 reader does)
         if isinstance(obs_data, UngriddedData):
-            are_there_station_types = len(
-                set(["station_type" in dict.keys() for dict in obs_data.metadata.values()])
+            are_there_station_types = set(
+                ["station_type" in dict.keys() for dict in obs_data.metadata.values()]
             )
-            if are_there_station_types == 1:  # all true, all have station_type
+            if are_there_station_types == {True}:  # all true, all have station_type
                 args.update(add_meta_keys=["station_type"])
-            elif are_there_station_types == 2:
+            elif len(are_there_station_types) == 2:
                 raise ValueError("some stations have `station_type` metadata while others do not")
 
         if self.obs_is_ungridded:

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -1041,10 +1041,13 @@ class Colocator:
         # check if the station_type key has been passed to the ungridded data object
         # (not all readers may do that, currently only the CAMS2_83 reader does)
         if isinstance(obs_data, UngriddedData):
-            if all("station_type" in dict.keys() for dict in obs_data.metadata.values()):
-                args.update(add_meta_keys=["station_type"])
-            elif any("station_type" in dict.keys() for dict in obs_data.metadata.values()):
-                raise ValueError("some stations have `station_type` metadata while others do not")
+            match len(set(["station_type" in dict.keys() for dict in obs_data.metadata.values()])):
+                case 1:  # all true, all have station_type
+                    args.update(add_meta_keys=["station_type"])
+                case 2:
+                    raise ValueError(
+                        "some stations have `station_type` metadata while others do not"
+                    )
 
         if self.obs_is_ungridded:
             ts_type = self._get_colocation_ts_type(model_data.ts_type)

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -1041,13 +1041,13 @@ class Colocator:
         # check if the station_type key has been passed to the ungridded data object
         # (not all readers may do that, currently only the CAMS2_83 reader does)
         if isinstance(obs_data, UngriddedData):
-            match len(set(["station_type" in dict.keys() for dict in obs_data.metadata.values()])):
-                case 1:  # all true, all have station_type
-                    args.update(add_meta_keys=["station_type"])
-                case 2:
-                    raise ValueError(
-                        "some stations have `station_type` metadata while others do not"
-                    )
+            are_there_station_types = len(
+                set(["station_type" in dict.keys() for dict in obs_data.metadata.values()])
+            )
+            if are_there_station_types == 1:  # all true, all have station_type
+                args.update(add_meta_keys=["station_type"])
+            elif are_there_station_types == 2:
+                raise ValueError("some stations have `station_type` metadata while others do not")
 
         if self.obs_is_ungridded:
             ts_type = self._get_colocation_ts_type(model_data.ts_type)

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -39,6 +39,7 @@ from pyaerocom.io.helpers import get_all_supported_ids_ungridded
 from pyaerocom.io.mscw_ctm.reader import ReadMscwCtm
 from pyaerocom.stats.mda8.const import MDA8_INPUT_VARS
 from pyaerocom.stats.mda8.mda8 import mda8_colocated_data
+from pyaerocom.ungriddeddata import UngriddedData
 
 from .colocated_data import ColocatedData
 from .colocation_3d import ColocatedDataLists, colocate_vertical_profile_gridded
@@ -1039,8 +1040,9 @@ class Colocator:
         )
         # check if the station_type key has been passed to the ungridded data object
         # (not all readers may do that, currently only the CAMS2_83 reader does)
-        if all("station_type" in dict.keys() for dict in obs_data.metadata.values()):
-            args.update(add_meta_keys=["station_type"])
+        if isinstance(obs_data, UngriddedData):
+            if all("station_type" in dict.keys() for dict in obs_data.metadata.values()):
+                args.update(add_meta_keys=["station_type"])
 
         if self.obs_is_ungridded:
             ts_type = self._get_colocation_ts_type(model_data.ts_type)

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -1035,7 +1035,13 @@ class Colocator:
             min_num_obs=self.colocation_setup.min_num_obs,
             colocate_time=self.colocation_setup.colocate_time,
             resample_how=rshow,
+            add_meta_keys=[],
         )
+        # check if the station_type key has been passed to the ungridded data object
+        # (not all readers may do that, currently only the CAMS2_83 reader does)
+        if all("station_type" in dict.keys() for dict in obs_data.metadata.values()):
+            args.update(add_meta_keys=["station_type"])
+
         if self.obs_is_ungridded:
             ts_type = self._get_colocation_ts_type(model_data.ts_type)
             args.update(

--- a/pyaerocom/io/cams2_83/obs.py
+++ b/pyaerocom/io/cams2_83/obs.py
@@ -76,27 +76,26 @@ def read_csv(
         df = df[df.conc > 0]
     metadata_file_path = Path(path).parent.parent / DEFAULT_METADATA_NAME
     if metadata_file_path.is_file():
-        df_metadata = read_metadata(metadata_file_path)
+        try:
+            df_metadata = read_metadata(metadata_file_path)
+        except ParserError as e:
+            logger.warning(f"Invalid metadata file {path}, {e}")
+            df_metadata = pd.DataFrame()
         if not df_metadata.empty:
             df = df.merge(df_metadata, on="station", how="left")
             return df["station lat lon alt time poll conc station_type".split()]
         else:
-            logger.warning(f"Empty metadata from {metadata_file_path}")
+            logger.warning("Empty metadata")
     else:
         logger.warning(f"Metadata file {metadata_file_path} does not exist")
     return df["station lat lon alt time poll conc".split()]
 
 
 def read_metadata(path: str | Path) -> pd.DataFrame:
-    df = pd.DataFrame()
-    try:
-        df = pd.read_csv(
-            path,
-            sep=",",
-            header=0,
-            names="station station_type".split(),
-            usecols=[0, 2],
-        )
-    except ParserError as e:
-        logger.warning(f"Invalid metadata file {path}, {e}")
-    return df
+    return pd.read_csv(
+        path,
+        sep=",",
+        header=0,
+        names="station station_type".split(),
+        usecols=[0, 2],
+    )

--- a/pyaerocom/io/cams2_83/obs.py
+++ b/pyaerocom/io/cams2_83/obs.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from typing import Protocol
 
 import pandas as pd
+from pandas.errors import ParserError
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +65,7 @@ def read_csv(
         names="station lat lon alt poll Y M D H _ conc".split(),
         usecols=lambda x: x != "_",
     )
+    print(df.head())
     df = df.pipe(add_time).pipe(conc_units).pipe(poll_names)
     if polls is not None:
         df = df[df.poll.isin(polls)]
@@ -73,9 +75,21 @@ def read_csv(
     if (df.conc <= 0).any():
         logger.warning("found negative obs")
         df = df[df.conc > 0]
-    df_metadata = read_metadata(Path(path).parent.parent / DEFAULT_METADATA_NAME)
-    df = df.merge(df_metadata, on="station", how="left")
-    return df["station lat lon alt time poll conc station_type".split()]
+    metadata_file_path = Path(path).parent.parent / DEFAULT_METADATA_NAME
+    print(metadata_file_path)
+    if metadata_file_path.is_file():
+        try:
+            df_metadata = read_metadata(metadata_file_path)
+            if not df_metadata.empty:
+                df = df.merge(df_metadata, on="station", how="left")
+                return df["station lat lon alt time poll conc station_type".split()]
+            else:
+                logger.warning(f"Empty metadata from {metadata_file_path}")
+        except ParserError as e:
+            logger.warning(f"Invalid metadata file {metadata_file_path}, {e}")
+    else:
+        logger.warning(f"Metadata file {metadata_file_path} does not exist")
+    return df["station lat lon alt time poll conc".split()]
 
 
 def read_metadata(path: str | Path) -> pd.DataFrame:

--- a/pyaerocom/io/cams2_83/obs.py
+++ b/pyaerocom/io/cams2_83/obs.py
@@ -18,6 +18,8 @@ CAMS2_50_DOMAIN = SimpleNamespace(
     lon=(-25, 45),  # °E
 )
 
+DEFAULT_METADATA_NAME = "mf_stations_list_classification_2025.csv"
+
 
 class Domain(Protocol):
     """domain for static type checking"""
@@ -71,7 +73,9 @@ def read_csv(
     if (df.conc <= 0).any():
         logger.warning("found negative obs")
         df = df[df.conc > 0]
-    return df["station lat lon alt time poll conc".split()]
+    df_metadata = read_metadata(Path(path).parent.parent / DEFAULT_METADATA_NAME)
+    df = df.merge(df_metadata, on="station", how="left")
+    return df["station lat lon alt time poll conc station_type".split()]
 
 
 def read_metadata(path: str | Path) -> pd.DataFrame:

--- a/pyaerocom/io/cams2_83/obs.py
+++ b/pyaerocom/io/cams2_83/obs.py
@@ -100,6 +100,7 @@ def read_metadata(path: str | Path) -> pd.DataFrame:
         path,
         sep=",",
         header=0,
+        skipinitialspace=True,
         names="station station_type".split(),
         usecols=[0, 2],
     )

--- a/pyaerocom/io/cams2_83/obs.py
+++ b/pyaerocom/io/cams2_83/obs.py
@@ -76,26 +76,27 @@ def read_csv(
         df = df[df.conc > 0]
     metadata_file_path = Path(path).parent.parent / DEFAULT_METADATA_NAME
     if metadata_file_path.is_file():
-        try:
-            df_metadata = read_metadata(metadata_file_path)
-            if not df_metadata.empty:
-                df = df.merge(df_metadata, on="station", how="left")
-                return df["station lat lon alt time poll conc station_type".split()]
-            else:
-                logger.warning(f"Empty metadata from {metadata_file_path}")
-        except ParserError as e:
-            logger.warning(f"Invalid metadata file {metadata_file_path}, {e}")
+        df_metadata = read_metadata(metadata_file_path)
+        if not df_metadata.empty:
+            df = df.merge(df_metadata, on="station", how="left")
+            return df["station lat lon alt time poll conc station_type".split()]
+        else:
+            logger.warning(f"Empty metadata from {metadata_file_path}")
     else:
         logger.warning(f"Metadata file {metadata_file_path} does not exist")
     return df["station lat lon alt time poll conc".split()]
 
 
 def read_metadata(path: str | Path) -> pd.DataFrame:
-    df = pd.read_csv(
-        path,
-        sep=",",
-        header=0,
-        names="station station_type".split(),
-        usecols=[0, 2],
-    )
+    df = pd.DataFrame()
+    try:
+        df = pd.read_csv(
+            path,
+            sep=",",
+            header=0,
+            names="station station_type".split(),
+            usecols=[0, 2],
+        )
+    except ParserError as e:
+        logger.warning(f"Invalid metadata file {path}, {e}")
     return df

--- a/pyaerocom/io/cams2_83/obs.py
+++ b/pyaerocom/io/cams2_83/obs.py
@@ -72,3 +72,14 @@ def read_csv(
         logger.warning("found negative obs")
         df = df[df.conc > 0]
     return df["station lat lon alt time poll conc".split()]
+
+
+def read_metadata(path: str | Path) -> pd.DataFrame:
+    df = pd.read_csv(
+        path,
+        sep=",",
+        header=0,
+        names="station station_type".split(),
+        usecols=[0, 2],
+    )
+    return df

--- a/pyaerocom/io/cams2_83/obs.py
+++ b/pyaerocom/io/cams2_83/obs.py
@@ -74,21 +74,25 @@ def read_csv(
     if (df.conc <= 0).any():
         logger.warning("found negative obs")
         df = df[df.conc > 0]
+
+    df = df["station lat lon alt time poll conc".split()]
+
     metadata_file_path = Path(path).parent.parent / DEFAULT_METADATA_NAME
-    if metadata_file_path.is_file():
-        try:
-            df_metadata = read_metadata(metadata_file_path)
-        except ParserError as e:
-            logger.warning(f"Invalid metadata file {path}, {e}")
-            df_metadata = pd.DataFrame()
-        if not df_metadata.empty:
-            df = df.merge(df_metadata, on="station", how="left")
-            return df["station lat lon alt time poll conc station_type".split()]
-        else:
-            logger.warning("Empty metadata")
-    else:
+    if not metadata_file_path.is_file():
         logger.warning(f"Metadata file {metadata_file_path} does not exist")
-    return df["station lat lon alt time poll conc".split()]
+        return df
+
+    try:
+        df_metadata = read_metadata(metadata_file_path)
+    except ParserError as e:
+        logger.warning(f"Invalid metadata file {path}, {e}")
+        return df
+
+    if df_metadata.empty:
+        logger.warning("Empty metadata")
+        return df
+
+    return df.merge(df_metadata, on="station", how="left")
 
 
 def read_metadata(path: str | Path) -> pd.DataFrame:

--- a/pyaerocom/io/cams2_83/obs.py
+++ b/pyaerocom/io/cams2_83/obs.py
@@ -65,7 +65,6 @@ def read_csv(
         names="station lat lon alt poll Y M D H _ conc".split(),
         usecols=lambda x: x != "_",
     )
-    print(df.head())
     df = df.pipe(add_time).pipe(conc_units).pipe(poll_names)
     if polls is not None:
         df = df[df.poll.isin(polls)]
@@ -76,7 +75,6 @@ def read_csv(
         logger.warning("found negative obs")
         df = df[df.conc > 0]
     metadata_file_path = Path(path).parent.parent / DEFAULT_METADATA_NAME
-    print(metadata_file_path)
     if metadata_file_path.is_file():
         try:
             df_metadata = read_metadata(metadata_file_path)

--- a/pyaerocom/io/cams2_83/read_obs.py
+++ b/pyaerocom/io/cams2_83/read_obs.py
@@ -103,7 +103,9 @@ class ReadCAMS2_83(ReadUngriddedBase):
         logger.info("Start read obs")
         # lazy data_iterator returns immediately, unpacked in from_station_data
         data_iterator = self.__reader(vars_to_retrieve, files)
-        ungriddeddata = UngriddedData.from_station_data(data_iterator)
+        ungriddeddata = UngriddedData.from_station_data(
+            data_iterator, add_meta_keys=["station_type"]
+        )
         logger.info(f"Time needed to convert obs to ungridded: {time.time() - start}s")
         return ungriddeddata
 

--- a/pyaerocom/io/cams2_83/read_obs.py
+++ b/pyaerocom/io/cams2_83/read_obs.py
@@ -85,7 +85,7 @@ class ReadCAMS2_83(ReadUngriddedBase):
             vars_to_retrieve = [vars_to_retrieve]
         if not isinstance(vars_to_retrieve, list):
             raise TypeError(
-                f"Unsupoerted type {type(vars_to_retrieve)}, "
+                f"Unsupported type {type(vars_to_retrieve)}, "
                 "vars_to_retrieve supported types are: str | list[str] | None"
             )
         assert all(

--- a/pyaerocom/io/cams2_83/read_obs.py
+++ b/pyaerocom/io/cams2_83/read_obs.py
@@ -126,6 +126,7 @@ class ReadCAMS2_83(ReadUngriddedBase):
             output = dict(
                 station_id=station,
                 station_name=station,
+                station_type=df["station_type"].iloc[0],
                 latitude=df["lat"].iloc[0],
                 longitude=df["lon"].iloc[0],
                 altitude=df["alt"].iloc[0],

--- a/pyaerocom/io/readungridded.py
+++ b/pyaerocom/io/readungridded.py
@@ -553,7 +553,6 @@ class ReadUngridded:
                     data_out.append(cache.loaded_data[var])
             if data_read is not None:
                 data_out.append(data_read)
-
         # close the cache-object, keeps otherwise data-references
         cache = None
 

--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -1276,6 +1276,7 @@ class UngriddedData:
         out_data = {
             "stats": [],
             "station_name": [],
+            "station_type": [],
             "latitude": [],
             "failed": [],
             "longitude": [],
@@ -1299,6 +1300,7 @@ class UngriddedData:
                 out_data["latitude"].append(data["latitude"])
                 out_data["longitude"].append(data["longitude"])
                 out_data["station_name"].append(data["station_name"])
+                out_data["station_type"].append(data["station_type"])
                 out_data["stats"].append(data)
 
             # catch the exceptions that are acceptable

--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -1265,10 +1265,11 @@ class UngriddedData:
         Returns
         -------
         dict
-            4-element dictionary containing following key / value pairs:
+            5-element dictionary containing following key / value pairs:
 
                 - stats: list of :class:`StationData` objects
                 - station_name: list of corresponding station names
+                - station_type: list of corresponding station types, might be empty
                 - latitude: list of latitude coordinates
                 - longitude: list of longitude coordinates
 
@@ -1296,7 +1297,6 @@ class UngriddedData:
                     ts_type_preferred=ts_type_preferred,
                     **kwargs,
                 )
-
                 out_data["latitude"].append(data["latitude"])
                 out_data["longitude"].append(data["longitude"])
                 out_data["station_name"].append(data["station_name"])

--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -1303,7 +1303,7 @@ class UngriddedData:
                 if hasattr(data, "station_type"):
                     out_data["station_type"].append(data["station_type"])
                 else:
-                    logger.info("No station_type found in StationData, statio_type will be blank")
+                    logger.info("No station_type found in StationData, station_type will be blank")
                 out_data["stats"].append(data)
 
             # catch the exceptions that are acceptable

--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -1300,7 +1300,10 @@ class UngriddedData:
                 out_data["latitude"].append(data["latitude"])
                 out_data["longitude"].append(data["longitude"])
                 out_data["station_name"].append(data["station_name"])
-                out_data["station_type"].append(data["station_type"])
+                if hasattr(data, "station_type"):
+                    out_data["station_type"].append(data["station_type"])
+                else:
+                    logger.info("No station_type found in StationData, statio_type will be blank")
                 out_data["stats"].append(data)
 
             # catch the exceptions that are acceptable

--- a/tests/colocation/test_colocation_utils.py
+++ b/tests/colocation/test_colocation_utils.py
@@ -77,8 +77,28 @@ S4["concpm10"][0:5] = range(5)
 @pytest.mark.parametrize(
     "stat_data,stat_data_ref,var,var_ref,ts_type,resample_how,min_num_obs, use_climatology_ref,num_valid",
     [
-        (S4, S3, "concpm10", "concpm10", "monthly", "mean", {"monthly": {"daily": 25}}, False, 10),
-        (S3, S4, "concpm10", "concpm10", "monthly", "mean", {"monthly": {"daily": 25}}, False, 24),
+        (
+            S4,
+            S3,
+            "concpm10",
+            "concpm10",
+            "monthly",
+            "mean",
+            {"monthly": {"daily": 25}},
+            False,
+            10,
+        ),
+        (
+            S3,
+            S4,
+            "concpm10",
+            "concpm10",
+            "monthly",
+            "mean",
+            {"monthly": {"daily": 25}},
+            False,
+            24,
+        ),
         (S1, S2, "concpm10", "concpm10", "monthly", "mean", 25, False, 12),
         (S2, S1, "concpm10", "concpm10", "monthly", "mean", 25, False, 11),
     ],
@@ -152,7 +172,8 @@ def test_colocate_gridded_ungridded_new_var(data_tm5, aeronetsunv3lev2_subset):
         ),
         (
             dict(
-                filter_name=f"{ALL_REGION_NAME}-wMOUNTAINS", min_num_obs=const.OBS_MIN_NUM_RESAMPLE
+                filter_name=f"{ALL_REGION_NAME}-wMOUNTAINS",
+                min_num_obs=const.OBS_MIN_NUM_RESAMPLE,
             ),
             "monthly",
             (2, 12, 11),
@@ -205,6 +226,16 @@ def test_colocate_gridded_ungridded(
     assert np.nanmean(coldata.data.data[1]) == pytest.approx(modmean, rel=TEST_RTOL)
 
 
+def test_colocate_gridded_ungridded_wstationtype(data_tm5, aeronetsunv3lev2_subset):
+    fake_type = ["faketype"] * len(aeronetsunv3lev2_subset.station_name)
+    for i, n in enumerate(fake_type):
+        aeronetsunv3lev2_subset.metadata[i].update({"station_type": n})
+    coldata = colocate_gridded_ungridded(
+        data_tm5, aeronetsunv3lev2_subset, add_meta_keys=["station_type"]
+    )
+    assert all(typ == "faketype" for typ in coldata.coords["station_type"].values.tolist())
+
+
 def test_colocate_gridded_ungridded_nonglobal(aeronetsunv3lev2_subset):
     times = [1, 2]
     time_unit = Unit("days since 2010-1-1 0:0:0")
@@ -213,7 +244,10 @@ def test_colocate_gridded_ungridded_nonglobal(aeronetsunv3lev2_subset):
     for time in times:
         time_coord = iris.coords.DimCoord(time, units=time_unit, standard_name="time")
         cube = helpers.make_dummy_cube_latlon(
-            lat_res_deg=1, lon_res_deg=1, lat_range=[30.05, 81.95], lon_range=[-29.5, 89.95]
+            lat_res_deg=1,
+            lon_res_deg=1,
+            lat_range=[30.05, 81.95],
+            lon_range=[-29.5, 89.95],
         )
         cube.add_aux_coord(time_coord)
         cubes.append(cube)

--- a/tests/colocation/test_colocator.py
+++ b/tests/colocation/test_colocator.py
@@ -153,6 +153,7 @@ def test_Colocator_model_add_vars(setup):
     assert isinstance(data, dict)
     assert model_var in data
     coldata = data[model_var][obs_var]
+    assert "station_type" in coldata.coords
     assert coldata.var_name == ["od550aer", "abs550aer"]
 
 
@@ -246,6 +247,7 @@ def test_Colocator_run_gridded_ungridded(
     assert isinstance(result, dict)
 
     coldata = result[chk_mvar][chk_ovar]
+    assert "station_type" in coldata.coords
     assert coldata.shape == sh
 
     mod_clim_used = any("9999" in x for x in coldata.metadata["from_files"])

--- a/tests/colocation/test_colocator.py
+++ b/tests/colocation/test_colocator.py
@@ -1,3 +1,4 @@
+import string
 from pathlib import Path
 
 import numpy as np
@@ -255,6 +256,39 @@ def test_Colocator_run_gridded_ungridded(
 
     assert np.nanmean(coldata.data[0].values) == pytest.approx(mean_obs, abs=0.01)
     assert np.nanmean(coldata.data[1].values) == pytest.approx(mean_mod, abs=0.01)
+
+
+def test_Colocator_prepare_colocation_args(monkeypatch):
+    def dummy_mdata(*args):
+        d = GriddedData()
+        d.ts_type = "hourly"
+        return d
+
+    def dummy_odata(*args):
+        d = UngriddedData()
+        d.ts_type = "hourly"
+        fake_data = list(string.ascii_lowercase)
+        for i, n in enumerate(fake_data):
+            d.metadata[i] = dict(
+                data_id="testcase",
+                station_name=n,
+                station_type=n,
+            )
+        assert d.station_name == fake_data
+        assert all("station_type" in dict.keys() for dict in d.metadata.values())
+        return d
+
+    with monkeypatch.context() as mp:
+        mp.setattr("pyaerocom.colocation.colocator.Colocator.get_model_data", dummy_mdata)
+        mp.setattr("pyaerocom.colocation.colocator.Colocator.get_obs_data", dummy_odata)
+
+        col_stp = ColocationSetup(**default_setup)
+        colocator = Colocator(col_stp)
+        colocator.start = 2015
+        colocator.stop = None
+        # with pytest.raises(DataDimensionError) as e:
+        args = colocator._prepare_colocation_args("abs550aer", "od550aer")
+        assert args["add_meta_keys"] == ["station_type"]
 
 
 @pytest.mark.parametrize(

--- a/tests/colocation/test_colocator.py
+++ b/tests/colocation/test_colocator.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from pyaerocom import ColocatedData, GriddedData, UngriddedData, const
+from pyaerocom.climatology_config import ClimatologyConfig
 from pyaerocom.colocation.colocation_setup import ColocationSetup
 from pyaerocom.colocation.colocator import Colocator
 from pyaerocom.config import ALL_REGION_NAME
@@ -13,7 +14,6 @@ from pyaerocom.exceptions import ColocationError, ColocationSetupError
 from pyaerocom.io.aux_read_cubes import add_cubes
 from pyaerocom.io.mscw_ctm.reader import ReadMscwCtm
 from tests.fixtures.data_access import TEST_DATA
-from pyaerocom.climatology_config import ClimatologyConfig
 
 COL_OUT_DEFAULT = Path(const.OUTPUTDIR) / "colocated_data"
 
@@ -292,6 +292,46 @@ def test_Colocator_prepare_colocation_args(monkeypatch):
         # with pytest.raises(DataDimensionError) as e:
         args = colocator._prepare_colocation_args("abs550aer", "od550aer")
         assert args["add_meta_keys"] == ["station_type"]
+
+
+def test_Colocator_prepare_colocation_args_malformed_metadata(monkeypatch):
+    def dummy_mdata(*args):
+        d = GriddedData()
+        d.ts_type = "hourly"
+        return d
+
+    def dummy_odata(*args):
+        d = UngriddedData()
+        d.ts_type = "hourly"
+        fake_data = list(string.ascii_lowercase)
+        # add station_type only to some
+        for i, n in enumerate(fake_data):
+            if i > len(fake_data) / 2:
+                d.metadata[i] = dict(
+                    data_id="testcase",
+                    station_name=n,
+                    station_type=n,
+                )
+            else:
+                d.metadata[i] = dict(
+                    data_id="testcase",
+                    station_name=n,
+                )
+
+        assert not all("station_type" in dict.keys() for dict in d.metadata.values())
+        return d
+
+    with monkeypatch.context() as mp:
+        mp.setattr("pyaerocom.colocation.colocator.Colocator.get_model_data", dummy_mdata)
+        mp.setattr("pyaerocom.colocation.colocator.Colocator.get_obs_data", dummy_odata)
+
+        col_stp = ColocationSetup(**default_setup)
+        colocator = Colocator(col_stp)
+        colocator.start = 2015
+        colocator.stop = None
+        with pytest.raises(ValueError) as e:
+            colocator._prepare_colocation_args("abs550aer", "od550aer")
+        assert "some stations have `station_type` metadata while others do not" == e.value.args[0]
 
 
 @pytest.mark.parametrize(

--- a/tests/colocation/test_colocator.py
+++ b/tests/colocation/test_colocator.py
@@ -278,8 +278,7 @@ def test_Colocator_prepare_colocation_args(monkeypatch):
                 station_type=n,
             )
         assert d.station_name == fake_data
-        assert all("station_type" in dict.keys() for dict in d.metadata.values())
-        assert len(set(["station_type" in dict.keys() for dict in d.metadata.values()])) == 1
+        assert {"station_type" in dict for dict in d.metadata.values()} == {True}
         return d
 
     with monkeypatch.context() as mp:
@@ -319,8 +318,7 @@ def test_Colocator_prepare_colocation_args_malformed_metadata(monkeypatch):
                     station_name=n,
                 )
 
-        assert not all("station_type" in dict.keys() for dict in d.metadata.values())
-        assert len(set(["station_type" in dict.keys() for dict in d.metadata.values()])) == 2
+        assert {"station_type" in dict for dict in d.metadata.values()} == {True, False}
         return d
 
     with monkeypatch.context() as mp:

--- a/tests/colocation/test_colocator.py
+++ b/tests/colocation/test_colocator.py
@@ -154,7 +154,6 @@ def test_Colocator_model_add_vars(setup):
     assert isinstance(data, dict)
     assert model_var in data
     coldata = data[model_var][obs_var]
-    assert "station_type" in coldata.coords
     assert coldata.var_name == ["od550aer", "abs550aer"]
 
 

--- a/tests/colocation/test_colocator.py
+++ b/tests/colocation/test_colocator.py
@@ -279,6 +279,7 @@ def test_Colocator_prepare_colocation_args(monkeypatch):
             )
         assert d.station_name == fake_data
         assert all("station_type" in dict.keys() for dict in d.metadata.values())
+        assert len(set(["station_type" in dict.keys() for dict in d.metadata.values()])) == 1
         return d
 
     with monkeypatch.context() as mp:
@@ -319,6 +320,7 @@ def test_Colocator_prepare_colocation_args_malformed_metadata(monkeypatch):
                 )
 
         assert not all("station_type" in dict.keys() for dict in d.metadata.values())
+        assert len(set(["station_type" in dict.keys() for dict in d.metadata.values()])) == 2
         return d
 
     with monkeypatch.context() as mp:

--- a/tests/io/cams2_83/test_read_obs.py
+++ b/tests/io/cams2_83/test_read_obs.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from pyaerocom import const
+from pyaerocom.io.cams2_83.obs import DEFAULT_METADATA_NAME, read_csv
 from pyaerocom.io.cams2_83.read_obs import DATA_FOLDER_PATH, ReadCAMS2_83
 from pyaerocom.io.cams2_83.read_obs import obs_paths as find_obs_paths
 from pyaerocom.io.readungridded import ReadUngridded
@@ -39,3 +40,77 @@ def test_init():
 def test_read_ungridded(obs_paths: list[Path]):
     data = ReadUngridded().read(const.CAMS2_83_NRT_NAME, "concco", files=obs_paths)
     assert isinstance(data, UngriddedData)
+
+
+def test_obs_no_metadata_file(tmp_path, caplog):
+    tmp_file = tmp_path / "obs.csv"
+    tmp_file.write_text("""
+            STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
+            AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
+            AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
+    """)
+    df = read_csv(tmp_file, polls=["o3"])
+    assert (
+        f"Metadata file {tmp_file.parent.parent / DEFAULT_METADATA_NAME} does not exist"
+        in caplog.text
+    )
+    assert df.columns.values.tolist() == [
+        "station",
+        "lat",
+        "lon",
+        "alt",
+        "time",
+        "poll",
+        "conc",
+    ]
+
+
+def test_obs_invalid_metadata_file(tmp_path, caplog):
+    tmp_dir = tmp_path / "tmp_d1"
+    tmp_dir.mkdir(parents=True)
+    tmp_file = tmp_dir / "obs.csv"
+    tmp_file.write_text("""
+            STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
+            AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
+            AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
+    """)
+    tmp_metadata_file = tmp_path / DEFAULT_METADATA_NAME
+    tmp_metadata_file.write_text("""
+                                 something not parsable, as expected
+                                 bla,bla
+                                 """)
+    df = read_csv(tmp_file, polls=["o3"])
+    assert df.columns.values.tolist() == [
+        "station",
+        "lat",
+        "lon",
+        "alt",
+        "time",
+        "poll",
+        "conc",
+    ]
+    assert f"Invalid metadata file {tmp_metadata_file}" in caplog.text
+
+
+def test_obs_empty_metadata_file(tmp_path, caplog):
+    tmp_dir = tmp_path / "tmp_d1"
+    tmp_dir.mkdir(parents=True)
+    tmp_file = tmp_dir / "obs.csv"
+    tmp_file.write_text("""
+            STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
+            AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
+            AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
+    """)
+    tmp_metadata_file = tmp_path / DEFAULT_METADATA_NAME
+    tmp_metadata_file.write_text("")
+    df = read_csv(tmp_file, polls=["o3"])
+    assert df.columns.values.tolist() == [
+        "station",
+        "lat",
+        "lon",
+        "alt",
+        "time",
+        "poll",
+        "conc",
+    ]
+    assert f"Empty metadata from {tmp_metadata_file}" in caplog.text

--- a/tests/io/cams2_83/test_read_obs.py
+++ b/tests/io/cams2_83/test_read_obs.py
@@ -76,8 +76,9 @@ def test_obs_invalid_metadata_file(tmp_path, caplog):
     """)
     tmp_metadata_file = tmp_path / DEFAULT_METADATA_NAME
     tmp_metadata_file.write_text("""
-                                 something not parsable, as expected
-                                 bla,bla
+                                 something not parsable as expected
+                                 bla;bla;bla
+                                 bla;bla;bla
                                  """)
     df = read_csv(tmp_file, polls=["O3"])
     assert df.columns.values.tolist() == [

--- a/tests/io/cams2_83/test_read_obs.py
+++ b/tests/io/cams2_83/test_read_obs.py
@@ -25,6 +25,21 @@ def obs_paths(dates: list[str | date | datetime]) -> list[Path]:
     return list(paths)
 
 
+@pytest.fixture
+def tmp_obs_file(tmp_path) -> Path:
+    tmp_dir = tmp_path / "tmp_d1"
+    tmp_dir.mkdir(parents=True)
+    tmp_file = tmp_dir / "obs.csv"
+    tmp_file.write_text(
+        """
+            STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
+            AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
+            AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
+    """
+    )
+    return tmp_file
+
+
 @pytest.mark.parametrize("dates", [TEST_DATES])
 def test_obs_paths(obs_paths: list[Path]):
     for path in obs_paths:
@@ -42,18 +57,10 @@ def test_read_ungridded(obs_paths: list[Path]):
     assert isinstance(data, UngriddedData)
 
 
-def test_obs_no_metadata_file(tmp_path, caplog):
-    tmp_file = tmp_path / "obs.csv"
-    tmp_file.write_text(
-        """
-            STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
-            AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
-            AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
-    """
-    )
-    df = read_csv(tmp_file, polls=["O3"])
+def test_obs_no_metadata_file(tmp_obs_file, caplog):
+    df = read_csv(tmp_obs_file, polls=["O3"])
     assert (
-        f"Metadata file {tmp_file.parent.parent / DEFAULT_METADATA_NAME} does not exist"
+        f"Metadata file {tmp_obs_file.parent.parent / DEFAULT_METADATA_NAME} does not exist"
         in caplog.text
     )
     assert df.columns.values.tolist() == [
@@ -67,26 +74,17 @@ def test_obs_no_metadata_file(tmp_path, caplog):
     ]
 
 
-def test_obs_invalid_metadata_file(tmp_path, caplog):
-    tmp_dir = tmp_path / "tmp_d1"
-    tmp_dir.mkdir(parents=True)
-    tmp_file = tmp_dir / "obs.csv"
-    tmp_file.write_text(
-        """
-            STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
-            AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
-            AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
-    """
-    )
-    tmp_metadata_file = tmp_path / DEFAULT_METADATA_NAME
+def test_obs_invalid_metadata_file(tmp_obs_file, caplog):
+    tmp_metadata_file = tmp_obs_file.parent.parent / DEFAULT_METADATA_NAME
     tmp_metadata_file.write_text(
         """
-                                 something not parsable as expected
-                                 bla;bla;bla
-                                 bla;bla;bla
-                                 """
+        something not parsable as expected
+        bla;bla;bla
+        bla;bla;bla
+        """
     )
-    df = read_csv(tmp_file, polls=["O3"])
+
+    df = read_csv(tmp_obs_file, polls=["O3"])
     assert df.columns.values.tolist() == [
         "station",
         "lat",
@@ -99,20 +97,11 @@ def test_obs_invalid_metadata_file(tmp_path, caplog):
     assert "Invalid metadata file" in caplog.text
 
 
-def test_obs_empty_metadata_file(tmp_path, caplog):
-    tmp_dir = tmp_path / "tmp_d1"
-    tmp_dir.mkdir(parents=True)
-    tmp_file = tmp_dir / "obs.csv"
-    tmp_file.write_text(
-        """
-            STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
-            AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
-            AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
-    """
-    )
-    tmp_metadata_file = tmp_path / DEFAULT_METADATA_NAME
+def test_obs_empty_metadata_file(tmp_obs_file, caplog):
+    tmp_metadata_file = tmp_obs_file.parent.parent / DEFAULT_METADATA_NAME
     tmp_metadata_file.write_text("station, station_type")
-    df = read_csv(tmp_file, polls=["O3"])
+
+    df = read_csv(tmp_obs_file, polls=["O3"])
     assert df.columns.values.tolist() == [
         "station",
         "lat",
@@ -125,26 +114,17 @@ def test_obs_empty_metadata_file(tmp_path, caplog):
     assert "Empty metadata" in caplog.text
 
 
-def test_obs_ok_metadata_file(tmp_path):
-    tmp_dir = tmp_path / "tmp_d1"
-    tmp_dir.mkdir(parents=True)
-    tmp_file = tmp_dir / "obs.csv"
-    tmp_file.write_text(
-        """
-            STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
-            AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
-            AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
-    """
-    )
-    tmp_metadata_file = tmp_path / DEFAULT_METADATA_NAME
+def test_obs_ok_metadata_file(tmp_obs_file):
+    tmp_metadata_file = tmp_obs_file.parent.parent / DEFAULT_METADATA_NAME
     tmp_metadata_file.write_text(
         """
-                                 something, something, something
-                                 bla, bla, bla
-                                 bla, bla, bla
-                                 """
+        something, something, something
+        bla, bla, bla
+        bla, bla, bla
+        """
     )
-    df = read_csv(tmp_file, polls=["O3"])
+
+    df = read_csv(tmp_obs_file, polls=["O3"])
     assert df.columns.values.tolist() == [
         "station",
         "lat",
@@ -157,27 +137,17 @@ def test_obs_ok_metadata_file(tmp_path):
     ]
 
 
-def test_obs_read_to_ungridded(tmp_path, caplog):
-    tmp_dir = tmp_path / "tmp_d1"
-    tmp_dir.mkdir(parents=True)
-    tmp_file = tmp_dir / "obs.csv"
-    tmp_file.write_text(
-        """
-            STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
-            AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
-            AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
-    """
-    )
-    tmp_metadata_file = tmp_path / DEFAULT_METADATA_NAME
+def test_obs_read_to_ungridded(tmp_obs_file, caplog):
+    tmp_metadata_file = tmp_obs_file.parent.parent / DEFAULT_METADATA_NAME
     tmp_metadata_file.write_text(
         """
-                                 something, something, something
-                                 AT0ENK1, bla, rur
-                                 AT0ENK1, bla, sub
-                                 """
+        something, something, something
+        AT0ENK1, bla, rur
+        AT0ENK1, bla, sub
+        """
     )
     reader = ReadCAMS2_83()
-    data = reader.read(vars_to_retrieve=["conco3"], files=[tmp_file])
+    data = reader.read(vars_to_retrieve=["conco3"], files=[tmp_obs_file])
     assert isinstance(data, UngriddedData)
     assert "Time needed to convert obs to ungridded" in caplog.text
     assert all("station_type" in dict.keys() for dict in data.metadata.values())

--- a/tests/io/cams2_83/test_read_obs.py
+++ b/tests/io/cams2_83/test_read_obs.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
+from textwrap import dedent
 
 import pytest
 
@@ -18,32 +19,30 @@ TEST_DATES = [TEST_DATE + timedelta(days=d) for d in range(3)]
 
 
 @pytest.fixture
-def obs_paths(dates: list[str | date | datetime]) -> list[Path]:
+def obs_paths() -> list[Path]:
     if not DATA_FOLDER_PATH.is_dir():
         pytest.skip(f"no access to {DATA_FOLDER_PATH}")
-    paths = find_obs_paths(*dates)
+    paths = find_obs_paths(*TEST_DATES)
     return list(paths)
 
 
 @pytest.fixture
-def tmp_obs_file(tmp_path) -> Path:
-    tmp_dir = tmp_path / "tmp_d1"
-    tmp_dir.mkdir(parents=True)
-    tmp_file = tmp_dir / "obs.csv"
-    tmp_file.write_text(
+def obs_file(tmp_path: Path) -> Path:
+    obs = """
+        STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
+        AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
+        AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
         """
-            STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
-            AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
-            AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
-    """
-    )
-    return tmp_file
+
+    path = tmp_path / "tmp_d1" / "obs.csv"
+    path.parent.mkdir(parents=True)
+    path.write_text(dedent(obs))
+    return path
 
 
-@pytest.mark.parametrize("dates", [TEST_DATES])
-def test_obs_paths(obs_paths: list[Path]):
-    for path in obs_paths:
-        assert path.exists()
+@pytest.fixture
+def metadata_file(tmp_path: Path) -> Path:
+    return tmp_path / DEFAULT_METADATA_NAME
 
 
 def test_init():
@@ -51,103 +50,77 @@ def test_init():
     assert isinstance(data, ReadUngriddedBase)
 
 
-@pytest.mark.parametrize("dates", [TEST_DATES])
+def test_obs_paths(obs_paths: list[Path]):
+    for path in obs_paths:
+        assert path.exists()
+
+
 def test_read_ungridded(obs_paths: list[Path]):
     data = ReadUngridded().read(const.CAMS2_83_NRT_NAME, "concco", files=obs_paths)
     assert isinstance(data, UngriddedData)
 
 
-def test_obs_no_metadata_file(tmp_obs_file, caplog):
-    df = read_csv(tmp_obs_file, polls=["O3"])
-    assert (
-        f"Metadata file {tmp_obs_file.parent.parent / DEFAULT_METADATA_NAME} does not exist"
-        in caplog.text
-    )
-    assert df.columns.values.tolist() == [
-        "station",
-        "lat",
-        "lon",
-        "alt",
-        "time",
-        "poll",
-        "conc",
-    ]
+def test_obs_no_metadata_file(
+    obs_file: Path, metadata_file: Path, caplog: pytest.LogCaptureFixture
+):
+    df = read_csv(obs_file, polls=["O3"])
+    assert f"Metadata file {metadata_file} does not exist" in caplog.text
+    assert list(df) == ["station", "lat", "lon", "alt", "time", "poll", "conc"]
 
 
-def test_obs_invalid_metadata_file(tmp_obs_file, caplog):
-    tmp_metadata_file = tmp_obs_file.parent.parent / DEFAULT_METADATA_NAME
-    tmp_metadata_file.write_text(
-        """
+def test_obs_invalid_metadata_file(
+    obs_file: Path, metadata_file: Path, caplog: pytest.LogCaptureFixture
+):
+    metadata = """
         something not parsable as expected
         bla;bla;bla
         bla;bla;bla
         """
-    )
+    metadata_file.write_text(dedent(metadata))
 
-    df = read_csv(tmp_obs_file, polls=["O3"])
-    assert df.columns.values.tolist() == [
-        "station",
-        "lat",
-        "lon",
-        "alt",
-        "time",
-        "poll",
-        "conc",
-    ]
+    df = read_csv(obs_file, polls=["O3"])
+    assert list(df) == ["station", "lat", "lon", "alt", "time", "poll", "conc"]
     assert "Invalid metadata file" in caplog.text
 
 
-def test_obs_empty_metadata_file(tmp_obs_file, caplog):
-    tmp_metadata_file = tmp_obs_file.parent.parent / DEFAULT_METADATA_NAME
-    tmp_metadata_file.write_text("station, station_type")
+def test_obs_empty_metadata_file(
+    obs_file: Path, metadata_file: Path, caplog: pytest.LogCaptureFixture
+):
+    metadata = "station, station_type"
+    metadata_file.write_text(metadata)
 
-    df = read_csv(tmp_obs_file, polls=["O3"])
-    assert df.columns.values.tolist() == [
-        "station",
-        "lat",
-        "lon",
-        "alt",
-        "time",
-        "poll",
-        "conc",
-    ]
+    df = read_csv(obs_file, polls=["O3"])
+    assert list(df) == ["station", "lat", "lon", "alt", "time", "poll", "conc"]
     assert "Empty metadata" in caplog.text
 
 
-def test_obs_ok_metadata_file(tmp_obs_file):
-    tmp_metadata_file = tmp_obs_file.parent.parent / DEFAULT_METADATA_NAME
-    tmp_metadata_file.write_text(
-        """
+def test_obs_ok_metadata_file(obs_file: Path, metadata_file: Path):
+    metadata = """
         something, something, something
         bla, bla, bla
         bla, bla, bla
         """
-    )
+    metadata_file.write_text(dedent(metadata))
 
-    df = read_csv(tmp_obs_file, polls=["O3"])
-    assert df.columns.values.tolist() == [
-        "station",
-        "lat",
-        "lon",
-        "alt",
-        "time",
-        "poll",
-        "conc",
-        "station_type",
-    ]
+    df = read_csv(obs_file, polls=["O3"])
+    assert list(df) == ["station", "lat", "lon", "alt", "time", "poll", "conc", "station_type"]
+    assert df["station_type"].isna().all()
 
 
-def test_obs_read_to_ungridded(tmp_obs_file, caplog):
-    tmp_metadata_file = tmp_obs_file.parent.parent / DEFAULT_METADATA_NAME
-    tmp_metadata_file.write_text(
-        """
+def test_obs_read_to_ungridded(
+    obs_file: Path, metadata_file: Path, caplog: pytest.LogCaptureFixture
+):
+    metadata = """
         something, something, something
         AT0ENK1, bla, rur
-        AT0ENK1, bla, sub
+        AT0ILL1, bla, sub
         """
-    )
+    metadata_file.write_text(dedent(metadata))
+
     reader = ReadCAMS2_83()
-    data = reader.read(vars_to_retrieve=["conco3"], files=[tmp_obs_file])
+    data = reader.read(vars_to_retrieve=["conco3"], files=[obs_file])
     assert isinstance(data, UngriddedData)
     assert "Time needed to convert obs to ungridded" in caplog.text
-    assert all("station_type" in dict.keys() for dict in data.metadata.values())
+    assert all("station_type" in dict for dict in data.metadata.values())
+    print(data.metadata)
+    assert {dict["station_type"] for dict in data.metadata.values()} == {"rur", "sub"}

--- a/tests/io/cams2_83/test_read_obs.py
+++ b/tests/io/cams2_83/test_read_obs.py
@@ -96,7 +96,7 @@ def test_obs_invalid_metadata_file(tmp_path, caplog):
         "poll",
         "conc",
     ]
-    assert f"Invalid metadata file {tmp_metadata_file}" in caplog.text
+    assert "Invalid metadata file" in caplog.text
 
 
 def test_obs_empty_metadata_file(tmp_path, caplog):
@@ -111,7 +111,7 @@ def test_obs_empty_metadata_file(tmp_path, caplog):
     """
     )
     tmp_metadata_file = tmp_path / DEFAULT_METADATA_NAME
-    tmp_metadata_file.write_text("")
+    tmp_metadata_file.write_text("station, station_type")
     df = read_csv(tmp_file, polls=["O3"])
     assert df.columns.values.tolist() == [
         "station",
@@ -122,7 +122,7 @@ def test_obs_empty_metadata_file(tmp_path, caplog):
         "poll",
         "conc",
     ]
-    assert f"Empty metadata from {tmp_metadata_file}" in caplog.text
+    assert "Empty metadata" in caplog.text
 
 
 def test_obs_ok_metadata_file(tmp_path):

--- a/tests/io/cams2_83/test_read_obs.py
+++ b/tests/io/cams2_83/test_read_obs.py
@@ -44,11 +44,13 @@ def test_read_ungridded(obs_paths: list[Path]):
 
 def test_obs_no_metadata_file(tmp_path, caplog):
     tmp_file = tmp_path / "obs.csv"
-    tmp_file.write_text("""
+    tmp_file.write_text(
+        """
             STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
             AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
             AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
-    """)
+    """
+    )
     df = read_csv(tmp_file, polls=["O3"])
     assert (
         f"Metadata file {tmp_file.parent.parent / DEFAULT_METADATA_NAME} does not exist"
@@ -69,17 +71,21 @@ def test_obs_invalid_metadata_file(tmp_path, caplog):
     tmp_dir = tmp_path / "tmp_d1"
     tmp_dir.mkdir(parents=True)
     tmp_file = tmp_dir / "obs.csv"
-    tmp_file.write_text("""
+    tmp_file.write_text(
+        """
             STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
             AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
             AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
-    """)
+    """
+    )
     tmp_metadata_file = tmp_path / DEFAULT_METADATA_NAME
-    tmp_metadata_file.write_text("""
+    tmp_metadata_file.write_text(
+        """
                                  something not parsable as expected
                                  bla;bla;bla
                                  bla;bla;bla
-                                 """)
+                                 """
+    )
     df = read_csv(tmp_file, polls=["O3"])
     assert df.columns.values.tolist() == [
         "station",
@@ -97,11 +103,13 @@ def test_obs_empty_metadata_file(tmp_path, caplog):
     tmp_dir = tmp_path / "tmp_d1"
     tmp_dir.mkdir(parents=True)
     tmp_file = tmp_dir / "obs.csv"
-    tmp_file.write_text("""
+    tmp_file.write_text(
+        """
             STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
             AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
             AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
-    """)
+    """
+    )
     tmp_metadata_file = tmp_path / DEFAULT_METADATA_NAME
     tmp_metadata_file.write_text("")
     df = read_csv(tmp_file, polls=["O3"])
@@ -117,21 +125,25 @@ def test_obs_empty_metadata_file(tmp_path, caplog):
     assert f"Empty metadata from {tmp_metadata_file}" in caplog.text
 
 
-def test_obs_ok_metadata_file(tmp_path, caplog):
+def test_obs_ok_metadata_file(tmp_path):
     tmp_dir = tmp_path / "tmp_d1"
     tmp_dir.mkdir(parents=True)
     tmp_file = tmp_dir / "obs.csv"
-    tmp_file.write_text("""
+    tmp_file.write_text(
+        """
             STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
             AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
             AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
-    """)
+    """
+    )
     tmp_metadata_file = tmp_path / DEFAULT_METADATA_NAME
-    tmp_metadata_file.write_text("""
+    tmp_metadata_file.write_text(
+        """
                                  something, something, something
                                  bla, bla, bla
                                  bla, bla, bla
-                                 """)
+                                 """
+    )
     df = read_csv(tmp_file, polls=["O3"])
     assert df.columns.values.tolist() == [
         "station",
@@ -143,3 +155,29 @@ def test_obs_ok_metadata_file(tmp_path, caplog):
         "conc",
         "station_type",
     ]
+
+
+def test_obs_read_to_ungridded(tmp_path, caplog):
+    tmp_dir = tmp_path / "tmp_d1"
+    tmp_dir.mkdir(parents=True)
+    tmp_file = tmp_dir / "obs.csv"
+    tmp_file.write_text(
+        """
+            STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
+            AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
+            AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
+    """
+    )
+    tmp_metadata_file = tmp_path / DEFAULT_METADATA_NAME
+    tmp_metadata_file.write_text(
+        """
+                                 something, something, something
+                                 AT0ENK1, bla, rur
+                                 AT0ENK1, bla, sub
+                                 """
+    )
+    reader = ReadCAMS2_83()
+    data = reader.read(vars_to_retrieve=["conco3"], files=[tmp_file])
+    assert isinstance(data, UngriddedData)
+    assert "Time needed to convert obs to ungridded" in caplog.text
+    assert all("station_type" in dict.keys() for dict in data.metadata.values())

--- a/tests/io/cams2_83/test_read_obs.py
+++ b/tests/io/cams2_83/test_read_obs.py
@@ -49,7 +49,7 @@ def test_obs_no_metadata_file(tmp_path, caplog):
             AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
             AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
     """)
-    df = read_csv(tmp_file, polls=["o3"])
+    df = read_csv(tmp_file, polls=["O3"])
     assert (
         f"Metadata file {tmp_file.parent.parent / DEFAULT_METADATA_NAME} does not exist"
         in caplog.text
@@ -79,7 +79,7 @@ def test_obs_invalid_metadata_file(tmp_path, caplog):
                                  something not parsable, as expected
                                  bla,bla
                                  """)
-    df = read_csv(tmp_file, polls=["o3"])
+    df = read_csv(tmp_file, polls=["O3"])
     assert df.columns.values.tolist() == [
         "station",
         "lat",
@@ -103,7 +103,7 @@ def test_obs_empty_metadata_file(tmp_path, caplog):
     """)
     tmp_metadata_file = tmp_path / DEFAULT_METADATA_NAME
     tmp_metadata_file.write_text("")
-    df = read_csv(tmp_file, polls=["o3"])
+    df = read_csv(tmp_file, polls=["O3"])
     assert df.columns.values.tolist() == [
         "station",
         "lat",
@@ -114,3 +114,31 @@ def test_obs_empty_metadata_file(tmp_path, caplog):
         "conc",
     ]
     assert f"Empty metadata from {tmp_metadata_file}" in caplog.text
+
+
+def test_obs_ok_metadata_file(tmp_path, caplog):
+    tmp_dir = tmp_path / "tmp_d1"
+    tmp_dir.mkdir(parents=True)
+    tmp_file = tmp_dir / "obs.csv"
+    tmp_file.write_text("""
+            STATION;LAT;LON;ALT(m);PARAMETER;YEAR;MONTH;DAY;HOUR;AVERAGING_PERIOD(h);CONCENTRATION(kg/m3)
+            AT0ENK1;48.392; 13.671;0525;o3;2025;02;12;01;1; 4.27600e-08
+            AT0ILL1;47.770; 16.766;0117;o3;2025;02;12;01;1; 6.56700e-08
+    """)
+    tmp_metadata_file = tmp_path / DEFAULT_METADATA_NAME
+    tmp_metadata_file.write_text("""
+                                 something, something, something
+                                 bla, bla, bla
+                                 bla, bla, bla
+                                 """)
+    df = read_csv(tmp_file, polls=["O3"])
+    assert df.columns.values.tolist() == [
+        "station",
+        "lat",
+        "lon",
+        "alt",
+        "time",
+        "poll",
+        "conc",
+        "station_type",
+    ]


### PR DESCRIPTION
## Change Summary

- station_type read from a (basically hardcoded) metadata file is added to the UngriddedData object read via the ReadCAMS2_83 reader
- station_type is added to StationData if found in the ungridded data and written to the colocated data too
- station_type is also handled in the colocated data -> json pipeline so to land in the map files (where the fairmode stats are also written, for now) like this:
  ```
  {
        "station_name": "SK0066A",
        "station_type": "sub",
        "latitude": 49.119,
        "longitude": 18.325,
        "altitude": 265.0,
        "region": [
            "Slovakia"
        ],
        ...
  ```
- none of this is pretty and it probably breaks some things 

## Related issue number
tackles #1523 but it's worth keeping the possibility open that that issue could be solved by a look-up table kind of operation on the frontend side perhaps

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
