### PR TITLE
fix: disambiguation of ebas column

### DIFF
--- a/pyaerocom/units/logging/callbacks.py
+++ b/pyaerocom/units/logging/callbacks.py
@@ -28,7 +28,7 @@ class LoggingCallback:
 
         self._logger.log(
             level,
-            "Successfully converted unit of variable '%s' from '%s' to '%s' using conversion factor '%.2f'.",
+            "Successfully converted unit of variable '%s' from '%s' to '%s' using conversion factor '%.6g'.",
             info.from_aerocom_var,
             info.from_cf_unit,
             info.to_cf_unit,

--- a/pyaerocom/units/units.py
+++ b/pyaerocom/units/units.py
@@ -221,7 +221,7 @@ class Unit:
         same_species = (self._species is not None and other._species is not None) and (
             self._species == other._species
         )
-        same_variable = (self._aerocom_var is not None and other._aerocom_var is not None) and (
+        same_variable = (self._aerocom_var is None and other._aerocom_var is None) or (
             self._aerocom_var == other._aerocom_var
         )
 
@@ -231,7 +231,10 @@ class Unit:
         if not compatible_element:
             return False
 
-        if same_species or same_variable:
+        if same_species and same_variable:
+            return self._cfunit.is_convertible(other._cfunit)
+
+        if (self._element == other._element) and same_variable:
             return self._cfunit.is_convertible(other._cfunit)
 
         return False

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -154,6 +154,16 @@ def test_unit_conversion(from_unit: str, to_unit: str, species: str, conversion_
 
 
 @pytest.mark.parametrize(
+    "from_unit,to_unit,aerocom_var,conversion_fac",
+    (("g N", "mg N", "blah", 1000), ("mg S l-1", "kg S m-3", "blah", 10**-3)),
+)
+def test_unit_conversion2(from_unit: str, to_unit: str, aerocom_var: str, conversion_fac: float):
+    u = Unit(from_unit, aerocom_var=aerocom_var)
+    fac = u.convert(1, to_unit, aerocom_var=aerocom_var)
+    assert fac == pytest.approx(conversion_fac)
+
+
+@pytest.mark.parametrize(
     "from_unit,to_unit",
     (
         (  # No known reference species to do conversion.


### PR DESCRIPTION
## Change Summary

The new unit conversion code is able to convert more units, so more columns will be kept [here](https://github.com/metno/pyaerocom/blob/211920ddb4bdaed6b95b4c8e15cdf580024ed0f5/pyaerocom/io/read_ebas.py#L848). This causes an exception further down, when multiple columns are available.

This PR seems to resolve that by fixing some unit convertability issue in units.

I've ran emep evaluation in different Pyaerocom versions to see that the output is the same for the variables, and have not been able to see any discrepancies:

- [v0.25.0 - December 2024](https://aeroval-test.met.no/thlun/pages/evaluation/?project=units-regression-test&experiment=old-20250616T135653)
- [v0.30.1 - May 2025](https://aeroval-test.met.no/thlun/pages/evaluation/?project=units-regression-test&experiment=before-20250616T113727)
- [This PR](https://aeroval-test.met.no/thlun/pages/evaluation/?project=units-regression-test&experiment=after-20250616T124602)

It is not entirely clear to me why this fixes it, and the most recent status evaluation ran using the June release module  fine for these variables without these changes so may be an intermittent issue?

## Related issue number

closes #1649 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
