### PR TITLE
not using aerovaldb4 yet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10"
 dependencies = [
     # NOTE: Please also update dependency versions in pyaerocom_env.yml,
     # and minimum versions in the tox config at the bottom of this file!
-    "aerovaldb>=0.2.3",
+    "aerovaldb>=0.2.3,<0.4.0",
     "scitools-iris>=3.11.0",
     "xarray>=2022.12.0",
     "cartopy>=0.21.1",


### PR DESCRIPTION
## Change Summary

CI crashes when using aerovaldb 0.4.0, limiting to smaller version

## Checklist

* [ ] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
