### PR TITLE
User customizable units

### DIFF
--- a/docs/api-aeroval.rst
+++ b/docs/api-aeroval.rst
@@ -11,9 +11,35 @@ Tools for AeroVal experiment setup
 High level analysis setup for AeroVal experiment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. automodule:: pyaerocom.aeroval.setup_classes
+.. automodule:: pyaerocom.aeroval.setup_classes.project_info
    :members:
 
+.. automodule:: pyaerocom.aeroval.setup_classes.experiment_info
+   :members:
+
+.. automodule:: pyaerocom.aeroval.setup_classes.eval_setup
+   :members:
+
+.. automodule:: pyaerocom.aeroval.setup_classes.time_setup
+   :members:
+
+.. automodule:: pyaerocom.aeroval.setup_classes.statistics_setup
+   :members:
+
+.. automodule:: pyaerocom.aeroval.setup_classes.web_display_setup
+   :members:
+
+.. automodule:: pyaerocom.aeroval.setup_classes.units_setup
+   :members:
+
+.. automodule:: pyaerocom.aeroval.setup_classes.cams2_83_setup
+   :members:
+
+.. automodule:: pyaerocom.aeroval.setup_classes.model_maps_setup
+   :members:
+
+.. automodule:: pyaerocom.aeroval.setup_classes.output_paths
+   :members:
 Specification of observation datasets
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/pyaerocom/aeroval/_processing_base.py
+++ b/pyaerocom/aeroval/_processing_base.py
@@ -6,7 +6,7 @@ from pyaerocom.aeroval import EvalSetup
 from pyaerocom.aeroval.experiment_output import ExperimentOutput
 from pyaerocom.colocation.colocation_setup import ColocationSetup
 from pyaerocom.colocation.colocator import Colocator
-
+from pyaerocom.units.helpers import set_unit_overrides
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +29,7 @@ class HasConfig:
 
     def __init__(self, cfg: EvalSetup):
         self.cfg = cfg
+        set_unit_overrides(cfg.units_cfg.units)
         self.exp_output = ExperimentOutput(cfg)
         self.avdb = self.exp_output.avdb
 

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -27,6 +27,7 @@ from pyaerocom.exceptions import (
     VariableDefinitionError,
     VarNotAvailableError,
 )
+from pyaerocom.units.helpers import get_standard_unit
 
 
 logger = logging.getLogger(__name__)
@@ -470,9 +471,10 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
             else:
                 var_info = const.VARS[var]
                 low, high = var_info.minimum, var_info.maximum
-            data.check_unit()
+
             data.remove_outliers(low, high, inplace=True)
 
+        data.convert_unit(get_standard_unit(data.var_name))
         return data
 
     def _check_ts_for_only_model_maps(

--- a/pyaerocom/aeroval/setup/__init__.py
+++ b/pyaerocom/aeroval/setup/__init__.py
@@ -7,3 +7,4 @@ from .web_display_setup import WebDisplaySetup
 from .experiment_info import ExperimentInfo
 from .eval_run_options import EvalRunOptions
 from .eval_setup import EvalSetup
+from .units_setup import UnitsSetup

--- a/pyaerocom/aeroval/setup/eval_setup.py
+++ b/pyaerocom/aeroval/setup/eval_setup.py
@@ -46,6 +46,7 @@ from .eval_run_options import EvalRunOptions
 from .project_info import ProjectInfo
 from .experiment_info import ExperimentInfo
 from .cams2_83_setup import CAMS2_83Setup
+from .units_setup import UnitsSetup
 
 logger = logging.getLogger(__name__)
 
@@ -266,6 +267,16 @@ class EvalSetup(BaseModel):
         for k, v in self.model_extra.get("model_cfg", {}).items():
             mc.add_entry(k, v)
         return mc
+
+    @computed_field
+    @cached_property
+    def units_cfg(self) -> UnitsSetup:
+        if not hasattr(self, "model_extra") or self.model_extra is None:
+            return UnitsSetup()
+        model_args = {
+            key: val for key, val in self.model_extra.items() if key in UnitsSetup.model_fields
+        }
+        return UnitsSetup(**model_args)
 
     @field_serializer("model_cfg")
     def serialize_model_cfg(self, model_cfg: ModelCollection):

--- a/pyaerocom/aeroval/setup/units_setup.py
+++ b/pyaerocom/aeroval/setup/units_setup.py
@@ -2,4 +2,15 @@ from pydantic import BaseModel
 
 
 class UnitsSetup(BaseModel):
+    """
+    Unit setup options
+
+    Attributes
+    ----------
+    units : dict[str, str]
+        A dictionary specifying a mapping from variable name (eg. concno2) to unit. All unit conversion
+        by pyaerocom will use this unit for harmonisation if provided. If not provided, the unit specified
+        in variables.ini will be used.
+    """
+
     units: dict[str, str] = {}

--- a/pyaerocom/aeroval/setup/units_setup.py
+++ b/pyaerocom/aeroval/setup/units_setup.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class UnitsSetup(BaseModel):
+    units: dict[str, str] = {}

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -239,16 +239,6 @@ def colocate_gridded_gridded(
     if filter_name is None:
         filter_name = const.DEFAULT_REG_FILTER
 
-    # if harmonise_units:
-    #    if not data.units == data_ref.units:
-    #        try:
-    #            data_ref.convert_unit(data.units)
-    #        except Exception:
-    #            raise DataUnitError(
-    #                f"Failed to merge data unit of reference gridded data object ({data.units}) "
-    #                f"to data unit of gridded data object ({data_ref.units})"
-    #            )
-
     if update_baseyear_gridded is not None:
         # update time dimension in gridded data
         data.base_year = update_baseyear_gridded
@@ -844,10 +834,7 @@ def colocate_gridded_ungridded(
     data_ref_unit = None
     ts_type_src_ref = None
     data_unit = str(data.units)
-    # if not harmonise_units:
-    #    data_unit = str(data.units)
-    # else:
-    #    data_unit = None
+
     # loop over all stations and append to colocated data object
     for i, obs_stat in enumerate(obs_stat_data):
         # Add coordinates to arrays required for xarray.DataArray below
@@ -890,13 +877,6 @@ def colocate_gridded_ungridded(
 
         # get model station data
         grid_stat = grid_stat_data[i]
-        # if harmonise_units:
-        #    grid_unit = grid_stat.get_unit(var)
-        #    to_unit = get_standard_unit(var_ref)
-        #    if not grid_unit == to_unit:
-        #        grid_stat.convert_unit(var, to_unit)
-        #    if data_unit is None:
-        #        data_unit = to_unit
 
         try:
             if colocate_time:

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -160,7 +160,6 @@ def colocate_gridded_gridded(
     stop=None,
     filter_name=None,
     regrid_res_deg: float | RegridResDeg | None = None,
-    # harmonise_units=True,
     regrid_scheme: str = "areaweighted",
     update_baseyear_gridded=None,
     min_num_obs=None,
@@ -203,9 +202,6 @@ def colocate_gridded_gridded(
         resolution (if input is integer, both lat and lon are regridded to that
         resolution, if input is dict, use keys `lat_res_deg` and `lon_res_deg`
         to specify regrid resolutions, respectively).
-    harmonise_units : bool
-        if True, units are attempted to be harmonised (note: raises Exception
-        if True and units cannot be harmonised). Defaults to True.
     regrid_scheme : str
         iris scheme used for regridding (defaults to area weighted regridding)
     update_baseyear_gridded : int, optional
@@ -603,7 +599,6 @@ def colocate_gridded_ungridded(
     stop=None,
     filter_name=None,
     regrid_res_deg: float | RegridResDeg | None = None,
-    # harmonise_units=True,
     regrid_scheme: str = "areaweighted",
     var_ref=None,
     update_baseyear_gridded=None,
@@ -652,9 +647,6 @@ def colocate_gridded_ungridded(
         resolution (if input is integer, both lat and lon are regridded to that
         resolution, if input is dict, use keys `lat_res_deg` and `lon_res_deg`
         to specify regrid resolutions, respectively).
-    harmonise_units : bool
-        if True, units are attempted to be harmonised (note: raises Exception
-        if True and units cannot be harmonised).
     var_ref : :obj:`str`, optional
         variable against which data in arg `data` is supposed to be compared.
         If None, then the same variable is used (i.e. `data.var_name`).

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -15,7 +15,6 @@ from pyaerocom import const
 from pyaerocom._lowlevel_helpers import RegridResDeg
 from pyaerocom.climatology_config import ClimatologyConfig
 from pyaerocom.exceptions import (
-    DataUnitError,
     DimensionOrderError,
     MetaDataError,
     TemporalResolutionError,
@@ -33,7 +32,6 @@ from pyaerocom.helpers import (
 )
 from pyaerocom.time_resampler import TimeResampler
 from pyaerocom.units.datetime import TsType
-from pyaerocom.units.helpers import get_standard_unit
 
 from .colocated_data import ColocatedData
 
@@ -162,7 +160,7 @@ def colocate_gridded_gridded(
     stop=None,
     filter_name=None,
     regrid_res_deg: float | RegridResDeg | None = None,
-    harmonise_units=True,
+    # harmonise_units=True,
     regrid_scheme: str = "areaweighted",
     update_baseyear_gridded=None,
     min_num_obs=None,
@@ -241,15 +239,15 @@ def colocate_gridded_gridded(
     if filter_name is None:
         filter_name = const.DEFAULT_REG_FILTER
 
-    if harmonise_units:
-        if not data.units == data_ref.units:
-            try:
-                data_ref.convert_unit(data.units)
-            except Exception:
-                raise DataUnitError(
-                    f"Failed to merge data unit of reference gridded data object ({data.units}) "
-                    f"to data unit of gridded data object ({data_ref.units})"
-                )
+    # if harmonise_units:
+    #    if not data.units == data_ref.units:
+    #        try:
+    #            data_ref.convert_unit(data.units)
+    #        except Exception:
+    #            raise DataUnitError(
+    #                f"Failed to merge data unit of reference gridded data object ({data.units}) "
+    #                f"to data unit of gridded data object ({data_ref.units})"
+    #            )
 
     if update_baseyear_gridded is not None:
         # update time dimension in gridded data
@@ -615,7 +613,7 @@ def colocate_gridded_ungridded(
     stop=None,
     filter_name=None,
     regrid_res_deg: float | RegridResDeg | None = None,
-    harmonise_units=True,
+    # harmonise_units=True,
     regrid_scheme: str = "areaweighted",
     var_ref=None,
     update_baseyear_gridded=None,
@@ -845,10 +843,11 @@ def colocate_gridded_ungridded(
 
     data_ref_unit = None
     ts_type_src_ref = None
-    if not harmonise_units:
-        data_unit = str(data.units)
-    else:
-        data_unit = None
+    data_unit = str(data.units)
+    # if not harmonise_units:
+    #    data_unit = str(data.units)
+    # else:
+    #    data_unit = None
     # loop over all stations and append to colocated data object
     for i, obs_stat in enumerate(obs_stat_data):
         # Add coordinates to arrays required for xarray.DataArray below
@@ -891,13 +890,13 @@ def colocate_gridded_ungridded(
 
         # get model station data
         grid_stat = grid_stat_data[i]
-        if harmonise_units:
-            grid_unit = grid_stat.get_unit(var)
-            to_unit = get_standard_unit(var_ref)
-            if not grid_unit == to_unit:
-                grid_stat.convert_unit(var, to_unit)
-            if data_unit is None:
-                data_unit = to_unit
+        # if harmonise_units:
+        #    grid_unit = grid_stat.get_unit(var)
+        #    to_unit = get_standard_unit(var_ref)
+        #    if not grid_unit == to_unit:
+        #        grid_stat.convert_unit(var, to_unit)
+        #    if data_unit is None:
+        #        data_unit = to_unit
 
         try:
             if colocate_time:

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -31,11 +31,9 @@ from pyaerocom.io.mscw_ctm.reader import ReadMscwCtm
 from pyaerocom.stats.mda8.const import MDA8_INPUT_VARS
 from pyaerocom.stats.mda8.mda8 import mda8_colocated_data
 from pyaerocom.ungridded_data_container import UngriddedDataContainer
-from pyaerocom.ungriddeddata import UngriddedData
-from pyaerocom.ungriddeddata_structured import UngriddedDataStructured
 from pyaerocom.units import Unit
 from pyaerocom.units.datetime import get_lowest_resolution, to_pandas_timestamp
-from pyaerocom.units.helpers import get_standard_unit
+from pyaerocom.units.harmonise import harmonise_units
 
 from .colocated_data import ColocatedData
 from .colocation_3d import ColocatedDataLists, colocate_vertical_profile_gridded
@@ -1001,13 +999,16 @@ class Colocator:
         obs_data = self.get_obs_data(obs_var)
 
         if self.colocation_setup.harmonise_units:
-            model_data.convert_unit(get_standard_unit(obs_var), inplace=True)
-            if isinstance(obs_data, GriddedData):
-                obs_data.convert_unit(get_standard_unit(model_var), inplace=True)
-            elif isinstance(obs_data, UngriddedDataStructured | UngriddedData):
-                obs_data.check_convert_var_units(
-                    obs_var
-                )  # TODO: Fix, units not necessarily harmonized if different vars.
+            model_data, obs_data = harmonise_units(
+                model_data, obs_data, var=model_var, var_ref=obs_var
+            )
+            # model_data.convert_unit(get_standard_unit(obs_var), inplace=True)
+            # if isinstance(obs_data, GriddedData):
+            #    obs_data.convert_unit(get_standard_unit(model_var), inplace=True)
+            # elif isinstance(obs_data, UngriddedDataStructured | UngriddedData):
+            #    obs_data.check_convert_var_units(
+            #        obs_var
+            #    )  # TODO: Fix, units not necessarily harmonized if different vars.
 
         if getattr(obs_data, "is_vertical_profile", None):
             self.obs_is_vertical_profile = obs_data.is_vertical_profile

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -1000,15 +1000,8 @@ class Colocator:
 
         if self.colocation_setup.harmonise_units:
             model_data, obs_data = harmonise_units(
-                model_data, obs_data, var=model_var, var_ref=obs_var
+                model_data, obs_data, var=model_var, var_ref=obs_var, inplace=True
             )
-            # model_data.convert_unit(get_standard_unit(obs_var), inplace=True)
-            # if isinstance(obs_data, GriddedData):
-            #    obs_data.convert_unit(get_standard_unit(model_var), inplace=True)
-            # elif isinstance(obs_data, UngriddedDataStructured | UngriddedData):
-            #    obs_data.check_convert_var_units(
-            #        obs_var
-            #    )  # TODO: Fix, units not necessarily harmonized if different vars.
 
         if getattr(obs_data, "is_vertical_profile", None):
             self.obs_is_vertical_profile = obs_data.is_vertical_profile

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -31,8 +31,11 @@ from pyaerocom.io.mscw_ctm.reader import ReadMscwCtm
 from pyaerocom.stats.mda8.const import MDA8_INPUT_VARS
 from pyaerocom.stats.mda8.mda8 import mda8_colocated_data
 from pyaerocom.ungridded_data_container import UngriddedDataContainer
+from pyaerocom.ungriddeddata import UngriddedData
+from pyaerocom.ungriddeddata_structured import UngriddedDataStructured
 from pyaerocom.units import Unit
 from pyaerocom.units.datetime import get_lowest_resolution, to_pandas_timestamp
+from pyaerocom.units.helpers import get_standard_unit
 
 from .colocated_data import ColocatedData
 from .colocation_3d import ColocatedDataLists, colocate_vertical_profile_gridded
@@ -996,6 +999,14 @@ class Colocator:
     def _prepare_colocation_args(self, model_var: str, obs_var: str):
         model_data = self.get_model_data(model_var)
         obs_data = self.get_obs_data(obs_var)
+
+        model_data.convert_unit(get_standard_unit(obs_var), inplace=True)
+        if isinstance(obs_data, GriddedData):
+            obs_data.convert_unit(get_standard_unit(model_var), inplace=True)
+        elif isinstance(obs_data, UngriddedDataStructured | UngriddedData):
+            obs_data.check_convert_var_units(
+                obs_var
+            )  # TODO: Fix, units not necessarily harmonized if different vars.
 
         if getattr(obs_data, "is_vertical_profile", None):
             self.obs_is_vertical_profile = obs_data.is_vertical_profile

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -1020,7 +1020,6 @@ class Colocator:
             stop=self.stop,
             filter_name=self.colocation_setup.filter_name,
             regrid_res_deg=self.colocation_setup.regrid_res_deg,
-            # harmonise_units=self.colocation_setup.harmonise_units,
             update_baseyear_gridded=baseyr,
             min_num_obs=self.colocation_setup.min_num_obs,
             colocate_time=self.colocation_setup.colocate_time,

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -1000,13 +1000,14 @@ class Colocator:
         model_data = self.get_model_data(model_var)
         obs_data = self.get_obs_data(obs_var)
 
-        model_data.convert_unit(get_standard_unit(obs_var), inplace=True)
-        if isinstance(obs_data, GriddedData):
-            obs_data.convert_unit(get_standard_unit(model_var), inplace=True)
-        elif isinstance(obs_data, UngriddedDataStructured | UngriddedData):
-            obs_data.check_convert_var_units(
-                obs_var
-            )  # TODO: Fix, units not necessarily harmonized if different vars.
+        if self.colocation_setup.harmonise_units:
+            model_data.convert_unit(get_standard_unit(obs_var), inplace=True)
+            if isinstance(obs_data, GriddedData):
+                obs_data.convert_unit(get_standard_unit(model_var), inplace=True)
+            elif isinstance(obs_data, UngriddedDataStructured | UngriddedData):
+                obs_data.check_convert_var_units(
+                    obs_var
+                )  # TODO: Fix, units not necessarily harmonized if different vars.
 
         if getattr(obs_data, "is_vertical_profile", None):
             self.obs_is_vertical_profile = obs_data.is_vertical_profile
@@ -1025,7 +1026,7 @@ class Colocator:
             stop=self.stop,
             filter_name=self.colocation_setup.filter_name,
             regrid_res_deg=self.colocation_setup.regrid_res_deg,
-            harmonise_units=self.colocation_setup.harmonise_units,
+            # harmonise_units=self.colocation_setup.harmonise_units,
             update_baseyear_gridded=baseyr,
             min_num_obs=self.colocation_setup.min_num_obs,
             colocate_time=self.colocation_setup.colocate_time,

--- a/pyaerocom/griddeddata.py
+++ b/pyaerocom/griddeddata.py
@@ -777,10 +777,16 @@ class GriddedData:
         try:
             var = const.VARS[self.cube.var_name]
             to_unit = get_standard_unit(var.var_name)
-            current_unit = self.units
+            current_unit = Unit(self.units, aerocom_var=var.var_name, ts_type=self.ts_type)
             if to_unit == current_unit:  # string match e.g. both are m-1
                 unit_ok = True
-            elif Unit(to_unit).convert(1, current_unit) == 1:
+            # TODO: Clean up the below line.
+            elif (
+                Unit(to_unit, aerocom_var=var.var_name, ts_type=self.ts_type).convert(
+                    1, current_unit, aerocom_var=var.var_name
+                )
+                == 1
+            ):
                 self.units = to_unit
                 logger.info(
                     f"Updating unit string from {current_unit} to {to_unit} in GriddedData."

--- a/pyaerocom/griddeddata.py
+++ b/pyaerocom/griddeddata.py
@@ -773,43 +773,38 @@ class GriddedData:
         """Check if unit is correct"""
         self._check_invalid_unit_alias()
         unit_ok = False
-        to_unit = None
+        to_unit_str = None
         try:
             var = const.VARS[self.cube.var_name]
-            to_unit = get_standard_unit(var.var_name)
+            to_unit_str = get_standard_unit(var.var_name)
+            to_unit = Unit(to_unit_str, aerocom_var=var.var_name, ts_type=self.ts_type)
             current_unit = Unit(self.units, aerocom_var=var.var_name, ts_type=self.ts_type)
             if to_unit == current_unit:  # string match e.g. both are m-1
                 unit_ok = True
-            # TODO: Clean up the below line.
-            elif (
-                Unit(to_unit, aerocom_var=var.var_name, ts_type=self.ts_type).convert(
-                    1, current_unit, aerocom_var=var.var_name
-                )
-                == 1
-            ):
-                self.units = to_unit
+            elif to_unit.convert(1, current_unit) == 1:
+                self.units = to_unit_str
                 logger.info(
-                    f"Updating unit string from {current_unit} to {to_unit} in GriddedData."
+                    f"Updating unit string from {current_unit} to {to_unit_str} in GriddedData."
                 )
                 unit_ok = True
         except (VariableDefinitionError, ValueError):
             pass
 
-        if not unit_ok and try_convert_if_wrong and isinstance(to_unit, str):
+        if not unit_ok and try_convert_if_wrong and isinstance(to_unit_str, str):
             logger.warning(
                 f"Unit {self.units} in GriddedData {self.short_str()} is not "
-                f"AeroCom conform ({to_unit}). Trying to convert ... "
+                f"AeroCom conform ({to_unit_str}). Trying to convert ... "
             )
             if self.var_info.units == "1" and self.units.is_unknown():
                 self.units = "1"
                 unit_ok = True
             else:
                 try:
-                    self.convert_unit(to_unit)
+                    self.convert_unit(to_unit_str)
                     unit_ok = True
                 except Exception as e:
                     logger.warning(
-                        f"Failed to convert unit from {self.units} to {to_unit}. Reason: {e}"
+                        f"Failed to convert unit from {self.units} to {to_unit_str}. Reason: {e}"
                     )
 
         return unit_ok

--- a/pyaerocom/units/harmonise.py
+++ b/pyaerocom/units/harmonise.py
@@ -4,7 +4,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def harmonise_units(data, data_ref, *, var: str, var_ref: str) -> tuple:
+def harmonise_units(data, data_ref, *, var: str, var_ref: str, inplace=False) -> tuple:
     """Tries to perform unit conversion for the provided data object, so that
     the units of the data objects match for the given variable names.
 
@@ -18,6 +18,7 @@ def harmonise_units(data, data_ref, *, var: str, var_ref: str) -> tuple:
     :param data: Reference data.
     :param var: Varname for data.
     :param var_ref: Varname for data_ref.
+    :param inplace: Whether to perform conversion inplace.
     :return: tuple of length n, containing converted data and ref_data.
     """
     std_unit = get_standard_unit(var)
@@ -31,13 +32,15 @@ def harmonise_units(data, data_ref, *, var: str, var_ref: str) -> tuple:
     harmonised_unit = std_unit_ref
 
     try:
-        data = data.convert_unit(harmonised_unit, inplace=True)
+        data = data.convert_unit(harmonised_unit, inplace=inplace)
     except AttributeError:
-        data = data.check_convert_var_units(var, to_unit=harmonised_unit, inplace=True)
+        data = data.check_convert_var_units(var, to_unit=harmonised_unit, inplace=inplace)
 
     try:
-        data_ref = data_ref.convert_unit(harmonised_unit, inplace=True)
+        data_ref = data_ref.convert_unit(harmonised_unit, inplace=inplace)
     except AttributeError:
-        data_ref = data_ref.check_convert_var_units(var_ref, to_unit=harmonised_unit, inplace=True)
+        data_ref = data_ref.check_convert_var_units(
+            var_ref, to_unit=harmonised_unit, inplace=inplace
+        )
 
     return data, data_ref

--- a/pyaerocom/units/harmonise.py
+++ b/pyaerocom/units/harmonise.py
@@ -1,0 +1,43 @@
+from pyaerocom.units.helpers import get_standard_unit
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def harmonise_units(data, data_ref, *, var: str, var_ref: str) -> tuple:
+    """Tries to perform unit conversion for the provided data object, so that
+    the units of the data objects match for the given variable names.
+
+    If var == var_ref, both data objects will be converted to the unit provided
+    by pyaerocom.units.get_standard_unit.
+
+    If var != var_ref, both data objects will be attempted converted to the unit
+    provided by pyaerocom.units.get_standard_unit for var_ref.
+
+    :param data: Data
+    :param data: Reference data.
+    :param var: Varname for data.
+    :param var_ref: Varname for data_ref.
+    :return: tuple of length n, containing converted data and ref_data.
+    """
+    std_unit = get_standard_unit(var)
+    std_unit_ref = get_standard_unit(var_ref)
+
+    if std_unit != std_unit_ref:
+        logger.info(
+            f"'std_unit' ({std_unit}) and 'std_unit_ref' ({std_unit_ref}) do not match. Attempting to convert both data objects to {std_unit_ref}."
+        )
+
+    harmonised_unit = std_unit_ref
+
+    try:
+        data = data.convert_unit(harmonised_unit, inplace=True)
+    except AttributeError:
+        data = data.check_convert_var_units(var, to_unit=harmonised_unit, inplace=True)
+
+    try:
+        data_ref = data_ref.convert_unit(harmonised_unit, inplace=True)
+    except AttributeError:
+        data_ref = data_ref.check_convert_var_units(var_ref, to_unit=harmonised_unit, inplace=True)
+
+    return data, data_ref

--- a/pyaerocom/units/logging/callbacks.py
+++ b/pyaerocom/units/logging/callbacks.py
@@ -28,7 +28,7 @@ class LoggingCallback:
 
         self._logger.log(
             level,
-            "Successfully converted unit of variable '%s' from '%s' to '%s' using conversion factor '%d'.",
+            "Successfully converted unit of variable '%s' from '%s' to '%s' using conversion factor '%.2f'.",
             info.from_aerocom_var,
             info.from_cf_unit,
             info.to_cf_unit,

--- a/pyaerocom/units/molecular_mass.py
+++ b/pyaerocom/units/molecular_mass.py
@@ -32,6 +32,8 @@ _VAR_PREFIXES = [
     "dep",
 ]
 
+_VAR_POSTFIXES = ["pr"]
+
 _MOLMASSES = {
     # Override molecular masses used for species that do not constitute molecular
     # formulas with only single letter elements.
@@ -71,8 +73,14 @@ def _get_species(aerocom_var: str) -> str:
     for prefix in _VAR_PREFIXES:
         if aerocom_var.startswith(prefix):
             species = aerocom_var.split(prefix)[-1]
+            break
             # if species in _MOLMASSES:
-            return species
+    for postfix in _VAR_POSTFIXES:
+        if species.endswith(postfix):
+            species = species.split(postfix)[0]
+            break
+
+    return species
 
     raise UnknownSpeciesError(
         f"Could not infer atom / molecule/ species from var_name {aerocom_var}"

--- a/pyaerocom/units/molecular_mass.py
+++ b/pyaerocom/units/molecular_mass.py
@@ -70,21 +70,23 @@ def _get_species(aerocom_var: str) -> str:
     """
     if aerocom_var in _MOLMASSES:
         return aerocom_var
+    species = None
     for prefix in _VAR_PREFIXES:
         if aerocom_var.startswith(prefix):
             species = aerocom_var.split(prefix)[-1]
             break
             # if species in _MOLMASSES:
+
+    if species is None:
+        raise UnknownSpeciesError(
+            f"Could not infer atom / molecule/ species from var_name {aerocom_var}"
+        )
     for postfix in _VAR_POSTFIXES:
         if species.endswith(postfix):
             species = species.split(postfix)[0]
             break
 
     return species
-
-    raise UnknownSpeciesError(
-        f"Could not infer atom / molecule/ species from var_name {aerocom_var}"
-    )
 
 
 class MolecularMass:

--- a/pyaerocom/units/units.py
+++ b/pyaerocom/units/units.py
@@ -14,17 +14,18 @@ from collections.abc import Iterable
 
 import cf_units
 import numpy as np
-import pandas as pd
+# import pandas as pd
 
 from .datetime import TsType
 from .datetime.time_config import SI_TO_TS_TYPE
 from pyaerocom.variable_helpers import get_variable
 
-from .constants import HA_TO_SQM, M_SO2, M_S, M_NO2, M_N, M_NH3, M_SO4
+# from .constants import HA_TO_SQM, M_SO2, M_S, M_NO2, M_N, M_NH3, M_SO4
 
 from typing import TypeVar, overload, NamedTuple
 from collections.abc import Callable
 from .typing import SupportsMul
+from .exceptions import UnitConversionError
 
 __all__ = ["Unit"]
 
@@ -67,39 +68,32 @@ class Unit:
     #: Custom unit conversion factors for certain variables
     #: columns: variable -> from unit -> to_unit -> conversion
     #: factor
-    _UCONV_MUL_FACS = pd.DataFrame(
-        [
-            # ["dryso4", "mg/m2/d", "mgS m-2 d-1", M_S / M_SO4],
-            # ["drynh4", "mg/m2/d", "mgN m-2 d-1", M_N/ M_NH4],
-            # ["concso4", "ug S/m3", "ug m-3", M_SO4 / M_S],
-            # ["SO4ugSm3", "ug/m3", "ug S m-3", M_S / M_SO4],
-            # ["concso4pm25", "ug S/m3", "ug m-3", M_SO4 / M_S],
-            # ["concso4pm10", "ug S/m3", "ug m-3", M_SO4 / M_S],
-            ["concso2", "ug S/m3", "ug m-3", M_SO2 / M_S],
-            ["concbc", "ug C/m3", "ug m-3", 1.0],
-            ["concoa", "ug C/m3", "ug m-3", 1.0],
-            ["concoc", "ug C/m3", "ug m-3", 1.0],
-            ["conctc", "ug C/m3", "ug m-3", 1.0],
-            # a little hacky for ratpm10pm25...
-            # ["ratpm10pm25", "ug m-3", "1", 1.0],
-            ["concpm25", "ug m-3", "ug m-3", 1.0],
-            ["concpm10", "ug m-3", "ug m-3", 1.0],
-            ["concno2", "ug N/m3", "ug m-3", M_NO2 / M_N],
-            # ["concno3", "ug N/m3", "ug m-3", M_NO3 / M_N],
-            ["concnh3", "ug N/m3", "ug m-3", M_NH3 / M_N],
-            # ["concnh4", "ug N/m3", "ug m-3", M_NH4 / M_N],
-            ["wetso4", "kg S/ha", "kg m-2", M_SO4 / M_S / HA_TO_SQM],
-            ["concso4pr", "mg S/L", "g m-3", M_SO4 / M_S],
-            ["drynh3", "kg ha-1 yr-1", "kg m-2 s-2", 1 / (HA_TO_SQM * (365 * 24 * 60 * 60))],
-            [
-                "drynh3",
-                "kg N ha-1 yr-1",
-                "kg m-2 s-1",
-                (M_NH3 / M_N) / (1 / (HA_TO_SQM * (365 * 24 * 60 * 60))),
-            ],
-        ],
-        columns=["var_name", "from", "to", "fac"],
-    ).set_index(["var_name", "from"])
+    # _UCONV_MUL_FACS = pd.DataFrame(
+    #    [
+    #        # ["dryso4", "mg/m2/d", "mgS m-2 d-1", M_S / M_SO4],
+    #        # ["drynh4", "mg/m2/d", "mgN m-2 d-1", M_N/ M_NH4],
+    #        # ["concso4", "ug S/m3", "ug m-3", M_SO4 / M_S],
+    #        # ["SO4ugSm3", "ug/m3", "ug S m-3", M_S / M_SO4],
+    #        # ["concso4pm25", "ug S/m3", "ug m-3", M_SO4 / M_S],
+    #        # ["concso4pm10", "ug S/m3", "ug m-3", M_SO4 / M_S],
+    #        ["concso2", "ug S/m3", "ug m-3", M_SO2 / M_S],
+    #        ["concbc", "ug C/m3", "ug m-3", 1.0],
+    #        ["concoa", "ug C/m3", "ug m-3", 1.0],
+    #        ["concoc", "ug C/m3", "ug m-3", 1.0],
+    #        ["conctc", "ug C/m3", "ug m-3", 1.0],
+    #        # a little hacky for ratpm10pm25...
+    #        # ["ratpm10pm25", "ug m-3", "1", 1.0],
+    #        ["concpm25", "ug m-3", "ug m-3", 1.0],
+    #        ["concpm10", "ug m-3", "ug m-3", 1.0],
+    #        ["concno2", "ug N/m3", "ug m-3", M_NO2 / M_N],
+    #        # ["concno3", "ug N/m3", "ug m-3", M_NO3 / M_N],
+    #        ["concnh3", "ug N/m3", "ug m-3", M_NH3 / M_N],
+    #        # ["concnh4", "ug N/m3", "ug m-3", M_NH4 / M_N],
+    #        ["wetso4", "kg S/ha", "kg m-2", M_SO4 / M_S / HA_TO_SQM],
+    #        ["concso4pr", "mg S/L", "g m-3", M_SO4 / M_S],
+    #    ],
+    #    columns=["var_name", "from", "to", "fac"],
+    # ).set_index(["var_name", "from"])
 
     _UALIASES = {
         # mass concentrations
@@ -151,9 +145,11 @@ class Unit:
         self._species = kwargs.pop("species", None)
         if self._species is None:
             try:
-                self._species = _get_species(aerocom_var).upper()
+                sp = _get_species(aerocom_var).upper()
             except (UnknownSpeciesError, AttributeError):
                 pass
+            else:
+                self._species = sp
 
         self._element = None
         if self._species is not None:
@@ -164,7 +160,11 @@ class Unit:
                     break
 
         if self._element is not None and self._species is not None:
-            factor = MolecularMass(self._species) / MolecularMass(self._element)
+            try:
+                factor = MolecularMass(self._species) / MolecularMass(self._element)
+            except ValueError:
+                self._species = None
+                factor = 1
         else:
             factor = 1
         # try:
@@ -241,7 +241,27 @@ class Unit:
 
         :param other: Other Unit.
         """
-        return self._cfunit.is_convertible(other)
+        if isinstance(other, str):
+            other = Unit(other)
+
+        if self._element == other._element and self._species == other._species:
+            return self._cfunit.is_convertible(other._cfunit)
+        elif self._element is not None:
+            known_mass_ratio = self._element is not None and self._species is not None
+            same_variable = self._aerocom_var == other._aerocom_var
+            if known_mass_ratio or same_variable:
+                return self._cfunit.is_convertible(other._cfunit)
+        elif other._element is not None:
+            known_mass_ratio = other._element is not None and other._species is not None
+            same_variable = self._aerocom_var == other._aerocom_var
+            if known_mass_ratio or same_variable:
+                return self._cfunit.is_convertible(other._cfunit)
+        # elif self._element == other._element and self._aerocom_var == other._aerocom_var:
+        #    return self._cfunit.is_convertible(other._cfunit)
+        else:
+            return self._cfunit.is_convertible(other._cfunit)
+
+        return False
 
     def is_dimensionless(self) -> bool:
         """
@@ -331,8 +351,12 @@ class Unit:
         :param kwargs: Will be passed as additional keyword args to PyaerocomUnit.__init__() for 'other'.
         :return: Unit converted data.
         """
-        to_unit = Unit(str(other), **kwargs)._cfunit
-        factor = float(self._cfunit.convert(1, to_unit, inplace=False))
+        to_unit = Unit(str(other), **kwargs)
+
+        if not self.is_convertible(to_unit):
+            raise UnitConversionError
+        to_unit_cf = to_unit._cfunit
+        factor = float(self._cfunit.convert(1, to_unit_cf, inplace=False))
 
         if inplace:
             value *= factor

--- a/pyaerocom/units/units.py
+++ b/pyaerocom/units/units.py
@@ -212,19 +212,26 @@ class Unit:
         if isinstance(other, str):
             other = Unit(other)
 
-        if self._element == other._element and self._species == other._species:
+        cf_units_only = self._element is None and other._element is None
+        compatible_element = (
+            (self._element is None)
+            or (other._element is None)
+            or (self._element == other._element)
+        )
+        same_species = (self._species is not None and other._species is not None) and (
+            self._species == other._species
+        )
+        same_variable = (self._aerocom_var is not None and other._aerocom_var is not None) and (
+            self._aerocom_var == other._aerocom_var
+        )
+
+        if cf_units_only:
             return self._cfunit.is_convertible(other._cfunit)
-        elif self._element is not None:
-            known_mass_ratio = self._element is not None and self._species is not None
-            same_variable = self._aerocom_var == other._aerocom_var
-            if known_mass_ratio or same_variable:
-                return self._cfunit.is_convertible(other._cfunit)
-        elif other._element is not None:
-            known_mass_ratio = other._element is not None and other._species is not None
-            same_variable = self._aerocom_var == other._aerocom_var
-            if known_mass_ratio or same_variable:
-                return self._cfunit.is_convertible(other._cfunit)
-        else:
+
+        if not compatible_element:
+            return False
+
+        if same_species or same_variable:
             return self._cfunit.is_convertible(other._cfunit)
 
         return False
@@ -326,7 +333,11 @@ class Unit:
         :param kwargs: Will be passed as additional keyword args to PyaerocomUnit.__init__() for 'other'.
         :return: Unit converted data.
         """
-        to_unit = Unit(str(other), **kwargs)
+        if isinstance(other, str):
+            to_unit = Unit(str(other), **kwargs)
+        else:
+            assert isinstance(other, Unit)
+            to_unit = other
 
         if not self.is_convertible(to_unit):
             raise ValueError(

--- a/pyaerocom/units/units.py
+++ b/pyaerocom/units/units.py
@@ -14,13 +14,10 @@ from collections.abc import Iterable
 
 import cf_units
 import numpy as np
-# import pandas as pd
 
 from .datetime import TsType
 from .datetime.time_config import SI_TO_TS_TYPE
 from pyaerocom.variable_helpers import get_variable
-
-# from .constants import HA_TO_SQM, M_SO2, M_S, M_NO2, M_N, M_NH3, M_SO4
 
 from typing import TypeVar, overload, NamedTuple
 from collections.abc import Callable
@@ -65,35 +62,6 @@ class Unit:
 
     # If found in the nominator, these are treated as elements for scaling units.
     _TREAT_AS_ELEMENT = ["C", "N", "S"]
-    #: Custom unit conversion factors for certain variables
-    #: columns: variable -> from unit -> to_unit -> conversion
-    #: factor
-    # _UCONV_MUL_FACS = pd.DataFrame(
-    #    [
-    #        # ["dryso4", "mg/m2/d", "mgS m-2 d-1", M_S / M_SO4],
-    #        # ["drynh4", "mg/m2/d", "mgN m-2 d-1", M_N/ M_NH4],
-    #        # ["concso4", "ug S/m3", "ug m-3", M_SO4 / M_S],
-    #        # ["SO4ugSm3", "ug/m3", "ug S m-3", M_S / M_SO4],
-    #        # ["concso4pm25", "ug S/m3", "ug m-3", M_SO4 / M_S],
-    #        # ["concso4pm10", "ug S/m3", "ug m-3", M_SO4 / M_S],
-    #        ["concso2", "ug S/m3", "ug m-3", M_SO2 / M_S],
-    #        ["concbc", "ug C/m3", "ug m-3", 1.0],
-    #        ["concoa", "ug C/m3", "ug m-3", 1.0],
-    #        ["concoc", "ug C/m3", "ug m-3", 1.0],
-    #        ["conctc", "ug C/m3", "ug m-3", 1.0],
-    #        # a little hacky for ratpm10pm25...
-    #        # ["ratpm10pm25", "ug m-3", "1", 1.0],
-    #        ["concpm25", "ug m-3", "ug m-3", 1.0],
-    #        ["concpm10", "ug m-3", "ug m-3", 1.0],
-    #        ["concno2", "ug N/m3", "ug m-3", M_NO2 / M_N],
-    #        # ["concno3", "ug N/m3", "ug m-3", M_NO3 / M_N],
-    #        ["concnh3", "ug N/m3", "ug m-3", M_NH3 / M_N],
-    #        # ["concnh4", "ug N/m3", "ug m-3", M_NH4 / M_N],
-    #        ["wetso4", "kg S/ha", "kg m-2", M_SO4 / M_S / HA_TO_SQM],
-    #        ["concso4pr", "mg S/L", "g m-3", M_SO4 / M_S],
-    #    ],
-    #    columns=["var_name", "from", "to", "fac"],
-    # ).set_index(["var_name", "from"])
 
     _UALIASES = {
         # mass concentrations
@@ -167,15 +135,6 @@ class Unit:
                 factor = 1
         else:
             factor = 1
-        # try:
-        #    info = Unit._UCONV_MUL_FACS.loc[(aerocom_var, str(unit)), :]
-        #    if not isinstance(info, pd.Series):
-        #        raise UnitConversionError(
-        #            "FATAL: Could not find unique conversion factor in table PyaerocomUnit._UCONV_MUL_FACS."
-        #        )
-        #    new_unit, factor = (info.to, info.fac)
-        # except KeyError:
-        #    new_unit, factor = unit, 1
 
         if factor != 1:
             new_unit = f"{factor} {unit}"
@@ -256,8 +215,6 @@ class Unit:
             same_variable = self._aerocom_var == other._aerocom_var
             if known_mass_ratio or same_variable:
                 return self._cfunit.is_convertible(other._cfunit)
-        # elif self._element == other._element and self._aerocom_var == other._aerocom_var:
-        #    return self._cfunit.is_convertible(other._cfunit)
         else:
             return self._cfunit.is_convertible(other._cfunit)
 

--- a/pyaerocom/units/units.py
+++ b/pyaerocom/units/units.py
@@ -22,7 +22,6 @@ from pyaerocom.variable_helpers import get_variable
 from typing import TypeVar, overload, NamedTuple
 from collections.abc import Callable
 from .typing import SupportsMul
-from .exceptions import UnitConversionError
 
 __all__ = ["Unit"]
 
@@ -47,9 +46,7 @@ class Unit:
     The first additional behaviour is to handle variables that measure only
     a portion of the real mass. Eg. if concso4 is provided as "ug S/m3", we
     want the mass in terms of SO4, so the values must be scaled up by a
-    constant factor MolecularMass("SO4")/MolecularMass("S"). This is
-    currently enabled using the lookup tables UCONV_MUL_FACS and UALIASES,
-    combined with a scalar factor in the unit.
+    constant factor MolecularMass("SO4")/MolecularMass("S").
 
     The second behaviour is adding implicit frequency for rate variables
     and a ts_type. If tstype and aerocom_var are provided in __init__, units
@@ -166,6 +163,9 @@ class Unit:
 
     @property
     def _origin_nominator(self) -> str:
+        """
+        The nominator of the original string used to initialize this Unit instance.
+        """
         if "/" in self.origin:
             return self.origin.split("/")[0].strip()
 
@@ -182,6 +182,9 @@ class Unit:
 
     @property
     def _origin_denominator(self) -> str:
+        """
+        The denominator of the original string used to initialize this Unit instance.
+        """
         if "/" in self.origin:
             return self.origin.split("/")[1].strip()
 
@@ -196,7 +199,13 @@ class Unit:
 
     def is_convertible(self, other: str | Unit) -> bool:
         """
-        Return whether this unit is convertible to other.
+        Return whether this unit is convertible to other. It handles a couple of
+        additional cases when checking convertibility, namely:
+
+        - Units that contain elements (eg. kg N m-2) need to have compatible mass ratios:
+           - This is assumed to be the case if element and species are the same, the aerocom
+           variable is the same (to account for variables that don't have a clear mass ratio —
+           eg. wetrdn.)
 
         :param other: Other Unit.
         """
@@ -236,7 +245,16 @@ class Unit:
         return self._cfunit.__str__()
 
     def __repr__(self) -> str:
-        return self._cfunit.__repr__()
+        result = f"Unit('{self.origin}'"
+        if self._aerocom_var is not None:
+            result += f", aerocom_var='{self._aerocom_var}'"
+        if self._species is not None:
+            result += f", species='{self._species}'"
+        if self._ts_type is not None:
+            result += f", ts_type='{self._ts_type}'"
+
+        result += ")"
+        return result
 
     def __add__(self, other: float) -> Unit:
         return Unit.from_cf_units(self._cfunit.__add__(other))
@@ -311,7 +329,9 @@ class Unit:
         to_unit = Unit(str(other), **kwargs)
 
         if not self.is_convertible(to_unit):
-            raise UnitConversionError
+            raise ValueError(
+                f"Unable to convert units. Got incompatible units '{repr(self)}' and '{repr(to_unit)}'."
+            )
         to_unit_cf = to_unit._cfunit
         factor = float(self._cfunit.convert(1, to_unit_cf, inplace=False))
 

--- a/pyaerocom/units/units.py
+++ b/pyaerocom/units/units.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 import datetime
 import sys
 
+from pyaerocom.units.molecular_mass import MolecularMass, UnknownSpeciesError, _get_species
+
 if sys.version_info >= (3, 11):
     from typing import Self
 else:
@@ -14,7 +16,6 @@ import cf_units
 import numpy as np
 import pandas as pd
 
-from .exceptions import UnitConversionError
 from .datetime import TsType
 from .datetime.time_config import SI_TO_TS_TYPE
 from pyaerocom.variable_helpers import get_variable
@@ -61,6 +62,8 @@ class Unit:
     This wrapper allows conversion of any data structure that supports __mul__.
     """
 
+    # If found in the nominator, these are treated as elements for scaling units.
+    _TREAT_AS_ELEMENT = ["C", "N", "S"]
     #: Custom unit conversion factors for certain variables
     #: columns: variable -> from unit -> to_unit -> conversion
     #: factor
@@ -140,22 +143,44 @@ class Unit:
         *,
         aerocom_var: str | None = None,
         ts_type: str | TsType | None = None,
+        **kwargs,
     ) -> None:
         self._origin = str(unit)
         unit = Unit._UALIASES.get(str(unit), str(unit))
 
-        try:
-            info = Unit._UCONV_MUL_FACS.loc[(aerocom_var, str(unit)), :]
-            if not isinstance(info, pd.Series):
-                raise UnitConversionError(
-                    "FATAL: Could not find unique conversion factor in table PyaerocomUnit._UCONV_MUL_FACS."
-                )
-            new_unit, factor = (info.to, info.fac)
-        except KeyError:
-            new_unit, factor = unit, 1
+        self._species = kwargs.pop("species", None)
+        if self._species is None:
+            try:
+                self._species = _get_species(aerocom_var).upper()
+            except (UnknownSpeciesError, AttributeError):
+                pass
+
+        self._element = None
+        if self._species is not None:
+            for e in Unit._TREAT_AS_ELEMENT:
+                if e in self._origin_nominator:
+                    unit = unit.replace(e, "", 1)
+                    self._element = e
+                    break
+
+        if self._element is not None and self._species is not None:
+            factor = MolecularMass(self._species) / MolecularMass(self._element)
+        else:
+            factor = 1
+        # try:
+        #    info = Unit._UCONV_MUL_FACS.loc[(aerocom_var, str(unit)), :]
+        #    if not isinstance(info, pd.Series):
+        #        raise UnitConversionError(
+        #            "FATAL: Could not find unique conversion factor in table PyaerocomUnit._UCONV_MUL_FACS."
+        #        )
+        #    new_unit, factor = (info.to, info.fac)
+        # except KeyError:
+        #    new_unit, factor = unit, 1
 
         if factor != 1:
-            new_unit = f"{factor} {new_unit}"
+            new_unit = f"{factor} {unit}"
+        else:
+            new_unit = unit
 
         if ts_type is not None and aerocom_var is not None and get_variable(aerocom_var).is_rate:
             ends_with_freq = False
@@ -179,6 +204,36 @@ class Unit:
         The original string used to create this Unit.
         """
         return self._origin
+
+    @property
+    def _origin_nominator(self) -> str:
+        if "/" in self.origin:
+            return self.origin.split("/")[0].strip()
+
+        if "-" in self.origin:
+            idx = self.origin.index("-")
+            try:
+                while self.origin[idx] not in [" ", "."]:
+                    idx -= 1
+            except IndexError:
+                pass
+            return self.origin[:idx].strip()
+
+        return self.origin.strip()
+
+    @property
+    def _origin_denominator(self) -> str:
+        if "/" in self.origin:
+            return self.origin.split("/")[1].strip()
+
+        if "-" in self.origin:
+            idx = self.origin.index("-")
+            while self.origin[idx] != " ":
+                idx -= 1
+
+            return self.origin[idx:].strip()
+
+        return ""
 
     def is_convertible(self, other: str | Unit) -> bool:
         """

--- a/pyaerocom/units/units_helpers.py
+++ b/pyaerocom/units/units_helpers.py
@@ -72,6 +72,7 @@ def convert_unit(
             other=Unit(to_unit, aerocom_var=var_name, ts_type=ts_type),
             inplace=inplace,
             callback=callback,
+            aerocom_var=var_name,
         )
     except ValueError as e:
         raise UnitConversionError(

--- a/tests/colocation/test_colocator.py
+++ b/tests/colocation/test_colocator.py
@@ -263,8 +263,9 @@ def test_Colocator_run_gridded_ungridded(
 
 def test_Colocator_prepare_colocation_args(monkeypatch):
     def dummy_mdata(*args):
-        d = GriddedData()
+        d = GriddedData(var_name="abs550aer")
         d.ts_type = "hourly"
+        d.units = "1"
         return d
 
     def dummy_odata(*args):
@@ -273,9 +274,7 @@ def test_Colocator_prepare_colocation_args(monkeypatch):
         fake_data = list(string.ascii_lowercase)
         for i, n in enumerate(fake_data):
             d.metadata[i] = dict(
-                data_id="testcase",
-                station_name=n,
-                station_type=n,
+                data_id="testcase", station_name=n, station_type=n, var_info={"units": "1"}
             )
         assert d.station_name == fake_data
         assert {"station_type" in dict for dict in d.metadata.values()} == {True}
@@ -296,8 +295,9 @@ def test_Colocator_prepare_colocation_args(monkeypatch):
 
 def test_Colocator_prepare_colocation_args_malformed_metadata(monkeypatch):
     def dummy_mdata(*args):
-        d = GriddedData()
+        d = GriddedData(var_name="abs550aer")
         d.ts_type = "hourly"
+        d.units = "1"
         return d
 
     def dummy_odata(*args):
@@ -308,15 +308,10 @@ def test_Colocator_prepare_colocation_args_malformed_metadata(monkeypatch):
         for i, n in enumerate(fake_data):
             if i > len(fake_data) / 2:
                 d.metadata[i] = dict(
-                    data_id="testcase",
-                    station_name=n,
-                    station_type=n,
+                    data_id="testcase", station_name=n, station_type=n, var_info={"units": "1"}
                 )
             else:
-                d.metadata[i] = dict(
-                    data_id="testcase",
-                    station_name=n,
-                )
+                d.metadata[i] = dict(data_id="testcase", station_name=n, var_info={"units": "1"})
 
         assert {"station_type" in dict for dict in d.metadata.values()} == {True, False}
         return d

--- a/tests/io/test_read_aasetal.py
+++ b/tests/io/test_read_aasetal.py
@@ -13,7 +13,6 @@ from numpy.testing import assert_almost_equal
 from pyaerocom import const
 from pyaerocom.io.read_aasetal import ReadAasEtal
 from pyaerocom.ungriddeddata import UngriddedData
-from pyaerocom.units.exceptions import UnitConversionError
 from pyaerocom.units.units_helpers import convert_unit
 from tests.conftest import lustre_unavail
 
@@ -106,7 +105,7 @@ def test_aasetal_data(aasetal_data: UngriddedData):
 
 
 @lustre_unavail
-@pytest.mark.xfail(raises=UnitConversionError)
+# @pytest.mark.xfail(raises=UnitConversionError)
 def test_aasetal_data_correct_units(aasetal_data: UngriddedData):
     tested = []
     stats = []
@@ -141,7 +140,7 @@ testdata = [
 
 @lustre_unavail
 @pytest.mark.parametrize("filenum,station_name,colname,var_name", testdata)
-@pytest.mark.xfail(raises=UnitConversionError)
+# @pytest.mark.xfail(raises=UnitConversionError)
 def test_reading_routines(
     aasetal_data: UngriddedData, data_paths: list[Path], filenum, station_name, colname, var_name
 ):

--- a/tests/io/test_read_aasetal.py
+++ b/tests/io/test_read_aasetal.py
@@ -11,9 +11,9 @@ import pytest
 from numpy.testing import assert_almost_equal
 
 from pyaerocom import const
-from pyaerocom.units import UnitConversionError
 from pyaerocom.io.read_aasetal import ReadAasEtal
 from pyaerocom.ungriddeddata import UngriddedData
+from pyaerocom.units.exceptions import UnitConversionError
 from pyaerocom.units.units_helpers import convert_unit
 from tests.conftest import lustre_unavail
 
@@ -76,7 +76,7 @@ def aasetal_data() -> UngriddedData:
 
 
 @lustre_unavail
-@pytest.mark.xfail(raises=UnitConversionError)
+# @pytest.mark.xfail(raises=UnitConversionError)
 def test_aasetal_data(aasetal_data: UngriddedData):
     data = aasetal_data
     assert len(data.station_name) == 890
@@ -152,9 +152,7 @@ def test_reading_routines(
     # values in original units
     vals = subset[colname].astype(float).values
     from_unit, to_unit = UNITCONVERSION[var_name]
-    should_be = convert_unit(
-        data=vals, from_unit=from_unit, to_unit=to_unit, var_name=var_name
-    ).mean()
+    should_be = convert_unit(vals, from_unit=from_unit, to_unit=to_unit, var_name=var_name).mean()
 
     actual = aasetal_data.to_station_data(station_name, var_name)[var_name].values.mean()
 

--- a/tests/io/test_read_aasetal.py
+++ b/tests/io/test_read_aasetal.py
@@ -75,7 +75,6 @@ def aasetal_data() -> UngriddedData:
 
 
 @lustre_unavail
-# @pytest.mark.xfail(raises=UnitConversionError)
 def test_aasetal_data(aasetal_data: UngriddedData):
     data = aasetal_data
     assert len(data.station_name) == 890
@@ -105,7 +104,6 @@ def test_aasetal_data(aasetal_data: UngriddedData):
 
 
 @lustre_unavail
-# @pytest.mark.xfail(raises=UnitConversionError)
 def test_aasetal_data_correct_units(aasetal_data: UngriddedData):
     tested = []
     stats = []
@@ -140,7 +138,6 @@ testdata = [
 
 @lustre_unavail
 @pytest.mark.parametrize("filenum,station_name,colname,var_name", testdata)
-# @pytest.mark.xfail(raises=UnitConversionError)
 def test_reading_routines(
     aasetal_data: UngriddedData, data_paths: list[Path], filenum, station_name, colname, var_name
 ):

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -15,10 +15,11 @@ from pyaerocom.units.units import UnitConversionCallbackInfo
 def test_PyaerocomUnit_custom_scaling(
     unit: str, aerocom_var: str | None, to_unit: str, exp_mul: float
 ):
-    u = Unit(unit, aerocom_var=aerocom_var)
+    u1 = Unit(unit, aerocom_var=aerocom_var)
+    u2 = Unit(to_unit, aerocom_var=aerocom_var)
 
-    assert u.convert(1, other=to_unit) == pytest.approx(exp_mul)
-    assert u.convert(1, other=to_unit, inplace=True) == pytest.approx(exp_mul)
+    assert u1.convert(1, other=u2) == pytest.approx(exp_mul)
+    assert u1.convert(1, other=u2, inplace=True) == pytest.approx(exp_mul)
 
 
 @pytest.mark.parametrize(
@@ -64,8 +65,11 @@ def test_origin():
         ("m", "km", True),
         ("m", "kg", False),
         (Unit("mg S"), Unit("mg"), False),
-        (Unit("mg S", species="SO4"), Unit("mg"), True),
-        (Unit("mg"), Unit("mg S", species="SO4"), True),
+        (Unit("mg S", species="SO4"), Unit("mg", species="SO4"), True),
+        (Unit("mg S", aerocom_var="concso2"), Unit("mg", aerocom_var="concso2"), True),
+        (Unit("mg", species="SO4"), Unit("mg S", species="SO4"), True),
+        (Unit("mg", aerocom_var="concso2"), Unit("mg S", aerocom_var="concso2"), True),
+        (Unit("mg S", species="SO2"), Unit("mg N", species="SO2"), False),
     ),
 )
 def test_is_convertible(from_unit: str | Unit, to_unit: str | Unit, is_convertible: bool):

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -54,21 +54,6 @@ def test_PyaerocomUnit_conversion_callback():
     assert callback_ran
 
 
-# def test__unit_conversion_fac_custom_FAIL(monkeypatch):
-#    MOCK_UCONV_MUL_FACS = pd.DataFrame(
-#        [
-#            ["concso4", "ug S/m3", "ug m-3", 1],
-#            ["concso4", "ug S/m3", "ug m-3", 2],
-#        ],
-#        columns=["var_name", "from", "to", "fac"],
-#    ).set_index(["var_name", "from"])
-#    monkeypatch.setattr("pyaerocom.units.units.Unit._UCONV_MUL_FACS", MOCK_UCONV_MUL_FACS)
-#
-#    with pytest.raises(UnitConversionError) as e:
-#        Unit("ug S/m3", aerocom_var="concso4")
-#    assert "Could not find unique conversion factor in table" in str(e.value)
-
-
 def test_origin():
     assert Unit("ug S/m3").origin == "ug S/m3"
 

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -108,3 +108,37 @@ def test_equality(
 )
 def test_custom_unit_conversion(unit: str, var: str, out_cf_unit: str):
     assert str(Unit(unit, aerocom_var=var)._cfunit) == out_cf_unit
+
+
+@pytest.mark.parametrize(
+    "unit,nominator,denominator",
+    (("mg", "mg", ""), ("mg N / m2 d", "mg N", "m2 d"), ("mg N m-2 d-1", "mg N", "m-2 d-1")),
+)
+def test_nominator_denominator(unit: str, nominator: str, denominator: str):
+    u = Unit(unit)
+    assert u._origin_nominator == nominator
+    assert u._origin_denominator == denominator
+
+
+@pytest.mark.parametrize(
+    "unit,element,species,var",
+    (
+        ("mg", None, None, None),
+        ("mg N", "N", None, None),
+        ("mg N", "N", "NH3", None),
+        ("mg N", "N", "NH3", "drynh3"),
+    ),
+)
+def test_species_and_element_detection(
+    unit: str, element: str | None, species: str | None, var: str | None
+):
+    if var is None:
+        u = Unit(unit, species=species, aerocom_var=var)
+    else:
+        u = Unit(unit, aerocom_var=var)
+    assert u._element == element
+    assert u._species == species
+
+
+def test_unit_conversion(from_unit: str, to_unit: str, species: str):
+    pass

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -1,8 +1,6 @@
 import pytest
-import pandas as pd
 
 from pyaerocom.units import Unit
-from pyaerocom.units.exceptions import UnitConversionError
 from pyaerocom.units.units import UnitConversionCallbackInfo
 
 
@@ -56,19 +54,19 @@ def test_PyaerocomUnit_conversion_callback():
     assert callback_ran
 
 
-def test__unit_conversion_fac_custom_FAIL(monkeypatch):
-    MOCK_UCONV_MUL_FACS = pd.DataFrame(
-        [
-            ["concso4", "ug S/m3", "ug m-3", 1],
-            ["concso4", "ug S/m3", "ug m-3", 2],
-        ],
-        columns=["var_name", "from", "to", "fac"],
-    ).set_index(["var_name", "from"])
-    monkeypatch.setattr("pyaerocom.units.units.Unit._UCONV_MUL_FACS", MOCK_UCONV_MUL_FACS)
-
-    with pytest.raises(UnitConversionError) as e:
-        Unit("ug S/m3", aerocom_var="concso4")
-    assert "Could not find unique conversion factor in table" in str(e.value)
+# def test__unit_conversion_fac_custom_FAIL(monkeypatch):
+#    MOCK_UCONV_MUL_FACS = pd.DataFrame(
+#        [
+#            ["concso4", "ug S/m3", "ug m-3", 1],
+#            ["concso4", "ug S/m3", "ug m-3", 2],
+#        ],
+#        columns=["var_name", "from", "to", "fac"],
+#    ).set_index(["var_name", "from"])
+#    monkeypatch.setattr("pyaerocom.units.units.Unit._UCONV_MUL_FACS", MOCK_UCONV_MUL_FACS)
+#
+#    with pytest.raises(UnitConversionError) as e:
+#        Unit("ug S/m3", aerocom_var="concso4")
+#    assert "Could not find unique conversion factor in table" in str(e.value)
 
 
 def test_origin():
@@ -76,10 +74,22 @@ def test_origin():
 
 
 @pytest.mark.parametrize(
-    "from_unit,to_unit,is_convertible", (("m", "km", True), ("m", "kg", False))
+    "from_unit,to_unit,is_convertible",
+    (
+        ("m", "km", True),
+        ("m", "kg", False),
+        (Unit("mg S"), Unit("mg"), False),
+        (Unit("mg S", species="SO4"), Unit("mg"), True),
+        (Unit("mg"), Unit("mg S", species="SO4"), True),
+    ),
 )
-def test_is_convertible(from_unit: str, to_unit: str, is_convertible: bool):
-    assert Unit(from_unit).is_convertible(to_unit) == is_convertible
+def test_is_convertible(from_unit: str | Unit, to_unit: str | Unit, is_convertible: bool):
+    if isinstance(from_unit, str):
+        from_unit = Unit(from_unit)
+    if isinstance(to_unit, str):
+        to_unit = Unit(to_unit)
+
+    assert from_unit.is_convertible(to_unit) == is_convertible
 
 
 def test_is_dimensionless():
@@ -104,13 +114,6 @@ def test_equality(
 
 
 @pytest.mark.parametrize(
-    "unit,var,out_cf_unit", (("kg N ha-1 yr-1", "drynh3", "383441123690.80505 kg m-2 s-1"),)
-)
-def test_custom_unit_conversion(unit: str, var: str, out_cf_unit: str):
-    assert str(Unit(unit, aerocom_var=var)._cfunit) == out_cf_unit
-
-
-@pytest.mark.parametrize(
     "unit,nominator,denominator",
     (("mg", "mg", ""), ("mg N / m2 d", "mg N", "m2 d"), ("mg N m-2 d-1", "mg N", "m-2 d-1")),
 )
@@ -121,24 +124,61 @@ def test_nominator_denominator(unit: str, nominator: str, denominator: str):
 
 
 @pytest.mark.parametrize(
-    "unit,element,species,var",
+    "unit,species,var,exp_element,exp_species",
     (
-        ("mg", None, None, None),
-        ("mg N", "N", None, None),
-        ("mg N", "N", "NH3", None),
-        ("mg N", "N", "NH3", "drynh3"),
+        ("mg", None, None, None, None),
+        ("mg N", None, None, None, None),
+        ("mg N", "NH3", None, "N", "NH3"),
+        ("mg N", None, "drynh3", "N", "NH3"),
     ),
 )
 def test_species_and_element_detection(
-    unit: str, element: str | None, species: str | None, var: str | None
+    unit: str,
+    species: str | None,
+    var: str | None,
+    exp_element: str | None,
+    exp_species: str | None,
 ):
-    if var is None:
-        u = Unit(unit, species=species, aerocom_var=var)
-    else:
-        u = Unit(unit, aerocom_var=var)
-    assert u._element == element
-    assert u._species == species
+    u = Unit(unit, species=species, aerocom_var=var)
+    assert u._element == exp_element
+    assert u._species == exp_species
 
 
-def test_unit_conversion(from_unit: str, to_unit: str, species: str):
-    pass
+@pytest.mark.parametrize(
+    "from_unit,to_unit,species,conversion_fac",
+    (
+        (
+            "kg N",
+            "kg",
+            "NH3",
+            17.03052 / 14.0067,  # Molecular mass ratio of NH3/N
+        ),
+        ("mg N", "kg", "NH3", (17.03052 / 14.0067) / 1_000_000),
+        ("mg N s-1", "kg s-1", "NH3", (17.03052 / 14.0067) / 1_000_000),
+        ("mg N s-1", "kg h-1", "NH3", 3_600 * (17.03052 / 14.0067) / (1_000_000)),
+    ),
+)
+def test_unit_conversion(from_unit: str, to_unit: str, species: str, conversion_fac: float):
+    u = Unit(from_unit, species=species)
+    fac = u.convert(1, to_unit, species=species)
+    assert fac == pytest.approx(conversion_fac)
+
+
+@pytest.mark.parametrize(
+    "from_unit,to_unit",
+    (
+        (  # No known reference species to do conversion.
+            Unit("kg S"),
+            Unit("kg"),
+        ),
+        (  # Element don't match
+            Unit(
+                "kg N",
+            ),
+            Unit("kg S"),
+        ),
+    ),
+)
+def test_unit_conversion_fails(from_unit: Unit, to_unit: Unit):
+    with pytest.raises(Exception):
+        from_unit.convert(1, to_unit)


### PR DESCRIPTION
## Change Summary

- Introduces a units config which allows the user to override units by variable.
- Data objects will always be converted to a standard unit everywhere. This unit is taken from the user config, or `variables.ini` if user config not provided.
  - Note: This breaks previous behaviour that data is converted to obs unit during colocation.
- Removes `harmonise_units` as an option in low level colocation api, and factors that functionality out into a new function in pyaerocom.units. Moves harmonisation to one place, in the (high-level) `Colocator` class.
- Handles mass ratio based unit conversion (eg. `mg N m-2` -> `mg m-2`) in a (I hope) more robust way than the previous lookup table approach, especially when it comes to unit aliases.

## Related issue number

- closes #1223

- closes #1411


## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review

If merged, we may want to follow up on https://github.com/metno/AeroToolsIssues/issues/62#issuecomment-2485260441