### PR TITLE
Race condition in cache when reading obs to cache in parallel

### DIFF
--- a/pyaerocom/_lowlevel_helpers.py
+++ b/pyaerocom/_lowlevel_helpers.py
@@ -524,17 +524,6 @@ def chk_make_subdir(base, name):
     return d
 
 
-def check_dirs_exist(*dirs, **add_dirs):
-    for d in dirs:
-        if not os.path.exists(d):
-            print(f"Creating dir: {d}")
-            os.mkdir(d)
-    for k, d in add_dirs.items():
-        if not os.path.exists(d):
-            os.mkdir(d)
-            print(f"Creating dir: {d} ({k})")
-
-
 def list_to_shortstr(lst, indent=0):
     """Custom function to convert a list into a short string representation"""
 

--- a/pyaerocom/_lowlevel_helpers.py
+++ b/pyaerocom/_lowlevel_helpers.py
@@ -520,8 +520,7 @@ def merge_dicts(dict1, dict2, discard_failing=True):
 def chk_make_subdir(base, name):
     """Check if sub-directory exists in parent directory"""
     d = os.path.join(base, name)
-    if not os.path.exists(d):
-        os.mkdir(d)
+    os.makedirs(d, exist_ok=True)
     return d
 
 

--- a/pyaerocom/io/cachehandler_ungridded.py
+++ b/pyaerocom/io/cachehandler_ungridded.py
@@ -144,7 +144,7 @@ class CacheHandlerUngridded:
             var_or_file_name = self.default_file_name(var_or_file_name)
         if cache_dir is None:
             cache_dir = self.cache_dir
-        elif not os.path.exists(cache_dir):
+        if not os.path.exists(cache_dir):
             raise FileNotFoundError(f"Specified output directory does not exist:{cache_dir}")
         return os.path.join(cache_dir, var_or_file_name)
 

--- a/pyaerocom/io/cachehandler_ungridded.py
+++ b/pyaerocom/io/cachehandler_ungridded.py
@@ -144,6 +144,8 @@ class CacheHandlerUngridded:
             var_or_file_name = self.default_file_name(var_or_file_name)
         if cache_dir is None:
             cache_dir = self.cache_dir
+        if cache_dir is None:
+            raise FileNotFoundError("Specified output directory is None")
         if not os.path.exists(cache_dir):
             raise FileNotFoundError(f"Specified output directory does not exist:{cache_dir}")
         return os.path.join(cache_dir, var_or_file_name)


### PR DESCRIPTION
## Change Summary

- Avoid race-condition on creation of directories
- Remove unused multi-directory creation function
- fail with correct FileNotFoundError exception if cachedir is None (usually only caused when creation of directories failed)

The race-conditions are unfortunately difficult to test, so no new test-cases have been provided.

## Related issue number

fix #1584

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
