### PR TITLE
Relax argument type of pyaro filename

### DIFF
--- a/pyaerocom/io/pyaro/pyaro_config.py
+++ b/pyaerocom/io/pyaro/pyaro_config.py
@@ -31,7 +31,7 @@ class PyaroConfig(BaseModel):
 
     name: str
     reader_id: str
-    filename_or_obj_or_url: str | list[str] | Path | list[Path]
+    filename_or_obj_or_url: Any
     filters: dict[str, FilterArgs]
     name_map: dict[str, str] | None = None  # no Unit conversion option
     post_processing: list[str] | None = None  # List of variables to add through post-processing


### PR DESCRIPTION
## Change Summary

<!-- Please give a short summary of the changes. -->

Relaxes `filename_or_obj_or_url` to be anything. It is up to the reader in question to type-check this argument.

This change enables the first argument to a reader to be arbitrarily complex, such as for nesting readers such as [pyaro-readers#60](https://github.com/metno/pyaro-readers/pull/60/files).

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Start with a draft-PR
* [ ] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
