### PR TITLE
Mitigate test warnings

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,6 @@
 # Root level conftest to ignore scripts folder in doctests.
-def pytest_ignore_collect(path):
-    if "scripts/" in str(path):
+def pytest_ignore_collect(collection_path):
+    if "scripts/" in str(collection_path):
         return True
-    if "docs/" in str(path):
+    if "docs/" in str(collection_path):
         return True

--- a/pyaerocom/_lowlevel_helpers.py
+++ b/pyaerocom/_lowlevel_helpers.py
@@ -531,6 +531,7 @@ def list_to_shortstr(lst, indent=0):
                     RuntimeWarning,
                     "divide by zero encountered in log10",
                     "overflow encountered in scalar multiply",
+                    "invalid value encountered in cast",
                 ):
                     ndigits = -1 * np.floor(np.log10(abs(np.asarray(val)))).astype(int) + 2
                 lout.append(f"{val:.{ndigits}f}")

--- a/pyaerocom/io/icpforests/reader.py
+++ b/pyaerocom/io/icpforests/reader.py
@@ -420,17 +420,15 @@ class ReadICPForest(ReadUngriddedBase):
 
         for year in range(self.MIN_YEAR, self.MAX_YEAR):
             yr_flags = flags_array[np.where(years == year)]
-            # yr_flags can have 0 length
-            try:
+
+            if len(yr_flags) == 0:
+                logger.warning(f"No data for species {species} in year {year}.")
+            else:
                 quality = np.sum(np.where(yr_flags == 0)) / len(yr_flags)
                 if quality < self.QUALITY_LIMIT:
                     logger.warning(
                         f"Quality of {quality} found for {species} in year {year}. Setting data this year to NaN"
                     )
                     data_array[np.where(years == year)] = np.nan
-
-            except RuntimeWarning:
-                # yr_flags has 0 length
-                logger.warning(f"No data for species {species} in year {year}.")
 
         return list(data_array)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,8 +120,6 @@ filterwarnings = [
     'ignore::PendingDeprecationWarning:^(?!pyaerocom|tests).*:',
     'ignore::DeprecationWarning:^(?!pyaerocom|tests).*:',
     'ignore::FutureWarning:^(?!pyaerocom|tests).*:',
-    # Ignore self-deprecation warnings related to plotting
-    'ignore:matplotlib based plotting is no longer directly supported. This (function|class) may be removed in future versions\.:DeprecationWarning:(pyaerocom|tests):',
     # and not on this list
     "ignore:Using DEFAULT_SPHERICAL_EARTH_RADIUS:UserWarning:iris.*:", # Issue #1394
 ]


### PR DESCRIPTION
## Change Summary

- /home/thlun8736/.pyenv/versions/3.13.2/envs/venv/lib/python3.13/site-packages/pyaerocom/_lowlevel_helpers.py:535: RuntimeWarning: invalid value encountered in cast
- Changes some division by zero check to check explicitly instead of except'ing a runtime warning.
- Removes suppression of matplotlib plotting (which has been removed) deprecation warning.



## Related issue number

#1066

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
