### PR TITLE
Only run test if pyaro-readers is installed

### DIFF
--- a/tests/io/pyaro/test_read_pyaro.py
+++ b/tests/io/pyaro/test_read_pyaro.py
@@ -9,7 +9,7 @@ from pyaerocom.io import ReadPyaro, PyaroConfig
 from pyaerocom.io.pyaro.read_pyaro import PyaroToUngriddedData
 from pyaerocom.io.pyaro.postprocess import matching_indices
 
-from tests.conftest import lustre_unavail
+from tests.conftest import lustre_unavail, __package_installed
 
 
 def test_testfile(pyaro_test_data_file):
@@ -138,6 +138,10 @@ def test_matching_indices():
 
 
 @lustre_unavail
+@pytest.mark.skipif(
+    not __package_installed("pyaro_readers"),
+    reason="reader_id=eeareder requires pyaro-readers to be installed",
+)
 def test_vmrox():
     config = PyaroConfig.from_dict(
         {


### PR DESCRIPTION
## Change Summary

`test_vmrox` requires `pyaro-readers` which is considered an optional dependency. This PR changes the test so it only runs if this package is installed

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [ ] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [ ] Tests pass on CI
* [x] At least 1 reviewer is selected
* [ ] Make PR ready to review
