### PR TITLE
use_meteorological_seasons option allows for handling DJF according to the meteorological definition

### DIFF
--- a/docs/_static/aeroval/cfg_examples_example1.py
+++ b/docs/_static/aeroval/cfg_examples_example1.py
@@ -147,8 +147,19 @@ GLOB_CFG = dict(
     main_freq="monthly",
     # Time periods for which statistical parameters are computed
     periods=["2010"],
-    # Whether or not to add seasonal statistics
+    # Whether or not to add seasonal statistics.
+    # If True seasons are ['all', 'DJF', 'MAM', 'JJA', 'SON'],
+    # if False, just ['all']
     add_seasons=True,
+    # Wheter or not statistics are based on the meteorological definition of seasons.
+    # This is relevant for periods that are a single year. So if use_meteorological_seasons=True
+    # and add_seasons=True, for a given year ['DJF'] will refer to data from Dec of the previous year
+    # (if available) and Jan/Feb of the same year, while if use_meteorological_seasons=False,
+    # it will refer to data from Jan/Feb and December of the same year. Similarly, and independently
+    # of the value of add_seasons, if use_meteorological_seasons=True, ['all'] (whole year) will refer
+    # to data from Dec of the previous year to Nov of the same year, while if False, it will refer to data
+    # from Jan to Dec of the same year.
+    use_meteorological_seasons=False,
     # Whether or not to add trends output to the analysis. Trends analysis
     # needs at least 7 years of data, so this is skipped here for this
     # single year experiment

--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -86,6 +86,7 @@ class ColdataToJsonEngine(ProcessingEngine):
         freqs = self.cfg.time_cfg.freqs
         periods = self.cfg.time_cfg.periods
         seasons = self.cfg.time_cfg.get_seasons()
+        use_meteorological_seasons = self.cfg.time_cfg.use_meteorological_seasons
         main_freq = self.cfg.time_cfg.main_freq
         annual_stats_constrained = self.cfg.statistics_opts.annual_stats_constrained
 
@@ -228,6 +229,7 @@ class ColdataToJsonEngine(ProcessingEngine):
                     stats_min_num=stats_min_num,
                     use_fairmode=use_fairmode,
                     avg_over_trends=avg_over_trends,
+                    use_meteorological_seasons=use_meteorological_seasons,
                 )
             if coldata.ts_type == "hourly" and use_diurnal:
                 logger.info("Processing diurnal profiles")
@@ -363,6 +365,7 @@ class ColdataToJsonEngine(ProcessingEngine):
         stats_min_num: int = 1,
         use_fairmode: bool = False,
         avg_over_trends: bool = False,
+        use_meteorological_seasons: bool = False,
     ):
         input_freq = self.cfg.statistics_opts.stats_tseries_base_freq
 
@@ -414,6 +417,7 @@ class ColdataToJsonEngine(ProcessingEngine):
             add_trends,
             trends_min_yrs,
             avg_over_trends,
+            use_meteorological_seasons,
         )
 
         for freq, hm_data in hm_all.items():

--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -251,6 +251,7 @@ class ColdataToJsonEngine(ProcessingEngine):
                 seasons=seasons,
                 obs_name=obs_name,
                 var_name_web=var_name_web,
+                use_meteorological_seasons=use_meteorological_seasons,
             )
 
         logger.info(
@@ -295,6 +296,7 @@ class ColdataToJsonEngine(ProcessingEngine):
         seasons: tuple[str, ...] = None,
         obs_name: str = None,
         var_name_web: str = None,
+        use_meteorological_seasons: bool = False,
     ):
         if region_names is None and station_names is None:
             raise ValueError("Both region_id and station_name can not both be None")
@@ -307,6 +309,7 @@ class ColdataToJsonEngine(ProcessingEngine):
                 use_country=use_country,
                 periods=periods,
                 seasons=seasons,
+                use_meteorological_seasons=use_meteorological_seasons,
             )
             location = region_names[regid]
             self.exp_output.add_profile_entry(
@@ -327,6 +330,7 @@ class ColdataToJsonEngine(ProcessingEngine):
                 use_country=use_country,
                 periods=periods,
                 seasons=seasons,
+                use_meteorological_seasons=use_meteorological_seasons,
             )
 
             self.exp_output.add_profile_entry(

--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -464,6 +464,7 @@ class ColdataToJsonEngine(ProcessingEngine):
                 use_fairmode,
                 obs_var,
                 drop_stats,
+                use_meteorological_seasons,
             )
 
             with self.avdb.lock():

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1263,7 +1263,7 @@ def _select_period_season_coldata(coldata, period, season, use_meteorological_se
             # for period = '2022' tslice needs to be slice('2021-12','2022-11')
             yeardt = datetime.strptime(period, "%Y")
             tslice = slice(f"{yeardt.year - 1}-12", f"{yeardt.year}-11")
-            logger.info(f"Using meteorological year slicing for {period}: {tslice}")
+            logger.debug(f"Using meteorological year slicing for {period}: {tslice}")
     # expensive, try use solution with numpy indexing directly...
     # also, keep an eye on: https://github.com/pydata/xarray/issues/2799
     arr = coldata.data.sel(time=tslice)

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -976,6 +976,7 @@ def _process_map_and_scat(
     use_fairmode,
     obs_var,
     drop_stats,
+    use_meteorological_seasons,
 ):
     stats_dummy = _init_stats_dummy(drop_stats=drop_stats)
     scat_data = {}
@@ -986,7 +987,9 @@ def _process_map_and_scat(
                 use_dummy = cd is None
                 if not use_dummy:
                     try:
-                        subset = _select_period_season_coldata(cd, per, season)
+                        subset = _select_period_season_coldata(
+                            cd, per, season, use_meteorological_seasons
+                        )
                         jsdate = subset.data.jsdate.values.tolist()
                     except (DataCoverageError, TemporalResolutionError):
                         use_dummy = True
@@ -1253,8 +1256,14 @@ def _calc_temporal_corr(coldata):
         return (np.nanmean(corr_time.data), np.nanmedian(corr_time.data))
 
 
-def _select_period_season_coldata(coldata, period, season):
+def _select_period_season_coldata(coldata, period, season, use_meteorological_seasons):
     tslice = _period_str_to_timeslice(period)
+    if use_meteorological_seasons:
+        if len(period) == 4:  # relevant only for single years
+            # for period = '2022' tslice needs to be slice('2021-12','2022-11')
+            yeardt = datetime.strptime(period, "%Y")
+            tslice = slice(f"{yeardt.year - 1}-12", f"{yeardt.year}-11")
+            logger.info(f"Using meteorological year slicing for {period}: {tslice}")
     # expensive, try use solution with numpy indexing directly...
     # also, keep an eye on: https://github.com/pydata/xarray/issues/2799
     arr = coldata.data.sel(time=tslice)
@@ -1423,8 +1432,7 @@ def _process_statistics_timeseries(
     # input frequency is lower resolution than output frequency
     if TsType(data_freq) < TsType(freq):
         raise TemporalResolutionError(
-            f"Desired input frequency {data_freq} is lower than desired "
-            f"output frequency {freq}"
+            f"Desired input frequency {data_freq} is lower than desired output frequency {freq}"
         )
 
     output = {}
@@ -1672,7 +1680,7 @@ def _remove_less_covered(
 
     new_stations = data.data.station_name.data
 
-    logger.info(f"Removed {len(stations)-len(new_stations)} stations")
+    logger.info(f"Removed {len(stations) - len(new_stations)} stations")
     if len(new_stations) == 0:
         logger.warning(
             f"No stations left after removing stations with fewer than {min_yrs} years!"

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -766,7 +766,7 @@ def process_trends(
     freq: str,
     use_weights: bool,
 ) -> dict:
-    # subset = _select_period_season_coldata(coldata, per, season)
+    # subset = _select_period_season_coldata(coldata, per, season, use_meteorological_seasons)
     stats = {}
     trends_successful = False
     mean_trends_successful = False
@@ -990,6 +990,7 @@ def _process_map_and_scat(
                         subset = _select_period_season_coldata(
                             cd, per, season, use_meteorological_seasons
                         )
+                        breakpoint()
                         jsdate = subset.data.jsdate.values.tolist()
                     except (DataCoverageError, TemporalResolutionError):
                         use_dummy = True
@@ -1294,6 +1295,7 @@ def _process_heatmap_data(
     add_trends,
     trends_min_yrs,
     avg_over_trends,
+    use_meteorological_seasons,
 ):
     output = {}
     stats_dummy = _init_stats_dummy(drop_stats=drop_stats)
@@ -1309,7 +1311,9 @@ def _process_heatmap_data(
                         stats = stats_dummy
                     else:
                         try:
-                            subset = _select_period_season_coldata(coldata, per, season)
+                            subset = _select_period_season_coldata(
+                                coldata, per, season, use_meteorological_seasons
+                            )
 
                             if add_trends and freq != "daily":
                                 trend_stats = process_trends(
@@ -1528,6 +1532,7 @@ def process_profile_data_for_regions(
     use_country: bool,
     periods: list[str],
     seasons: list[str],
+    use_meteorological_seasons: bool,
 ) -> dict:  # pragma: no cover
     """
     This method populates the json files in data/profiles which are use for visualization.
@@ -1566,7 +1571,9 @@ def process_profile_data_for_regions(
                     output["mod"][freq][perstr] = np.nan
                 else:
                     try:
-                        per_season_subset = _select_period_season_coldata(coldata, per, season)
+                        per_season_subset = _select_period_season_coldata(
+                            coldata, per, season, use_meteorological_seasons
+                        )
 
                         subset = per_season_subset.filter_region(
                             region_id=region_id, check_country_meta=use_country
@@ -1595,6 +1602,7 @@ def process_profile_data_for_stations(
     use_country: bool,
     periods: list[str],
     seasons: list[str],
+    use_meteorological_seasons: bool,
 ) -> dict:  # pragma: no cover
     """
     This method populates the json files in data/profiles which are use for visualization.
@@ -1633,7 +1641,9 @@ def process_profile_data_for_stations(
                     output["mod"][freq][perstr] = np.nan
                 else:
                     try:
-                        per_season_subset = _select_period_season_coldata(coldata, per, season)
+                        per_season_subset = _select_period_season_coldata(
+                            coldata, per, season, use_meteorological_seasons
+                        )
 
                         subset = per_season_subset.data[
                             :,

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -990,7 +990,6 @@ def _process_map_and_scat(
                         subset = _select_period_season_coldata(
                             cd, per, season, use_meteorological_seasons
                         )
-                        breakpoint()
                         jsdate = subset.data.jsdate.values.tolist()
                     except (DataCoverageError, TemporalResolutionError):
                         use_dummy = True

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1258,12 +1258,12 @@ def _calc_temporal_corr(coldata):
 
 def _select_period_season_coldata(coldata, period, season, use_meteorological_seasons):
     tslice = _period_str_to_timeslice(period)
-    if use_meteorological_seasons:
-        if len(period) == 4:  # relevant only for single years
-            # for period = '2022' tslice needs to be slice('2021-12','2022-11')
-            yeardt = datetime.strptime(period, "%Y")
-            tslice = slice(f"{yeardt.year - 1}-12", f"{yeardt.year}-11")
-            logger.debug(f"Using meteorological year slicing for {period}: {tslice}")
+    if use_meteorological_seasons and len(period) == 4:
+        # relevant only for single years
+        # for period = '2022' tslice needs to be slice('2021-12','2022-11')
+        yeardt = datetime.strptime(period, "%Y")
+        tslice = slice(f"{yeardt.year - 1}-12", f"{yeardt.year}-11")
+        logger.debug(f"Using meteorological year slicing for {period}: {tslice}")
     # expensive, try use solution with numpy indexing directly...
     # also, keep an eye on: https://github.com/pydata/xarray/issues/2799
     arr = coldata.data.sel(time=tslice)

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import os
 import sys
@@ -6,7 +7,6 @@ from functools import cached_property
 from getpass import getuser
 from pathlib import Path
 from typing import Annotated, Literal
-import datetime
 
 from pyaerocom.aeroval.glob_defaults import VarWebInfo, VarWebScaleAndColormap
 from pyaerocom.aeroval.obsentry import ObsEntry
@@ -22,8 +22,8 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
-    PositiveInt,
     NonNegativeInt,
+    PositiveInt,
     computed_field,
     field_serializer,
     field_validator,
@@ -35,13 +35,13 @@ from pyaerocom.aeroval.aux_io_helpers import ReadAuxHandler
 from pyaerocom.aeroval.collections import ModelCollection, ObsCollection
 from pyaerocom.aeroval.exceptions import ConfigError
 from pyaerocom.aeroval.helpers import (
+    BoundingBox,
     _check_statistics_periods,
     _get_min_max_year_periods,
     check_if_year,
-    BoundingBox,
 )
-from pyaerocom.aeroval.modelmaps_helpers import CONTOUR, OVERLAY
 from pyaerocom.aeroval.json_utils import read_json, set_float_serialization_precision
+from pyaerocom.aeroval.modelmaps_helpers import CONTOUR, OVERLAY
 from pyaerocom.colocation.colocation_setup import ColocationSetup
 
 logger = logging.getLogger(__name__)
@@ -252,6 +252,7 @@ class TimeSetup(BaseModel):
     freqs: list[str] = ["monthly", "yearly"]
     periods: list[str] = Field(default_factory=list)
     add_seasons: bool = True
+    use_meteorological_seasons: bool = False
 
     def get_seasons(self):
         """

--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -246,6 +246,24 @@ class StatisticsSetup(BaseModel, extra="allow"):
 
 
 class TimeSetup(BaseModel):
+    """
+    Time setup options
+
+    Attributes
+    ----------
+    add_seasons : bool, default True
+        if True, seasons will be ['all', 'DJF', 'MAM', 'JJA', 'SON'], if False, just ['all'].
+    use_meteorological_seasons : bool, default False
+        if True, then statistics are based on the meteorological definition of seasons. This is relevant
+        for periods that are a single year. So if :attr:`add_seasons` is True, for a given year ['DJF'] will
+        refer to data from Dec of the previous year (if available) and Jan/Feb of the same year, while if
+        :attr:`use_meteorological_seasons` is False, it will be based on data from Jan/Feb and December
+        of the same year. Similarly, and weather or not :attr:`add_seasons` is True,
+        if :attr:`use_meteorological_seasons` is True, ['all'] (whole year) will refer to data from Dec of
+        the previous year to Nov of the same year, while if False, it will refer to data from Jan to Dec
+        of the same year.
+    """
+
     DEFAULT_FREQS: Literal["monthly", "yearly"] = "monthly"
     SEASONS: list[str] = ["all", "DJF", "MAM", "JJA", "SON"]
     main_freq: str = "monthly"

--- a/pyaerocom/scripts/cams2_83/cli_mos.py
+++ b/pyaerocom/scripts/cams2_83/cli_mos.py
@@ -26,6 +26,7 @@ def make_config_mos(
     id: str,
     name: str,
     description: str,
+    add_seasons: bool,
 ) -> dict:
     logger.info("Making the configuration")
 
@@ -56,6 +57,9 @@ def make_config_mos(
     cfg.update(exp_id=id, exp_name=name, exp_descr=description)
 
     cfg.update(use_fairmode=True)
+
+    if add_seasons:
+        cfg.update(add_seasons=True)
 
     return cfg
 
@@ -90,6 +94,7 @@ def main(
     id: str = typer.Option(CFG["exp_id"], help="experiment ID"),
     name: str = typer.Option(CFG["exp_name"], help="experiment name"),
     description: str = typer.Option(CFG["exp_descr"], help="experiment description"),
+    add_seasons: bool = typer.Option(False, "--addseasons", help="set add_seasons"),
     pool: int = typer.Option(
         1,
         "--pool",
@@ -113,6 +118,7 @@ def main(
         id,
         name,
         description,
+        add_seasons,
     )
 
     # we do not want the cache produced in previous runs to be silently cleared

--- a/pyaerocom/scripts/cams2_83/config.py
+++ b/pyaerocom/scripts/cams2_83/config.py
@@ -44,6 +44,7 @@ GLOBAL_CONFIG = dict(
     ],  # Periodes, can be single years or range, e.g. 2010-2015. EMEP only supports single years as of now
     main_freq="hourly",  # default frequency to use. This will be overwritten in most of the observation options (see below)
     add_seasons=False,
+    use_meteorological_seasons=True,
     # This has to be true for the web interface to show diurnal evaluation
     use_diurnal=False,
     # O3 is special, since we want to look at daily max

--- a/pyaerocom/scripts/cams2_83/engine.py
+++ b/pyaerocom/scripts/cams2_83/engine.py
@@ -97,7 +97,7 @@ class CAMS2_83_Engine(ProcessingEngine):
 
                     try:
                         subset = [
-                            _select_period_season_coldata(col, per, season)
+                            _select_period_season_coldata(col, per, season, use_meteorological_seasons)
                             for col in subset_region
                         ]
                     except (DataCoverageError, UnknownRegion) as e:

--- a/pyaerocom/scripts/cams2_83/engine.py
+++ b/pyaerocom/scripts/cams2_83/engine.py
@@ -39,6 +39,7 @@ class CAMS2_83_Engine(ProcessingEngine):
         out_dirs = self.cfg.path_manager.get_json_output_dirs(True)
         forecast_days = self.cfg.statistics_opts.forecast_days
         periods = self.cfg.time_cfg.periods
+        use_meteorological_seasons = self.cfg.time_cfg.use_meteorological_seasons
 
         if "var_name_input" in coldata[0].metadata:
             obs_var = coldata[0].metadata["var_name_input"][0]

--- a/tests/aeroval/test_coldatatojson_helpers2.py
+++ b/tests/aeroval/test_coldatatojson_helpers2.py
@@ -16,6 +16,7 @@ from pyaerocom.aeroval.coldatatojson_helpers import (
     _map_indices,
     _process_statistics_timeseries,
     _remove_less_covered,
+    _select_period_season_coldata,
 )
 from pyaerocom.aeroval.exceptions import TrendsError
 from pyaerocom.exceptions import TemporalResolutionError, UnknownRegion
@@ -339,3 +340,43 @@ def test__remove_less_covered_all():
     cd = COLDATA["fake_3d_partial_trends_coltime"]()
     new_cd = _remove_less_covered(cd, 1000)
     assert new_cd.data.station_name.shape[0] == 0
+
+
+@pytest.mark.parametrize(
+    "period, use_meteorological_seasons, resultfirst, resultlast",
+    [
+        (
+            "2004",
+            True,
+            np.datetime64("2003-12-01T00:00:00.000000000"),
+            np.datetime64("2004-02-29T00:00:00.000000000"),
+        ),
+        (
+            "2003-2004",
+            True,
+            np.datetime64("2003-01-01T00:00:00.000000000"),
+            np.datetime64("2004-12-31T00:00:00.000000000"),
+        ),
+        (
+            "2004",
+            False,
+            np.datetime64("2004-01-01T00:00:00.000000000"),
+            np.datetime64("2004-12-31T00:00:00.000000000"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("coldataset", ["fake_3d_partial_trends"])
+def test__select_period_season_coldata(
+    coldata: ColocatedData,
+    period: str,
+    use_meteorological_seasons: bool,
+    resultfirst: np.datetime64,
+    resultlast: np.datetime64,
+):
+    coldatamod = coldata.copy()
+    coldatamod.data = coldatamod.data.assign_coords(
+        season=("time", coldata.coords["time.season"].values)
+    )
+    cd = _select_period_season_coldata(coldatamod, period, "DJF", use_meteorological_seasons)
+    assert cd.coords["time"].values[0] == resultfirst
+    assert cd.coords["time"].values[-1] == resultlast

--- a/tests/cams2_83/test_cams2_83_cli_mos.py
+++ b/tests/cams2_83/test_cams2_83_cli_mos.py
@@ -23,9 +23,10 @@ def test_eval_mos_dummy(
     tmp_path: Path,
     caplog,
 ):
-    options = f"season 2024-03-01 2024-05-12 --data-path {tmp_path} --coldata-path {tmp_path} --name 'Test'"
+    options = f"season 2024-03-01 2024-05-12 --data-path {tmp_path} --coldata-path {tmp_path} --name 'Test' --addseasons"
     result = runner.invoke(app, options.split())
     assert result.exit_code == 0
+    assert "'add_seasons': True," in caplog.text
     assert "no output available" in caplog.text
 
 


### PR DESCRIPTION
## Change Summary

a new option is introduced such that if True, for single year periods the time slicing accounts for the definition of meteorological seasons, meaning that the data is sliced from nov of the previous year to nov of the same year  
this makes the seasonal stats consistent with the meteorological definition (relevant for djf)  
it also means that if `use_meteorological_seasons=True` the 'all' key for a a year will contain stats based on the meteorological year, so from djf to son of that year (currently it's from 1 jan to 31 dec, so missing a month of djf and including a month that actually belongs to djf of next year)

## Related issue number
one way to adress #1536 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
