### PR TITLE
bump reader versions to purge cache for revision

### DIFF
--- a/pyaerocom/io/pyaro/read_pyaro.py
+++ b/pyaerocom/io/pyaro/read_pyaro.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 class ReadPyaro(ReadUngriddedBase):
-    __version__ = "1.2.0"
+    __version__ = "1.2.1"
 
     SUPPORTED_DATASETS = list(list_timeseries_engines().keys())
 

--- a/pyaerocom/io/read_ebas.py
+++ b/pyaerocom/io/read_ebas.py
@@ -189,7 +189,7 @@ class ReadEbas(ReadUngriddedBase):
     """
 
     #: version log of this class (for caching)
-    __version__ = "0.52_" + ReadUngriddedBase.__baseversion__
+    __version__ = "0.53_" + ReadUngriddedBase.__baseversion__
 
     #: Name of dataset (OBS_ID)
     DATA_ID = const.EBAS_MULTICOLUMN_NAME


### PR DESCRIPTION
## Change Summary

The ungridded_structure based reader didn't set the data_revision in the metadata. This has been fixed in #1605 . Old cache files of these readers are still missing the data_revision, and bumping the version helps to purge the caches.

## Related issue number

#1605

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
