### PR TITLE
Adding data_revision to ungridded_structured

### DIFF
--- a/pyaerocom/colocation/colocation_3d.py
+++ b/pyaerocom/colocation/colocation_3d.py
@@ -238,14 +238,11 @@ def _colocate_vertical_profile_gridded(
                 )
 
         try:
-            revision = data_ref.data_revision[dataset_ref]
+            revision = data_ref.get_data_revision[dataset_ref]
+        except MetaDataError:
+            revision = "MULTIPLE"
         except Exception:
-            try:
-                revision = data_ref.get_data_id_revision(dataset_ref)
-            except MetaDataError:
-                revision = "MULTIPLE"
-            except Exception:
-                revision = "n/a"
+            revision = "n/a"
 
         files = [os.path.basename(x) for x in data.from_files]
 
@@ -262,7 +259,7 @@ def _colocate_vertical_profile_gridded(
             "from_files": files,
             "from_files_ref": None,
             "colocate_time": colocate_time,
-            "obs_is_clim": True if isinstance(use_climatology_ref, ClimatologyConfig) else False,
+            "obs_is_clim": (True if isinstance(use_climatology_ref, ClimatologyConfig) else False),
             "pyaerocom": pya_ver,
             "min_num_obs": min_num_obs,
             "resample_how": resample_how,

--- a/pyaerocom/colocation/colocation_3d.py
+++ b/pyaerocom/colocation/colocation_3d.py
@@ -241,7 +241,7 @@ def _colocate_vertical_profile_gridded(
             revision = data_ref.data_revision[dataset_ref]
         except Exception:
             try:
-                revision = data_ref._get_data_revision_helper(dataset_ref)
+                revision = data_ref.get_data_id_revision(dataset_ref)
             except MetaDataError:
                 revision = "MULTIPLE"
             except Exception:

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -950,7 +950,7 @@ def colocate_gridded_ungridded(
         revision = data_ref.data_revision[dataset_ref]
     except Exception:
         try:
-            revision = data_ref._get_data_revision_helper(dataset_ref)
+            revision = data_ref.get_data_id_revision(dataset_ref)
         except MetaDataError:
             revision = "MULTIPLE"
         except Exception:

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -947,14 +947,11 @@ def colocate_gridded_ungridded(
                 f"not be added to ColocatedData. Reason: {e}"
             )
     try:
-        revision = data_ref.data_revision[dataset_ref]
+        revision = data_ref.get_data_revision(dataset_ref)
+    except MetaDataError:
+        revision = "MULTIPLE"
     except Exception:
-        try:
-            revision = data_ref.get_data_id_revision(dataset_ref)
-        except MetaDataError:
-            revision = "MULTIPLE"
-        except Exception:
-            revision = "n/a"
+        revision = "n/a"
 
     files = [os.path.basename(x) for x in data.from_files]
 

--- a/pyaerocom/io/read_ebas.py
+++ b/pyaerocom/io/read_ebas.py
@@ -1435,6 +1435,7 @@ class ReadEbas(ReadUngriddedBase):
         data_out = StationData()
 
         data_out = self._add_meta(data_out, file)
+        data_out.data_revision = self.data_revision
 
         freq_ebas = data_out["ts_type"]  # resolution code
         # store the raw EBAS meta dictionary (who knows what for later ;P )

--- a/pyaerocom/ungridded_data_container.py
+++ b/pyaerocom/ungridded_data_container.py
@@ -57,9 +57,9 @@ class UngriddedDataContainer(abc.ABC):
         return data
 
     @abc.abstractmethod
-    def _get_data_revision_helper(self, data_id):
+    def get_data_id_revision(self, data_id):
         """
-        Helper method to get last data revision
+        Get the data revision of the data_id
 
         Parameters
         ----------

--- a/pyaerocom/ungridded_data_container.py
+++ b/pyaerocom/ungridded_data_container.py
@@ -57,7 +57,7 @@ class UngriddedDataContainer(abc.ABC):
         return data
 
     @abc.abstractmethod
-    def get_data_id_revision(self, data_id):
+    def get_data_revision(self, data_id):
         """
         Get the data revision of the data_id
 
@@ -924,7 +924,7 @@ class UngriddedDataContainer(abc.ABC):
             obj.append_station_data(all_stations["stats"])
 
         # update metadata
-        obj.data_revision.update(other.data_revision)
+        obj._data_revision.update(other._data_revision)
         obj.filter_hist.update(other.filter_hist)
 
         return obj

--- a/pyaerocom/ungridded_data_metadata.py
+++ b/pyaerocom/ungridded_data_metadata.py
@@ -44,7 +44,7 @@ class UngriddedDataMetadata(UngriddedDataContainer):
 
     def __init__(self):
         self.metadata = {}
-        self.data_revision = {}
+        self._data_revision = {}
         self.var_idx = {}
         self.filter_hist = {}
         self._is_vertical_profile = False
@@ -54,15 +54,15 @@ class UngriddedDataMetadata(UngriddedDataContainer):
         deepcopy metadata-fields to the other object
         """
         other.metadata = deepcopy(self.metadata)
-        other.data_revision = deepcopy(self.data_revision)
+        other._data_revision = deepcopy(self._data_revision)
         other.var_idx = deepcopy(self.var_idx)
         other.filter_hist = deepcopy(self.filter_hist)
         other.is_vertical_profile = self._is_vertical_profile
 
     @override
-    def get_data_id_revision(self, data_id):
+    def get_data_revision(self, data_id) -> str | None:
         """
-        Helper method to get last data revision
+        Get data revision for a data_id.
 
         Parameters
         ----------
@@ -79,18 +79,18 @@ class UngriddedDataMetadata(UngriddedDataContainer):
         latest revision (None if no revision is available).
 
         """
-        rev = None
-        for meta in self.metadata.values():
-            if meta["data_id"] == data_id:
-                if rev is None:
-                    rev = meta["data_revision"]
-                elif not meta["data_revision"] == rev:
-                    raise MetaDataError(f"Found different data revisions for dataset {data_id}")
-        if data_id in self.data_revision:
-            if not rev == self.data_revision[data_id]:
-                raise MetaDataError(f"Found different data revisions for dataset {data_id}")
-        self.data_revision[data_id] = rev
-        return rev
+        if data_id not in self._data_revision:
+            rev = None
+            for meta in self.metadata.values():
+                if meta["data_id"] == data_id:
+                    if rev is None:
+                        rev = meta["data_revision"]
+                    elif not meta["data_revision"] == rev:
+                        raise MetaDataError(
+                            f"Found different data revisions for dataset {data_id}"
+                        )
+            self._data_revision[data_id] = rev
+        return self._data_revision[data_id]
 
     @property
     def _first_meta_idx(self):

--- a/pyaerocom/ungridded_data_metadata.py
+++ b/pyaerocom/ungridded_data_metadata.py
@@ -60,7 +60,7 @@ class UngriddedDataMetadata(UngriddedDataContainer):
         other.is_vertical_profile = self._is_vertical_profile
 
     @override
-    def _get_data_revision_helper(self, data_id):
+    def get_data_id_revision(self, data_id):
         """
         Helper method to get last data revision
 

--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -700,7 +700,7 @@ class UngriddedData(UngriddedDataMetadata):
             rev = meta["data_revision"]
         else:
             try:
-                rev = self.data_revision[meta["data_id"]]
+                rev = self.get_data_revision[meta["data_id"]]
             except Exception:
                 logger.debug("Data revision could not be accessed")
         sd.data_revision = rev
@@ -1182,7 +1182,7 @@ class UngriddedData(UngriddedDataMetadata):
 
         # write history of filtering applied
         new.filter_hist.update(self.filter_hist)
-        new.data_revision.update(self.data_revision)
+        new._data_revision.update(self._data_revision)
 
         return new
 
@@ -1534,7 +1534,7 @@ class UngriddedData(UngriddedDataMetadata):
             obj._data = other._data
             obj.metadata = other.metadata
             # obj.unit = other.unit
-            obj.data_revision = other.data_revision
+            obj._data_revision = other._data_revision
             obj.meta_idx = other.meta_idx
             # potentially temporary fix for pyaro actrisebas reader
             # if len(other.meta_idx) != len(other.metadata):
@@ -1569,7 +1569,7 @@ class UngriddedData(UngriddedDataMetadata):
                     else:
                         obj.var_idx[var] = idx
             obj._data = np.vstack([obj._data, other._data])
-            obj.data_revision.update(other.data_revision)
+            obj._data_revision.update(other._data_revision)
         obj.filter_hist.update(other.filter_hist)
         obj._check_index()
         return obj

--- a/pyaerocom/ungriddeddata_structured.py
+++ b/pyaerocom/ungriddeddata_structured.py
@@ -620,6 +620,8 @@ class UngriddedDataStructured(UngriddedDataMetadata):
                     self.metadata[meta_idx][key] = station_data[key]
             contains_vars = list(station_data.var_info)
             self.metadata[meta_idx]["variables"] = contains_vars
+            if "data_revision" in station_data:
+                self.metadata[meta_idx]["data_revision"] = station_data.data_revision
 
             for var in contains_vars:
                 vardata = station_data[var]

--- a/pyaerocom/ungriddeddata_structured.py
+++ b/pyaerocom/ungriddeddata_structured.py
@@ -819,6 +819,14 @@ class UngriddedDataStructured(UngriddedDataMetadata):
             ugs._dra.append_array(**dra_data)
 
         logger.info(f"Converting metadata from pyaro/{data_id} to ungridded")
+        rev = None
+        if "revision" in reader.metadata():
+            rev = reader.metadata()["revision"]
+        else:
+            logger.warning(
+                f"pyaro/{data_id} does not contain a 'revision', please inform data-provider, or pyaro-readers"
+            )
+
         stations_with_metadata = reader.stations()
         for var in vars_to_retrieve:
             for station_tstype, meta_id in var_metas[var].items():
@@ -826,6 +834,7 @@ class UngriddedDataStructured(UngriddedDataMetadata):
                 extra_metadata = stations_with_metadata[station_name].metadata
                 d = {
                     "data_id": data_id,
+                    "data_revision": rev,
                     "station_name": station_name,
                     "var_info": {
                         var: {"units": var_units[var]},

--- a/pyaerocom/ungriddeddata_structured.py
+++ b/pyaerocom/ungriddeddata_structured.py
@@ -295,7 +295,7 @@ class UngriddedDataStructured(UngriddedDataMetadata):
             rev = meta["data_revision"]
         else:
             try:
-                rev = self.data_revision[meta["data_id"]]
+                rev = self.get_data_revision(meta["data_id"])
             except Exception:
                 logger.debug("Data revision could not be accessed")
         sd.data_revision = rev

--- a/tests/io/pyaro/test_read_pyaro.py
+++ b/tests/io/pyaro/test_read_pyaro.py
@@ -173,7 +173,10 @@ def test_vmrox():
     )
     reader = PyaroToUngriddedData(config)
     data = reader.read(vars_to_retrieve=["vmrox"])
-
+    rev = data.get_data_revision("whatever")
+    # WIP: waiting for eeareader to add revision, to be done by m06-2025
+    # assert rev is not None
+    rev is not None
     alldata = data.to_station_data_all()
     stats = alldata["stats"]
     assert len(stats) >= 4

--- a/tests/test_ungriddeddata_structured.py
+++ b/tests/test_ungriddeddata_structured.py
@@ -114,10 +114,17 @@ ALL_SITES = [
 def test_filter_by_meta(aeronetsunv3lev2_subset_uds, args, sitenames):
     data = aeronetsunv3lev2_subset_uds
     assert isinstance(data, UngriddedDataStructured)
+    assert data.get_data_id_revision("AeronetSunV3L2Subset.daily") == "n/d"
     subset = data.filter_by_meta(**args)
+    assert subset.get_data_id_revision("AeronetSunV3L2Subset.daily") == "n/d"
     sites = [x["station_name"] for x in subset.metadata.values()]
     stats = sorted(list(dict.fromkeys(sites)))
     assert sorted(sitenames) == stats
+
+
+def test_ebas_revision(data_scat_jungfraujoch: UngriddedDataContainer):
+    assert isinstance(data_scat_jungfraujoch, UngriddedDataStructured)
+    assert data_scat_jungfraujoch.get_data_id_revision("EBASSubset") == "20220101"
 
 
 def test_cache_reload(data_scat_jungfraujoch: UngriddedDataContainer, tmp_path: Path):

--- a/tests/test_ungriddeddata_structured.py
+++ b/tests/test_ungriddeddata_structured.py
@@ -114,9 +114,9 @@ ALL_SITES = [
 def test_filter_by_meta(aeronetsunv3lev2_subset_uds, args, sitenames):
     data = aeronetsunv3lev2_subset_uds
     assert isinstance(data, UngriddedDataStructured)
-    assert data.get_data_id_revision("AeronetSunV3L2Subset.daily") == "n/d"
+    assert data.get_data_revision("AeronetSunV3L2Subset.daily") == "n/d"
     subset = data.filter_by_meta(**args)
-    assert subset.get_data_id_revision("AeronetSunV3L2Subset.daily") == "n/d"
+    assert subset.get_data_revision("AeronetSunV3L2Subset.daily") == "n/d"
     sites = [x["station_name"] for x in subset.metadata.values()]
     stats = sorted(list(dict.fromkeys(sites)))
     assert sorted(sitenames) == stats
@@ -124,7 +124,7 @@ def test_filter_by_meta(aeronetsunv3lev2_subset_uds, args, sitenames):
 
 def test_ebas_revision(data_scat_jungfraujoch: UngriddedDataContainer):
     assert isinstance(data_scat_jungfraujoch, UngriddedDataStructured)
-    assert data_scat_jungfraujoch.get_data_id_revision("EBASSubset") == "20220101"
+    assert data_scat_jungfraujoch.get_data_revision("EBASSubset") == "20220101"
 
 
 def test_cache_reload(data_scat_jungfraujoch: UngriddedDataContainer, tmp_path: Path):


### PR DESCRIPTION
## Change Summary

data-revision was missing from ungridded_structured readers. This PR reworks data-revisions for generally ungridded_structured readers, e.g. EBAS and pyaro.

data-revision in ungridded is now simplified to always be accessible from `get_data_revision` rather than needing ungridded.data_revision['XXX'] and ungridded._get_data_revision_helper('XXX') (both removed now).

data_revision added to ungridded-data read from pyaro. This requires "revision" metadata in pyaro. (This will be implemented for EEA-reader in https://github.com/metno/pyaro-readers/pull/68 )

## Related issue number

 fix #1602 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
