### PR TITLE
Re-enable caching for pyaro

### DIFF
--- a/pyaerocom/io/cachehandler_ungridded.py
+++ b/pyaerocom/io/cachehandler_ungridded.py
@@ -14,6 +14,7 @@ from pyaerocom.exceptions import CacheReadError, CacheWriteError
 from pyaerocom.ungridded_data_container import UngriddedDataContainer
 from pyaerocom.ungriddeddata import UngriddedData
 from pyaerocom.ungriddeddata_structured import UngriddedDataStructured
+from pyaerocom.io.pyaro.read_pyaro import ReadPyaro
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +58,7 @@ class CacheHandlerUngridded:
     def __init__(self, reader=None, cache_dir=None, **kwargs):
         self._reader = None
         if reader is not None:
-            self.reader = reader
+            self._reader = reader
 
         self.loaded_data = {}
         self._cache_dir = cache_dir
@@ -207,6 +208,8 @@ class CacheHandlerUngridded:
         current["ungridded_data_class"] = data_classname
         current["ungridded_data_version"] = dataclass.__version__
         current["cacher_version"] = self.__version__
+        if isinstance(self._reader, ReadPyaro):
+            current["pyaro_config"] = self.reader.config
         return current
 
     def check_and_load(self, var_or_file_name, force_use_outdated=False, cache_dir=None):

--- a/pyaerocom/io/readungridded.py
+++ b/pyaerocom/io/readungridded.py
@@ -513,7 +513,7 @@ class ReadUngridded:
                 f"supported by {data_id} interface"
             )
         cache = CacheHandlerUngridded(reader)
-        if not self.ignore_cache and not isinstance(cache.reader, ReadPyaro):
+        if not self.ignore_cache:
             # initiate cache handler
             for var in vars_available:
                 try:
@@ -538,7 +538,7 @@ class ReadUngridded:
 
             for var in vars_to_read:
                 # write the cache file
-                if not self.ignore_cache and not isinstance(cache.reader, ReadPyaro):
+                if not self.ignore_cache:
                     try:
                         cache.write(data_read, var)
                     except Exception as e:

--- a/tests/io/test_cachehandler_ungridded.py
+++ b/tests/io/test_cachehandler_ungridded.py
@@ -6,6 +6,8 @@ from pyaerocom import UngriddedData
 from pyaerocom.io import ReadAeronetSunV3
 from pyaerocom.io.cachehandler_ungridded import CacheHandlerUngridded
 from tests.conftest import lustre_avail
+from pyaerocom.io.pyaro.pyaro_config import PyaroConfig
+from pyaerocom.io.pyaro.read_pyaro import ReadPyaro
 
 
 @pytest.fixture(scope="module")
@@ -48,3 +50,49 @@ def test_reload(
     reloaded = cache_handler.loaded_data["od550aer"]
     assert isinstance(reloaded, UngriddedData)
     assert reloaded.shape == subset.shape
+
+
+def test_reload_pyaro(cache_handler: CacheHandlerUngridded, pyaro_test_data_file):
+    config0 = PyaroConfig(
+        reader_id="csv_timeseries",
+        filename_or_obj_or_url=str(pyaro_test_data_file),
+        name="test",
+        name_map={
+            "NO": "concno",
+        },
+        post_processing=[
+            "concNno_from_concno",
+        ],
+        filters=dict(),
+    )
+
+    reader0 = ReadPyaro(config0)
+    cache_handler.reader = reader0
+    has_data = cache_handler.check_and_load("concno")
+    assert not has_data, "Data was present"
+
+    data = reader0.read("concno")
+    _outpath = cache_handler.write(data, var_or_file_name="concno")
+
+    has_data = cache_handler.check_and_load("concno")
+    assert has_data, "Data should not be present"
+    assert cache_handler.loaded_data.get("concno") is not None
+
+    reader1 = ReadPyaro(config0)
+    cache_handler.reader = reader1
+    has_data = cache_handler.check_and_load("concno")
+    assert has_data, "Data should be present"
+
+    # Enable a filter which should invalidate the cache
+    config2 = config0.model_copy()
+    config2.filters["countries"] = {"include": "DE"}
+
+    reader2 = ReadPyaro(config2)
+    cache_handler.reader = reader2
+    has_data = cache_handler.check_and_load("concno")
+    assert not has_data, "Data should not be present"
+
+    data = reader2.read("concno")
+    _outpath = cache_handler.write(data, var_or_file_name="concno")
+    has_data = cache_handler.check_and_load("concno")
+    assert has_data, "Data should be present"


### PR DESCRIPTION
## Change Summary

<!-- Please give a short summary of the changes. -->
Enable caching for readers using `pyaro`. The caching is safer than before as the entire `pyaro-config` is included as part of the cache check, which includes filters and kwargs required by the reader.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

Fixes #1571

Relevant issue #1532

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
