### PR TITLE
CF compliance when standard_name and axis are missing

### DIFF
--- a/pyaerocom/projection_information.py
+++ b/pyaerocom/projection_information.py
@@ -51,7 +51,8 @@ class ProjectionInformation:
         if "grid_mapping" not in da.attrs:
             return None
         pi = ProjectionInformation()
-        pi._crs = CRS.from_cf(ds[da.grid_mapping].attrs)
+        grid_mapping = ds[da.attrs["grid_mapping"]]
+        pi._crs = CRS.from_cf(grid_mapping.attrs)
 
         for c in da.coords:
             if len(da.coords[c].dims) != 1:
@@ -68,6 +69,17 @@ class ProjectionInformation:
                 if da.coords[c].axis in ("x", "X"):
                     pi._x_axis = c
                     break
+            units = ds.coords[c].attrs.get("units")
+            if units in [
+                "degrees_east",
+                "degree_east",
+                "degree_E",
+                "degrees_E",
+                "degreeE",
+                "degreesE",
+            ]:
+                pi._x_axis = c
+                break
         for c in da.coords:
             if len(da.coords[c].dims) != 1:
                 continue
@@ -83,6 +95,17 @@ class ProjectionInformation:
                 if da.coords[c].axis in ("y", "Y"):
                     pi._y_axis = c
                     break
+            units = ds.coords[c].attrs.get("units")
+            if units in [
+                "degrees_north",
+                "degree_north",
+                "degree_N",
+                "degrees_N",
+                "degreeN",
+                "degreesN",
+            ]:
+                pi._y_axis = c
+                break
         if pi._x_axis is None or pi._y_axis is None:
             raise ProjectionInformationException(f"no x or y axis found for variable '{var}'")
         pi._units = da.coords[pi._y_axis].units

--- a/tests/test_projection_info.py
+++ b/tests/test_projection_info.py
@@ -1,5 +1,6 @@
 import xarray
 from pytest import approx
+import numpy as np
 
 from pyaerocom.projection_information import ProjectionInformation
 from tests.fixtures.data_access import TEST_DATA
@@ -24,3 +25,36 @@ def test_projection_information():
         x, y = pi.to_proj(lat, lon)
         assert x == approx(x0, abs=1.0)
         assert y == approx(y0, abs=1.0)
+
+
+def test_projection_snap():
+    x = [10, 12, 13]
+    y = [60, 61]
+
+    lons, lats = np.meshgrid(x, y)
+
+    field = np.ones_like(lons)
+
+    ds = xarray.Dataset(
+        {
+            "x": xarray.DataArray(x, coords={"x": x}, attrs={"units": "degrees_east"}),
+            "y": xarray.DataArray(y, coords={"y": y}, attrs={"units": "degrees_north"}),
+            "lons": xarray.DataArray(lons, dims=["y", "x"], attrs={"units": "degrees_east"}),
+            "lats": xarray.DataArray(lats, dims=["y", "x"], attrs={"units": "degrees_north"}),
+            "field": xarray.DataArray(
+                field,
+                dims=["y", "x"],
+                attrs={"grid_mapping": "projection", "coordinates": "longitude latitude"},
+            ),
+            "projection": xarray.DataArray(0, attrs={"grid_mapping_name": "latitude_longitude"}),
+        }
+    )
+    pi = ProjectionInformation.from_xarray(ds, "field")
+    assert pi._x_axis == "x"
+    assert pi._y_axis == "y"
+
+    # Transform like an identity matrix
+    y0, x0 = 11, 61.5
+    (lat, lon) = pi.to_latlon(x0, y0)
+    assert x0 == approx(lon, abs=1e-3)
+    assert y0 == approx(lat, abs=1e-3)


### PR DESCRIPTION
## Change Summary

A coordinate axis can be identified with `degrees_{north/east}` [0], which is currently not recognized by pyaerocom. This PR reads the `units` attribute to determine if the coordinate is an axis. This is necessary to read files created by e.g. SNAP


[0] https://cfconventions.org/Data/cf-conventions/cf-conventions-1.12/cf-conventions.html#latitude-coordinate


<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
