### PR TITLE
process colocated files for conco3mda8 in a cams2_83 mos experiment

### DIFF
--- a/pyaerocom/aeroval/experiment_processor.py
+++ b/pyaerocom/aeroval/experiment_processor.py
@@ -4,11 +4,11 @@ import glob
 import logging
 
 from pyaerocom.aeroval._processing_base import HasColocator, ProcessingEngine
+from pyaerocom.aeroval.bulkfraction_engine import BulkFractionEngine
 from pyaerocom.aeroval.coldatatojson_engine import ColdataToJsonEngine
 from pyaerocom.aeroval.helpers import delete_dummy_model, make_dummy_model
 from pyaerocom.aeroval.modelmaps_engine import ModelMapsEngine
 from pyaerocom.aeroval.superobs_engine import SuperObsEngine
-from pyaerocom.aeroval.bulkfraction_engine import BulkFractionEngine
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +87,7 @@ class ExperimentProcessor(ProcessingEngine, HasColocator):
             col = self.get_colocator(model_name, obs_name)
             if self.cfg.processing_opts.only_json:
                 files_to_convert = col.get_available_coldata_files(var_list)
+                logger.info(f"Found files to process: {files_to_convert}")
             else:
                 col.run(var_list)
                 files_to_convert = col.files_written

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -466,6 +466,8 @@ class Colocator:
                             break
                 if ok:
                     valid.append(file)
+            elif candidate and meta["obs_var"] == "conco3mda8":
+                valid.append(file)
 
         return valid
 

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -466,8 +466,6 @@ class Colocator:
                             break
                 if ok:
                     valid.append(file)
-            elif candidate and meta["obs_var"] == "conco3mda8":
-                valid.append(file)
 
         return valid
 

--- a/pyaerocom/scripts/cams2_83/cli_mos.py
+++ b/pyaerocom/scripts/cams2_83/cli_mos.py
@@ -59,7 +59,7 @@ def make_config_mos(
     cfg.update(only_json=True)
 
     #this is an only_json=True experiment so conco3mda8 needs to be added to the variables list in order for the conco3mda8 colocated data files to be read by Colocator.get_available_coldata_files to 
-    cfg.update(species_list=["concno2","concco","conco3","conco3mda8","concso2","concpm10","concpm25",])
+    cfg["obs_cfg"]["EEA"]["obs_vars"]=["concno2","concco","conco3","conco3mda8","concso2","concpm10","concpm25",]
 
     cfg.update(exp_id=id, exp_name=name, exp_descr=description)
 

--- a/pyaerocom/scripts/cams2_83/cli_mos.py
+++ b/pyaerocom/scripts/cams2_83/cli_mos.py
@@ -58,6 +58,9 @@ def make_config_mos(
 
     cfg.update(only_json=True)
 
+    #this is an only_json=True experiment so conco3mda8 needs to be added to the variables list in order for the conco3mda8 colocated data files to be read by Colocator.get_available_coldata_files to 
+    cfg.update(species_list = ["concno2","concco","conco3","conco3mda8","concso2","concpm10","concpm25",])
+
     cfg.update(exp_id=id, exp_name=name, exp_descr=description)
 
     cfg.update(use_cams2_83_fairmode=True)

--- a/pyaerocom/scripts/cams2_83/cli_mos.py
+++ b/pyaerocom/scripts/cams2_83/cli_mos.py
@@ -59,7 +59,7 @@ def make_config_mos(
     cfg.update(only_json=True)
 
     #this is an only_json=True experiment so conco3mda8 needs to be added to the variables list in order for the conco3mda8 colocated data files to be read by Colocator.get_available_coldata_files to 
-    cfg.update(species_list = ["concno2","concco","conco3","conco3mda8","concso2","concpm10","concpm25",])
+    cfg.update(species_list=["concno2","concco","conco3","conco3mda8","concso2","concpm10","concpm25",])
 
     cfg.update(exp_id=id, exp_name=name, exp_descr=description)
 

--- a/pyaerocom/scripts/cams2_83/engine.py
+++ b/pyaerocom/scripts/cams2_83/engine.py
@@ -95,7 +95,7 @@ class CAMS2_83_Engine(ProcessingEngine):
             persistence_coldata = persistence_coldata[0]
             calc_forecast_target = True
 
-            if SPECIES[var_name]["freq"] != TsType("hourly"):
+            if var_name!="conco3mda8" and SPECIES[var_name]["freq"] != TsType("hourly"):
                 persistence_coldata = persistence_coldata.resample_time(
                     SPECIES[var_name]["freq"],
                     settings_from_meta=True,

--- a/pyaerocom/scripts/cams2_83/engine.py
+++ b/pyaerocom/scripts/cams2_83/engine.py
@@ -95,7 +95,7 @@ class CAMS2_83_Engine(ProcessingEngine):
             persistence_coldata = persistence_coldata[0]
             calc_forecast_target = True
 
-            if var_name!="conco3mda8" and SPECIES[var_name]["freq"] != TsType("hourly"):
+            if SPECIES[var_name]["freq"] != TsType("hourly"):
                 persistence_coldata = persistence_coldata.resample_time(
                     SPECIES[var_name]["freq"],
                     settings_from_meta=True,

--- a/pyaerocom/scripts/cams2_83/engine.py
+++ b/pyaerocom/scripts/cams2_83/engine.py
@@ -38,7 +38,7 @@ class CAMS2_83_Engine(ProcessingEngine):
     def run(
         self, files: list[list[str | Path]], var_list: list
     ) -> None:  # type:ignore[override]
-        logger.info(f"Processing: {repr(files)}")
+        logger.info(f"Processing: {files}")
         coldata = [ColocatedData(data=file) for file in files]
         coldata, persistence_cols, found_vars, found_persistence = self._sort_coldata(
             coldata

--- a/pyaerocom/scripts/cams2_83/engine.py
+++ b/pyaerocom/scripts/cams2_83/engine.py
@@ -52,7 +52,7 @@ class CAMS2_83_Engine(ProcessingEngine):
                     f"No variables found in colocated data var_list={var_list}, found_vars={found_vars}"
                 )
                 return
-        elif var_list == ["conco3"] or (len(var_list) > 1 and "conco3" in var_list):
+        elif var_list == ["conco3"] or (len(var_list) > 1 and "conco3" in var_list and "conco3mda8" not in var_list):
             var_list_2 = list(var_list)
             var_list_2.append("conco3mda8")
         else:

--- a/pyaerocom/scripts/cams2_83/evaluation.py
+++ b/pyaerocom/scripts/cams2_83/evaluation.py
@@ -200,7 +200,7 @@ def runnermedianscores(
     stp = EvalSetup(**cfg)
 
     logger.info(
-        "Running CAMS2_83 Specific Statistics, cache is not cleared, colocated data is assumed in place, regular statistics are assumed to have been run"
+        "Running CAMS2_83 Specific Statistics, cache is not cleared, regular statistics are assumed to have been run"
     )
     if pool > 1:
         logger.info(f"Making median scores plot with pool {pool} and analysis {analysis}")


### PR DESCRIPTION
fix necessary to make it so that pre-created colocated files for conco3mda8 (relevant for the MOS experiments which have only_json=True) are processed at all

## Related issue number

#1655
#1658

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
