### PR TITLE
Add display_name for stations

### DIFF
--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -491,7 +491,7 @@ class CoordSiteArrays:
     alts: list[float]
     countries: list[str]
     jsdates: dict[str, list[str]]
-    display_names: list[str] | None
+    display_names: list[str | None] | None
 
 
 def _init_site_coord_arrays(data) -> CoordSiteArrays:
@@ -577,7 +577,9 @@ def _process_sites(data, regions, regions_how, meta_glob):
         else:
             site_meta["region"] = regs[i]
         if coord_arrays.display_names is not None:
-            site_meta["station_display_name"] = coord_arrays.display_names[i]
+            display_name = coord_arrays.display_names[i]
+            if display_name is not None:
+                site_meta["station_display_name"] = display_name
         ts_data = _init_ts_data(freqs)
         ts_data.update(meta_glob)
         ts_data.update(site_meta)

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -516,8 +516,8 @@ def _init_site_coord_arrays(data) -> CoordSiteArrays:
                 countries = cd.data.country.values
             else:
                 countries = ["UNAVAIL"] * len(lats)
-            if "display_name" in cd.data.coords:
-                display_names = cd.data["display_name"].values
+            if "station_display_name" in cd.data.coords:
+                display_names = cd.data["station_display_name"].values
             else:
                 display_names = None
 

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -7,6 +7,7 @@ from collections.abc import Callable
 from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Literal
+from dataclasses import dataclass
 
 import numpy as np
 import pandas as pd
@@ -481,7 +482,19 @@ def _process_sites_weekly_ts(coldata, regions_how, region_ids, meta_glob):
     return (ts_objs, ts_objs_reg)
 
 
-def _init_site_coord_arrays(data):
+@dataclass
+class CoordSiteArrays:
+    station_names: list[str]
+    station_types: list[str]
+    lats: list[float]
+    lons: list[float]
+    alts: list[float]
+    countries: list[str]
+    jsdates: dict[str, list[str]]
+    display_names: list[str] | None
+
+
+def _init_site_coord_arrays(data) -> CoordSiteArrays:
     found = False
     jsdates = {}
     for freq, cd in data.items():
@@ -503,12 +516,25 @@ def _init_site_coord_arrays(data):
                 countries = cd.data.country.values
             else:
                 countries = ["UNAVAIL"] * len(lats)
+            if "display_name" in cd.data.coords:
+                display_names = cd.data["display_name"].values
+            else:
+                display_names = None
 
             found = True
         else:
             assert all(cd.data.station_name.values == sites)
         jsdates[freq] = cd.data.jsdate.values.tolist()
-    return (sites, sites_types, lats, lons, alts, countries, jsdates)
+    return CoordSiteArrays(
+        station_names=sites,
+        station_types=sites_types,
+        lats=lats,
+        lons=lons,
+        alts=alts,
+        countries=countries,
+        jsdates=jsdates,
+        display_names=display_names,
+    )
 
 
 def _get_stat_regions(lats, lons, regions, **kwargs):
@@ -522,31 +548,36 @@ def _get_stat_regions(lats, lons, regions, **kwargs):
 
 def _process_sites(data, regions, regions_how, meta_glob):
     freqs = list(data)
-    (sites, site_types, lats, lons, alts, countries, jsdates) = _init_site_coord_arrays(data)
+    # (sites, site_types, lats, lons, alts, countries, jsdates)
+    coord_arrays = _init_site_coord_arrays(data)
     if regions_how == "country":
-        regs = countries
+        regs = coord_arrays.countries
     elif regions_how == "htap":
-        regs = _get_stat_regions(lats, lons, regions, regions_how=regions_how)
+        regs = _get_stat_regions(
+            coord_arrays.lats, coord_arrays.lons, regions, regions_how=regions_how
+        )
     else:
-        regs = _get_stat_regions(lats, lons, regions)
+        regs = _get_stat_regions(coord_arrays.lats, coord_arrays.lons, regions)
 
     ts_objs = []
     site_indices = []
     map_meta = []
 
-    for i, site in enumerate(sites):
+    for i, site in enumerate(coord_arrays.station_names):
         # init empty timeseries data object
         site_meta = {
             "station_name": str(site),
-            "station_type": site_types[i],
-            "latitude": lats[i],
-            "longitude": lons[i],
-            "altitude": alts[i],
+            "station_type": coord_arrays.station_types[i],
+            "latitude": coord_arrays.lats[i],
+            "longitude": coord_arrays.lons[i],
+            "altitude": coord_arrays.alts[i],
         }
         if regions_how == "country":
             site_meta["region"] = [regs[i]]
         else:
             site_meta["region"] = regs[i]
+        if coord_arrays.display_names is not None:
+            site_meta["station_display_name"] = coord_arrays.display_names[i]
         ts_data = _init_ts_data(freqs)
         ts_data.update(meta_glob)
         ts_data.update(site_meta)
@@ -558,7 +589,7 @@ def _process_sites(data, regions, regions_how, meta_glob):
                 if np.all(np.isnan(sitedata)):
                     # skip this site, all is NaN
                     continue
-                ts_data[f"{freq}_date"] = jsdates[freq]
+                ts_data[f"{freq}_date"] = coord_arrays.jsdates[freq]
                 ts_data[f"{freq}_obs"] = sitedata[0].tolist()
                 ts_data[f"{freq}_mod"] = sitedata[1].tolist()
                 has_data = True

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -857,7 +857,7 @@ def colocate_gridded_ungridded(
         alts[i] = obs_stat.altitude
         station_names[i] = obs_stat.station_name
         station_types[i] = getattr(obs_stat, "station_type", "")
-        station_display_names[i] = getattr(obs_stat, "station_display_name", None)
+        station_display_names[i] = getattr(obs_stat, "display_name", None)
 
         # ToDo: consider removing to keep ts_type_src_ref (this was probably
         # introduced for EBAS were the original data frequency is not constant

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -841,6 +841,7 @@ def colocate_gridded_ungridded(
     alts = [np.nan] * stat_num
     station_names = [""] * stat_num
     station_types = [""] * stat_num
+    station_display_names = [None] * stat_num
 
     data_ref_unit = None
     ts_type_src_ref = None
@@ -856,6 +857,7 @@ def colocate_gridded_ungridded(
         alts[i] = obs_stat.altitude
         station_names[i] = obs_stat.station_name
         station_types[i] = getattr(obs_stat, "station_type", "")
+        station_display_names[i] = getattr(obs_stat, "station_display_name", None)
 
         # ToDo: consider removing to keep ts_type_src_ref (this was probably
         # introduced for EBAS were the original data frequency is not constant
@@ -985,6 +987,8 @@ def colocate_gridded_ungridded(
         "longitude": ("station_name", lons),
         "altitude": ("station_name", alts),
     }
+    if any(x is not None for x in station_display_names):
+        coords["station_display_name"] = ("station_name", station_display_names)
 
     dims = ["data_source", "time", "station_name"]
     coldata = ColocatedData(data=arr, coords=coords, dims=dims, name=var, attrs=meta)

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -1025,15 +1025,14 @@ class Colocator:
         # (not all readers may do that, currently only the CAMS2_83 reader does)
         if isinstance(obs_data, UngriddedDataContainer):
             add_meta_keys = []
-            are_there_station_types = {
-                "station_type" in dict for dict in obs_data.metadata.values()
-            }
+            are_there_station_types = {"station_type" in d for d in obs_data.metadata.values()}
             if are_there_station_types == {True, False}:
                 raise ValueError("some stations have `station_type` metadata while others do not")
             if are_there_station_types == {True}:  # all have station_type
                 add_meta_keys.append("station_type")
 
-            add_meta_keys.append("display_name")
+            if any("display_name" in d for d in obs_data.metadata.values()):
+                add_meta_keys.append("display_name")
             args["add_meta_keys"] = add_meta_keys
 
         if self.obs_is_ungridded:

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -1024,13 +1024,17 @@ class Colocator:
         # check if the station_type key has been passed to the ungridded data object
         # (not all readers may do that, currently only the CAMS2_83 reader does)
         if isinstance(obs_data, UngriddedDataContainer):
+            add_meta_keys = []
             are_there_station_types = {
                 "station_type" in dict for dict in obs_data.metadata.values()
             }
             if are_there_station_types == {True, False}:
                 raise ValueError("some stations have `station_type` metadata while others do not")
             if are_there_station_types == {True}:  # all have station_type
-                args.update(add_meta_keys=["station_type"])
+                add_meta_keys.append("station_type")
+
+            add_meta_keys.append("display_name")
+            args["add_meta_keys"] = add_meta_keys
 
         if self.obs_is_ungridded:
             ts_type = self._get_colocation_ts_type(model_data.ts_type)


### PR DESCRIPTION
## Change Summary

There are two primary motivations for separating `station_name` and `display_name`:

* Some readers have `station_name` which are used as index key, but are not helpful for the users of aeroval
* pyaerocom implicitly requires station names to be unique which may cause issues when merging different observation networks

A result can be seen at https://aeroval-test.met.no/magnusu/pages/evaluation/?project=eeareadertest&experiment=display-name (cf. [older experiment](https://aeroval-test.met.no/magnusu/pages/evaluation/?project=eeareadertest&experiment=2024-reporting-catalog-eea-reader))

An alternative would be to rename `station_name` to `station_id`, but this requires extensive changes over most of the code of pyaerocom and aeroval

<!-- Please give a short summary of the changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

Potentially addressing https://github.com/metno/pyaerocom/issues/1581

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
