### PR TITLE
increase versions to update caches

### DIFF
--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -91,8 +91,8 @@ class UngriddedData(UngriddedDataMetadata):
 
     """
 
-    #: version of class (for caching)
-    __version__ = "0.22"
+    #: version for caching, needs also updating when UngriddedDataMetadata has changed
+    __version__ = "0.23"
 
     #: default number of rows that are dynamically added if total number of
     #: data rows is reached.

--- a/pyaerocom/ungriddeddata_structured.py
+++ b/pyaerocom/ungriddeddata_structured.py
@@ -35,7 +35,8 @@ logger = logging.getLogger(__name__)
 class UngriddedDataStructured(UngriddedDataMetadata):
     """Class implementing UngriddedData in a numpy structured array"""
 
-    __version__ = "0.01"
+    #: version for caching, needs also updating when UngriddedDataMetadata has changed
+    __version__ = "0.02"
     _merging_error_logged = False
 
     _dtype = [


### PR DESCRIPTION
## Change Summary

I forgot to update the versions of the UngriddedData classes which gives now a attribute mismatch when reading old cached files. Should be in the 2025-05 version, if possible since it affects all cached data.

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
