### PR TITLE
cams2_83 model forecasts against analysis observations set

### DIFF
--- a/pyaerocom/io/cams2_83/models.py
+++ b/pyaerocom/io/cams2_83/models.py
@@ -24,6 +24,24 @@ class ModelName(str, Enum):
     def __str__(self) -> str:
         return self.value
 
+    @property
+    def webname(self) -> str:
+        return dict(
+            ENSEMBLE="ENSEMBLE",
+            CHIMERE="CHIMERE",
+            DEHM="DEHM",
+            EMEP="EMEP",
+            EURAD="EURAD-IM",
+            GEMAQ="GEM-AQ",
+            LOTOS="LOTOS-EUROS",
+            MATCH="MATCH",
+            MINNI="MINNI",
+            MOCAGE="MOCAGE",
+            MONARCH="MONARCH",
+            SILAM="SILAM",
+            IFS="IFS",
+        )[self.name]
+
 
 class RunType(str, Enum):
     FC = "forecast"

--- a/pyaerocom/io/cams2_83/read_obs.py
+++ b/pyaerocom/io/cams2_83/read_obs.py
@@ -35,6 +35,7 @@ def obs_paths(
     *dates: datetime | date | str,
     root_path: Path | str = DATA_FOLDER_PATH,
     analysis: bool = False,
+    forceanaobsset: bool = False,
 ) -> Iterator[Path]:
     for date in dates:  # noqa: F402
         if isinstance(date, str):
@@ -43,7 +44,7 @@ def obs_paths(
             date = date.date()
         if isinstance(root_path, str):
             root_path = Path(root_path)
-        if analysis:
+        if analysis or forceanaobsset:
             filename = "%Y%m/obsmacc4verifana_%Y%m%d.csv"
         else:
             filename = "%Y%m/obsmacc4verif_%Y%m%d.csv"

--- a/pyaerocom/scripts/cams2_83/cli.py
+++ b/pyaerocom/scripts/cams2_83/cli.py
@@ -58,6 +58,7 @@ def make_config(
     add_seasons: bool,
     fairmode: bool,
     medianscores: bool,
+    forceanaobsset: bool,
 ) -> dict:
     logger.info("Making the configuration")
 
@@ -92,10 +93,10 @@ def make_config(
     else:
         obs_dates = date_range(start_date, end_date + timedelta(days=extra_obs_days))
     cfg["obs_cfg"]["EEA"]["read_opts_ungridded"]["files"] = [  # type:ignore[index]
-        str(p) for p in obs_paths(*obs_dates, root_path=obs_path, analysis=run_type == RunType.AN)
+        str(p) for p in obs_paths(*obs_dates, root_path=obs_path, analysis=run_type == RunType.AN, forceanaobsset=forceanaobsset)
     ]
 
-    if run_type == RunType.AN:
+    if (run_type == RunType.AN or forceanaobsset):
         cfg.update(forecast_days=1)
 
     cfg.update(exp_id=id, exp_name=name, exp_descr=description)
@@ -170,6 +171,7 @@ def main(
         "--medianscores",
         help="If true just the cams2_83-specific statistics are computed, a.k.a. the median scores plots or 'weird' plots, the cache is not cleared and it's assumed that the colocated data is already in place and the regular statistics have already been run",
     ),
+    forceanaobsset: bool = typer.Option(False, "--forceanaobsset", help="Meant to be used in combination with eval_type forecast: the observations set will be the one for the analysis, evaluation will be limited to just 1 forecast day. This is a hack to produce plots needed for the quarterly reports."),
     cache: Optional[Path] = typer.Option(
         None,
         help="Optional path to cache. If nothing is given, the default pyaerocom cache is used",
@@ -214,7 +216,8 @@ def main(
         add_map,
         add_seasons,
         fairmode,
-        medianscores
+        medianscores,
+        forceanaobsset,
     )
     
     # we do not want the cache produced in previous runs to be silently cleared

--- a/pyaerocom/scripts/cams2_83/cli.py
+++ b/pyaerocom/scripts/cams2_83/cli.py
@@ -15,7 +15,12 @@ from pyaerocom.io.cams2_83.read_obs import DATA_FOLDER_PATH as DEFAULT_OBS_PATH
 from pyaerocom.io.cams2_83.read_obs import obs_paths
 from pyaerocom.io.cams2_83.reader import DATA_FOLDER_PATH as DEFAULT_MODEL_PATH
 from pyaerocom.scripts.cams2_83.config import CFG
-from pyaerocom.scripts.cams2_83.evaluation import EvalType, date_range, runner, runnermedianscores
+from pyaerocom.scripts.cams2_83.evaluation import (
+    EvalType,
+    date_range,
+    runner,
+    runnermedianscores,
+)
 
 app = typer.Typer(add_completion=False, no_args_is_help=True)
 logger = logging.getLogger(__name__)
@@ -68,7 +73,7 @@ def make_config(
     cfg = deepcopy(CFG)
     cfg.update(
         model_cfg={
-            f"{model.name}": make_model_entry(
+            f"{model.webname}": make_model_entry(
                 start_date,
                 end_date,
                 leap,
@@ -89,7 +94,9 @@ def make_config(
 
     extra_obs_days = 4 if eval_type in {"season", "long"} else 0
     if run_type != RunType.AN and medianscores:
-        obs_dates = date_range(start_date - timedelta(days=1), end_date + timedelta(days=extra_obs_days))
+        obs_dates = date_range(
+            start_date - timedelta(days=1), end_date + timedelta(days=extra_obs_days)
+        )
     else:
         obs_dates = date_range(start_date, end_date + timedelta(days=extra_obs_days))
     cfg["obs_cfg"]["EEA"]["read_opts_ungridded"]["files"] = [  # type:ignore[index]
@@ -108,7 +115,7 @@ def make_config(
         cfg.update(add_model_maps=True, only_model_maps=True)
 
     if add_seasons:
-        cfg.update(add_seasons=True)    
+        cfg.update(add_seasons=True)
 
     if fairmode:
         if eval_type in ["season", "long"]:
@@ -129,7 +136,9 @@ def main(
     end_date: datetime = typer.Argument(
         ..., formats=["%Y-%m-%d", "%Y%m%d"], help="evaluation end date"
     ),
-    leap: int = typer.Argument(0, min=RunType.AN.days, max=RunType.FC.days, help="forecast day"),
+    leap: int = typer.Argument(
+        0, min=RunType.AN.days, max=RunType.FC.days, help="forecast day"
+    ),
     model_path: Path = typer.Option(
         DEFAULT_MODEL_PATH, exists=True, readable=True, help="path to model data"
     ),
@@ -219,7 +228,7 @@ def main(
         medianscores,
         forceanaobsset,
     )
-    
+
     # we do not want the cache produced in previous runs to be silently cleared
     const.RM_CACHE_OUTDATED = False
 
@@ -237,7 +246,9 @@ def main(
             )
         else:
             logger.info("Special run for median scores only")
-            runnermedianscores(cfg, cache, analysis=analysis, dry_run=dry_run, pool=pool)
+            runnermedianscores(
+                cfg, cache, analysis=analysis, dry_run=dry_run, pool=pool
+            )
     else:
         logger.info("Standard run")
         runner(cfg, cache, dry_run=dry_run, pool=pool)

--- a/pyaerocom/scripts/cams2_83/engine.py
+++ b/pyaerocom/scripts/cams2_83/engine.py
@@ -121,7 +121,7 @@ class CAMS2_83_Engine(ProcessingEngine):
         if modelname == "ENS" or modelname == "MOS":  # MOS/ENS evaluation special case
             mcfg = self.cfg.model_cfg.get_entry(modelname)
         else:
-            mcfg = self.cfg.model_cfg.get_entry(model.name)
+            mcfg = self.cfg.model_cfg.get_entry(model.webname)
         var_name_web = mcfg.get_varname_web(model_var, obs_var)
         seasons = self.cfg.time_cfg.get_seasons()
 
@@ -204,7 +204,7 @@ class CAMS2_83_Engine(ProcessingEngine):
                             fairmode_subset = fairmode_subset.resample_time(
                                 SPECIES[var_name]["freq"],
                                 settings_from_meta=True,
-                                min_num_obs=min_num_obs
+                                min_num_obs=min_num_obs,
                             )
 
                         results_fairmode[f"{regname}"][f"{perstr}"] = (
@@ -214,20 +214,17 @@ class CAMS2_83_Engine(ProcessingEngine):
                         )
 
                         if calc_forecast_target:
-                            
+
                             results_mqi = []
                             for day in range(forecast_days):
                                 ds = subset[day]
                                 ds_p = persistence_subset_region
 
-                                
                                 mqi_results = self._calc_forecast_target_MQI_vectorized(
                                     ds, ds_p, var_name, day, min_num_obs
                                 )
 
                                 results_mqi.append(mqi_results)
-
-                               
 
                             for station in results_fairmode[f"{regname}"][f"{perstr}"]:
                                 results_fairmode[f"{regname}"][f"{perstr}"][station][
@@ -275,7 +272,7 @@ class CAMS2_83_Engine(ProcessingEngine):
                     (
                         modelname
                         if (modelname == "ENS" or modelname == "MOS")
-                        else model.name
+                        else model.webname
                     ),  # MOS/ENS evaluation special case
                     model_var,
                 )
@@ -290,7 +287,7 @@ class CAMS2_83_Engine(ProcessingEngine):
                 (
                     modelname
                     if (modelname == "ENS" or modelname == "MOS")
-                    else model.name
+                    else model.webname
                 ),  # MOS/ENS evaluation special case
                 model_var,
             )
@@ -365,7 +362,7 @@ class CAMS2_83_Engine(ProcessingEngine):
             coldata = coldata.resample_time(
                 SPECIES[var_name]["freq"],
                 settings_from_meta=True,
-                min_num_obs=min_num_obs
+                min_num_obs=min_num_obs,
             )
 
         # Creation of mask of shared stations between normal data and persistence data
@@ -448,9 +445,7 @@ class CAMS2_83_Engine(ProcessingEngine):
             axis=1,
             where=mask,
         )
-        sign = np.where(
-            false_alarms <= missed_alarms, -1.0, 1.0
-        )  
+        sign = np.where(false_alarms <= missed_alarms, -1.0, 1.0)
         return sign
 
     def _sort_coldata(

--- a/tests/cams2_83/test_cams2_83_cli.py
+++ b/tests/cams2_83/test_cams2_83_cli.py
@@ -139,6 +139,7 @@ def test_make_config(
         add_seasons=True,
         fairmode=True,
         medianscores=True,
+        forceanaobsset=False,
     )
     assert cfg["periods"] == ["20250301-20250308"]
     assert cfg["add_model_maps"]


### PR DESCRIPTION
## Change Summary

add option to run a forecast experiment with the set of observations usually used for the analysis
this is by request due to quarterly reporting 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Start with a draft-PR
* [ ] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
