### PR TITLE
pip freeze saved to config

### DIFF
--- a/pyaerocom/aeroval/setup_classes.py
+++ b/pyaerocom/aeroval/setup_classes.py
@@ -29,6 +29,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
+import subprocess
 
 from pyaerocom import __version__, const
 from pyaerocom.aeroval.aux_io_helpers import ReadAuxHandler
@@ -565,6 +566,14 @@ class EvalSetup(BaseModel):
     @field_serializer("model_cfg")
     def serialize_model_cfg(self, model_cfg: ModelCollection):
         return model_cfg.as_dict()
+
+    @computed_field
+    @cached_property
+    def pip_freeze(self) -> list[str]:
+        reqs = subprocess.check_output([sys.executable, "-m", "pip", "freeze"])
+        splt = [x for x in reqs.decode().split("\n") if x != ""]
+
+        return sorted(splt)
 
     ###########################
     ##       Methods


### PR DESCRIPTION
## Change Summary

It would sometimes be useful to see what packages were installed in the environment in which a pyaerocom experiment was run after it was run (I've encountered this when testing new versions of aerovaldb where I'm not sure the correct version was installed for instance). This PR writes a pip freeze to the config as can be seen [here](https://aeroval-test.met.no/thlun/pages/infos/?project=testing&experiment=benchmark&tab=experiment) (scroll to bottom).

Alternatively this could be written to logs, but logs are not always kept, and are less strongly linked to the output, and it is not that many lines of extra output.

## Related issue number

Loosely related to https://github.com/metno/pyaerocom/pull/1529

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
