### PR TITLE
Remove eprofile get list test

### DIFF
--- a/tests/io/test_read_eprofile.py
+++ b/tests/io/test_read_eprofile.py
@@ -8,8 +8,6 @@ import numpy as np
 from pyaerocom.io.read_eprofile import ReadEprofile
 from pyaerocom import const, VerticalProfile, UngriddedData
 
-from tests.conftest import lustre_unavail
-
 
 ROOT: str = const.OBSLOCS_UNGRIDDED["Eprofile-test"]
 
@@ -22,13 +20,6 @@ TEST_FILES: list[str] = [
 def test_all_files_exist():
     for file in TEST_FILES:
         assert Path(file).exists()
-
-
-@lustre_unavail
-def test_ReadEprofile_get_file_list():
-    reader = ReadEprofile()
-    files = reader.get_file_list()
-    assert isinstance(files, list)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Summary
Remove an EPROFILE test which runs on PPI. May be clogging metadata-server.

## Related issue number

NA

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
