### PR TITLE
modify behavior of use_meteorological_seasons=True

### DIFF
--- a/docs/_static/aeroval/cfg_examples_example1.py
+++ b/docs/_static/aeroval/cfg_examples_example1.py
@@ -151,14 +151,13 @@ GLOB_CFG = dict(
     # If True seasons are ['all', 'DJF', 'MAM', 'JJA', 'SON'],
     # if False, just ['all']
     add_seasons=True,
-    # Whether or not statistics are based on the meteorological definition of seasons.
+    # Whether or not DJF statistics are based on the meteorological definition of the season.
     # This is relevant for periods that are a single year. So if use_meteorological_seasons=True
     # and add_seasons=True, for a given year ['DJF'] will refer to data from Dec of the previous year
     # (if available) and Jan/Feb of the same year, while if use_meteorological_seasons=False,
-    # it will refer to data from Jan/Feb and December of the same year. Similarly, and independently
-    # of the value of add_seasons, if use_meteorological_seasons=True, ['all'] (whole year) will refer
-    # to data from Dec of the previous year to Nov of the same year, while if False, it will refer to data
-    # from Jan to Dec of the same year.
+    # it will refer to data from Jan/Feb and December of the same year. (The ['all'] (whole year) key
+    # for the year in question will not be affected, so it will refer to data from January 1st to
+    # December 31st.
     use_meteorological_seasons=False,
     # Whether or not to add trends output to the analysis. Trends analysis
     # needs at least 7 years of data, so this is skipped here for this

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1258,8 +1258,8 @@ def _calc_temporal_corr(coldata):
 
 def _select_period_season_coldata(coldata, period, season, use_meteorological_seasons):
     tslice = _period_str_to_timeslice(period)
-    if use_meteorological_seasons and len(period) == 4:
-        # relevant only for single years
+    if use_meteorological_seasons and len(period) == 4 and season == "DJF":
+        # relevant only for single years and DJF
         # for period = '2022' tslice needs to be slice('2021-12','2022-11')
         yeardt = datetime.strptime(period, "%Y")
         tslice = slice(f"{yeardt.year - 1}-12", f"{yeardt.year}-11")


### PR DESCRIPTION
## Change Summary

for CAMS2_82 it is desired that `use_meteorological_seasons=True` should only affect yyyy-DJF keys  
so basically for example for 2024: 
- `2024-DJF` should indeed contain data from Dec23 + Jan24 + Feb24 
- `2024-all` should contain data from Jan24 + Feb24 + Dec24  

the current logic is that `2024-all` is coherent with `2024-DJF` so it contains data from D24 to Nov24

this PR restricts the behavior of the flag as wanted by CAMS2_82  
to be discussed: is it ok for other projects? do we need a different (more configurable) approach?

## Related issue number

#1591 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
