### PR TITLE
Colocated data from Mines Paris + solar irradiance variables

### DIFF
--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -157,8 +157,8 @@ class ColdataToJsonEngine(ProcessingEngine):
         else:
             raise ValueError("Unable to determine obs_var/model_var")
 
-        model_name = coldata.model_name
-        obs_name = coldata.obs_name
+        model_name = str(coldata.model_name)
+        obs_name = str(coldata.obs_name)
 
         mcfg = self.cfg.model_cfg.get_entry(model_name)
         var_name_web = mcfg.get_varname_web(model_var, obs_var)
@@ -393,7 +393,15 @@ class ColdataToJsonEngine(ProcessingEngine):
         with multiprocessing.Pool(processes=int(num_workers)) as pool:
             results = pool.starmap(_process_statistics_timeseries_single_region, args)
 
-        for stats_ts, region, obs_name, var_name_web, vert_code, model_name, model_var in results:
+        for (
+            stats_ts,
+            region,
+            obs_name,
+            var_name_web,
+            vert_code,
+            model_name,
+            model_var,
+        ) in results:
             self.exp_output.add_heatmap_timeseries_entry(
                 stats_ts,
                 region,

--- a/pyaerocom/aeroval/data/var_scale_colmap.ini
+++ b/pyaerocom/aeroval/data/var_scale_colmap.ini
@@ -466,3 +466,15 @@ colmap = coolwarm
 [fractioneBCffem]
 scale = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
 colmap = coolwarm
+
+[BNI]
+scale = [0, 250, 500, 750, 1000, 1250]
+colmap = coolwarm
+
+[DHI]
+scale = [0, 100, 200, 300, 400, 500]
+colmap = coolwarm
+
+[GHI]
+scale = [0, 250, 500, 750, 1000, 1250]
+colmap = coolwarm

--- a/pyaerocom/aeroval/data/var_web_info.ini
+++ b/pyaerocom/aeroval/data/var_web_info.ini
@@ -896,3 +896,18 @@ category = Particle ratio
 menu_name = Equivalent BC
 vertical_type = 3D
 category = Particle concentrations
+
+[BNI]
+menu_name = BNI
+vertical_type = 3D
+category = Solar irradiance
+
+[DHI]
+menu_name = DHI
+vertical_type = 3D
+category = Solar irradiance
+
+[GHI]
+menu_name = GHI
+vertical_type = 3D
+category = Solar irradiance

--- a/pyaerocom/aeroval/glob_defaults.py
+++ b/pyaerocom/aeroval/glob_defaults.py
@@ -122,6 +122,7 @@ class CategoryType(str, Enum):
     vertical_column_density = "Vertical column density"
     surface_emission = "Surface emission"
     column_burden = "Column burden"
+    solar_irradiance = "Solar irradiance"
     UNDEFINED = "UNDEFINED"
 
     def __str__(self):


### PR DESCRIPTION
## Change Summary

Introduce `BNI`, `DHI`, and `GHI` solar irradiance variables, their web display options, and a new `CategoryType` in `global_defaults.py` for solar irradiance. Used in experiments to evaluate renewable energy production models.

## Related issue number

NA

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
