### PR TITLE
Adds NOTE to colocate_time about model interpolation

### DIFF
--- a/pyaerocom/colocation/colocation_setup.py
+++ b/pyaerocom/colocation/colocation_setup.py
@@ -270,7 +270,8 @@ class ColocationSetup(BaseModel):
         if True and if obs and model sampling frequency (e.g. daily) are higher
         than output colocation frequency (e.g. monthly), then the datasets are
         first colocated in time (e.g. on a daily basis), before the monthly
-        averages are calculated. Default is False.
+        averages are calculated. Default is False. NOTE: If there are missing data
+        in the model, having this true will interpolate the missing model data!
     reanalyse_existing : bool
         if True, always redo co-location, even if there is already an existing
         co-located NetCDF file (under the output location specified by

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -222,7 +222,8 @@ def colocate_gridded_gridded(
     colocate_time : bool
         if True and if original time resolution of data is higher than desired
         time resolution (`ts_type`), then both datasets are colocated in time
-        *before* resampling to lower resolution.
+        *before* resampling to lower resolution. NOTE: If there are missing data
+        in the model, having this true will interpolate the missing model data!
     resample_how : str or dict
         string specifying how data should be aggregated when resampling in time.
         Default is "mean". Can also be a nested dictionary, e.g.
@@ -682,7 +683,8 @@ def colocate_gridded_ungridded(
     colocate_time : bool
         if True and if original time resolution of data is higher than desired
         time resolution (`ts_type`), then both datasets are colocated in time
-        *before* resampling to lower resolution.
+        *before* resampling to lower resolution. NOTE: If there are missing data
+        in the model, having this true will interpolate the missing model data!
     use_climatology_ref : ClimateConfig | bool, optional.
         Configuration for calculating the climatology. If set to a bool, this will not be done
     resample_how : str or dict


### PR DESCRIPTION
## Change Summary

Adds small NOTE/warning to the docstrings about colocate_time, that if this is true then missing model data will be interpolated

## Related issue number

Issue #1615 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
