### PR TITLE
change logging level for message about station_type not found in StationData

### DIFF
--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -1303,7 +1303,9 @@ class UngriddedData:
                 if hasattr(data, "station_type"):
                     out_data["station_type"].append(data["station_type"])
                 else:
-                    logger.info("No station_type found in StationData, station_type will be blank")
+                    logger.debug(
+                        "No station_type found in StationData, station_type will be blank"
+                    )
                 out_data["stats"].append(data)
 
             # catch the exceptions that are acceptable


### PR DESCRIPTION
## Change Summary

logging.info is too noisy given that most experiment do not have station_type passed to ungriddeddata at the moment

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
