### PR TITLE
Fix up earlinet paths and overlay plotting

### DIFF
--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -607,6 +607,4 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         coldata = ColocatedData(data=file_to_convert[0])
         data = coldata.data.sel(data_source=model_name)
         data = data.drop_vars("data_source")
-        data = data.transpose("time", "latitude", "longitude")
-        data = data.sortby(["latitude", "longitude"])
         return data

--- a/pyaerocom/aeroval/modelmaps_helpers.py
+++ b/pyaerocom/aeroval/modelmaps_helpers.py
@@ -150,6 +150,9 @@ def plot_overlay_pixel_maps(
     matplotlib.use("Agg")
     proj = ccrs.epsg(3857)
 
+    if data.longitude.max().item() == 180:  # projection conversion fails for data on line 180
+        data[:, -1] = np.nan
+
     fig, axis = plt.subplots(
         1,
         1,
@@ -159,7 +162,7 @@ def plot_overlay_pixel_maps(
 
     data.plot(
         ax=axis,
-        transform=ccrs.PlateCarree(),
+        # transform=ccrs.PlateCarree(),
         add_colorbar=False,
         add_labels=False,
         vmin=cmap_bins[0],

--- a/pyaerocom/data/paths.ini
+++ b/pyaerocom/data/paths.ini
@@ -73,7 +73,7 @@ AERONET_INV_V3L2_DAILY = ${BASEDIR}/aerocom/aerocom1/AEROCOM_OBSDATA/Aeronet.Inv
 # other observations
 EBAS_MULTICOLUMN = ${BASEDIR}/aerocom/aerocom1/AEROCOM_OBSDATA/EBASMultiColumn/data
 EEA = ${BASEDIR}/aerocom/aerocom1/AEROCOM_OBSDATA/EEA_AQeRep/renamed
-EARLINET = ${BASEDIR}/aerocom/aerocom1/AEROCOM_OBSDATA/EarlinetV3/download
+EARLINET = ${BASEDIR}/aerocom/aerocom1/AEROCOM_OBSDATA/EarlinetV4/download
 GAWTADsubsetAasEtAl = ${BASEDIR}/aerocom/aerocom1/AEROCOM_OBSDATA/PYAEROCOM/GAWTADSulphurSubset/data
 DMS_AMS_CVO = ${BASEDIR}/aerocom/aerocom1/AEROCOM_OBSDATA/PYAEROCOM/DMS_AMS_CVO/data
 GHOST_EEA_DAILY = ${BASEDIR}/aerocom/aerocom1/AEROCOM_OBSDATA/GHOST/data/EEA_AQ_eReporting/daily


### PR DESCRIPTION
## Change Summary

- Change EARLINET path to v4. New data released Friday and downloaded over the weekend.
- Observations which are on the longitude 180 failed to be converted int the cartopy projection. Remove points on this line. 

## Related issue number
closed https://github.com/metno/AeroToolsIssues/issues/88?issue=metno%7CAeroToolsIssues%7C98
part of https://github.com/metno/AeroToolsIssues/issues/88


## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
