### PR TITLE
make add_season configurable from cl for CAMS2_83

### DIFF
--- a/pyaerocom/scripts/cams2_83/cli.py
+++ b/pyaerocom/scripts/cams2_83/cli.py
@@ -208,7 +208,7 @@ def main(
         add_seasons,
         fairmode,
     )
-
+    
     # we do not want the cache produced in previous runs to be silently cleared
     const.RM_CACHE_OUTDATED = False
 

--- a/pyaerocom/scripts/cams2_83/cli.py
+++ b/pyaerocom/scripts/cams2_83/cli.py
@@ -55,6 +55,7 @@ def make_config(
     run_type: RunType,
     only_map: bool,
     add_map: bool,
+    add_seasons: bool,
     fairmode: bool,
 ) -> dict:
     logger.info("Making the configuration")
@@ -100,6 +101,9 @@ def make_config(
 
     if only_map:
         cfg.update(add_model_maps=True, only_model_maps=True)
+
+    if add_seasons:
+        cfg.update(add_seasons=True)    
 
     if fairmode:
         cfg.update(use_fairmode=True)
@@ -152,6 +156,7 @@ def main(
     only_map: bool = typer.Option(
         False, "--onlymap", help="set add_model_maps and only_model_maps"
     ),
+    add_seasons: bool = typer.Option(False, "--addseasons", help="set add_seasons"),
     fairmode: bool = typer.Option(False, "--fairmode", help="set use_fairmode"),
     medianscores: bool = typer.Option(
         False,
@@ -200,6 +205,7 @@ def main(
         run_type,
         only_map,
         add_map,
+        add_seasons,
         fairmode,
     )
 

--- a/pyaerocom/scripts/cams2_83/config.py
+++ b/pyaerocom/scripts/cams2_83/config.py
@@ -43,6 +43,7 @@ GLOBAL_CONFIG = dict(
         "2021-2022"
     ],  # Periodes, can be single years or range, e.g. 2010-2015. EMEP only supports single years as of now
     main_freq="hourly",  # default frequency to use. This will be overwritten in most of the observation options (see below)
+    add_seasons=False,
     # This has to be true for the web interface to show diurnal evaluation
     use_diurnal=False,
     # O3 is special, since we want to look at daily max

--- a/tests/cams2_83/test_cams2_83_cli.py
+++ b/tests/cams2_83/test_cams2_83_cli.py
@@ -69,7 +69,7 @@ def test_config_options(
     tmp_path: Path,
     caplog,
 ):
-    options = f"forecast week 2024-03-16 2024-03-23 --model-path {tmp_path} --obs-path {tmp_path} --data-path {tmp_path} --coldata-path {tmp_path} --cache {tmp_path} --id test_config --fairmode --addmap --addseasons"
+    options = f"forecast week 2024-03-16 2024-03-23 --model-path {tmp_path} --obs-path {tmp_path} --data-path {tmp_path} --coldata-path {tmp_path} --id test_config --fairmode --addmap --addseasons"
     runner.invoke(app, options.split())
     print(caplog.text)
     assert "'add_model_maps': True," in caplog.text

--- a/tests/cams2_83/test_cams2_83_cli.py
+++ b/tests/cams2_83/test_cams2_83_cli.py
@@ -10,21 +10,6 @@ from pyaerocom.scripts.cams2_83.cli import app
 runner = CliRunner()
 
 
-def test_config_options(
-    fake_cache_path: Path,
-    tmp_path: Path,
-    caplog,
-):
-    options = f"forecast week 2024-03-16 2024-03-23 --model-path {tmp_path} --obs-path {tmp_path} --data-path {tmp_path} --coldata-path {tmp_path} --cache {fake_cache_path} --id test_config --fairmode --addmap --addseasons"
-    runner.invoke(app, options.split())
-    print(caplog.text)
-    assert "'add_model_maps': True," in caplog.text
-    assert "'add_seasons': True," in caplog.text
-    assert "'exp_id': 'test_config'," in caplog.text
-    assert "'use_fairmode': True," in caplog.text
-    assert "'periods': ['20240316-20240323']," in caplog.text
-
-
 @pytest.mark.usefixtures("fake_ExperimentProcessor", "reset_cachedir")
 def test_clearcache(
     monkeypatch,
@@ -78,3 +63,17 @@ def test_eval_medianscores_dummy(
     assert result.exit_code == 0
     assert "Running CAMS2_83 Specific Statistics, cache is not cleared" in caplog.text
     assert "Failed to read model variable" in caplog.text
+
+
+def test_config_options(
+    tmp_path: Path,
+    caplog,
+):
+    options = f"forecast week 2024-03-16 2024-03-23 --model-path {tmp_path} --obs-path {tmp_path} --data-path {tmp_path} --coldata-path {tmp_path} --cache {tmp_path} --id test_config --fairmode --addmap --addseasons"
+    runner.invoke(app, options.split())
+    print(caplog.text)
+    assert "'add_model_maps': True," in caplog.text
+    assert "'add_seasons': True," in caplog.text
+    assert "'exp_id': 'test_config'," in caplog.text
+    assert "'use_fairmode': True," in caplog.text
+    assert "'periods': ['20240316-20240323']," in caplog.text

--- a/tests/cams2_83/test_cams2_83_cli.py
+++ b/tests/cams2_83/test_cams2_83_cli.py
@@ -71,7 +71,6 @@ def test_config_options(
 ):
     options = f"forecast week 2024-03-16 2024-03-23 --model-path {tmp_path} --obs-path {tmp_path} --data-path {tmp_path} --coldata-path {tmp_path} --id test_config --fairmode --addmap --addseasons"
     runner.invoke(app, options.split())
-    print(caplog.text)
     assert "'add_model_maps': True," in caplog.text
     assert "'add_seasons': True," in caplog.text
     assert "'exp_id': 'test_config'," in caplog.text

--- a/tests/cams2_83/test_cams2_83_cli.py
+++ b/tests/cams2_83/test_cams2_83_cli.py
@@ -11,10 +11,11 @@ runner = CliRunner()
 
 
 def test_config_options(
+    fake_cache_path: Path,
     tmp_path: Path,
     caplog,
 ):
-    options = f"forecast week 2024-03-16 2024-03-23 --model-path {tmp_path} --obs-path {tmp_path} --data-path {tmp_path} --coldata-path {tmp_path} --cache {tmp_path} --id test_config --fairmode --addmap --addseasons"
+    options = f"forecast week 2024-03-16 2024-03-23 --model-path {tmp_path} --obs-path {tmp_path} --data-path {tmp_path} --coldata-path {tmp_path} --cache {fake_cache_path} --id test_config --fairmode --addmap --addseasons"
     runner.invoke(app, options.split())
     print(caplog.text)
     assert "'add_model_maps': True," in caplog.text

--- a/tests/cams2_83/test_cams2_83_cli.py
+++ b/tests/cams2_83/test_cams2_83_cli.py
@@ -10,6 +10,20 @@ from pyaerocom.scripts.cams2_83.cli import app
 runner = CliRunner()
 
 
+def test_config_options(
+    tmp_path: Path,
+    caplog,
+):
+    options = f"forecast week 2024-03-16 2024-03-23 --model-path {tmp_path} --obs-path {tmp_path} --data-path {tmp_path} --coldata-path {tmp_path} --cache {tmp_path} --id test_config --fairmode --addmap --addseasons"
+    runner.invoke(app, options.split())
+    print(caplog.text)
+    assert "'add_model_maps': True," in caplog.text
+    assert "'add_seasons': True," in caplog.text
+    assert "'exp_id': 'test_config'," in caplog.text
+    assert "'use_fairmode': True," in caplog.text
+    assert "'periods': ['20240316-20240323']," in caplog.text
+
+
 @pytest.mark.usefixtures("fake_ExperimentProcessor", "reset_cachedir")
 def test_clearcache(
     monkeypatch,

--- a/tests/io/cams2_83/test_read_obs.py
+++ b/tests/io/cams2_83/test_read_obs.py
@@ -122,5 +122,4 @@ def test_obs_read_to_ungridded(
     assert isinstance(data, UngriddedData)
     assert "Time needed to convert obs to ungridded" in caplog.text
     assert all("station_type" in dict for dict in data.metadata.values())
-    print(data.metadata)
     assert {dict["station_type"] for dict in data.metadata.values()} == {"rur", "sub"}


### PR DESCRIPTION
having `add_seasons=True` does not make sense for week/day/single-season experiments, so we set it False by default and introduce a command line argument that can be used by the long multi-season evaluations, where it actually makes sense to have it  

example of results for a week evaluation with add_seasons=False
https://aeroval-test.met.no/charlien/pages/evaluation/?project=cams2-83&experiment=test_noseasons

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
