### PR TITLE
fix array overrun in ungriddeddata

### DIFF
--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -1166,7 +1166,8 @@ class UngriddedData(UngriddedDataMetadata):
                 totnum = len(indices)
 
                 stop = data_idx_new + totnum
-
+                while stop > new._data.shape[0]:
+                    new.add_chunk()
                 new._data[data_idx_new:stop, :] = self._data[indices, :]
                 new._data[data_idx_new:stop, new._METADATAKEYINDEX] = meta_idx_new
                 new.meta_idx[meta_idx_new][var] = np.arange(data_idx_new, stop)


### PR DESCRIPTION
## Change Summary

pyaerocom crashed with AirNow data now having more than 10000000 datapoints, which are the maximum after filtering.

Dynamically increasing `UngriddedData` when too many datapoints.

## Checklist

* [ ] Start with a draft-PR
* [ ] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
