### PR TITLE
Small units bug

### DIFF
--- a/pyaerocom/io/read_ebas.py
+++ b/pyaerocom/io/read_ebas.py
@@ -851,6 +851,8 @@ class ReadEbas(ReadUngriddedBase):
                     continue
             if len(_cols) > 0:
                 result_col = _cols
+        if len(result_col) > 1:
+            result_col = [result_col[0]]
         return result_col
 
     def _resolve_meas_height_cols(self, result_col, file):

--- a/pyaerocom/units/datetime/time_config.py
+++ b/pyaerocom/units/datetime/time_config.py
@@ -81,6 +81,7 @@ TS_TYPE_TO_NUMPY_FREQ = {
 
 # conversion of ts_types to strings that cf_units understands
 TS_TYPE_TO_SI = {
+    "secondly": "s",
     "minutely": "min",
     "hourly": "h",
     "daily": "d",

--- a/pyaerocom/units/molecular_mass.py
+++ b/pyaerocom/units/molecular_mass.py
@@ -43,6 +43,8 @@ _MOLMASSES = {
     "glyox": 58.036,
 }
 
+_SPECIES_OVERRIDE = {"concso4c": "SO4"}
+
 
 class UnknownSpeciesError(ValueError):
     pass
@@ -70,6 +72,9 @@ def _get_species(aerocom_var: str) -> str:
     """
     if aerocom_var in _MOLMASSES:
         return aerocom_var
+
+    if aerocom_var in _SPECIES_OVERRIDE:
+        return _SPECIES_OVERRIDE.get(aerocom_var)
     species = None
     for prefix in _VAR_PREFIXES:
         if aerocom_var.startswith(prefix):

--- a/pyaerocom/units/units.py
+++ b/pyaerocom/units/units.py
@@ -124,12 +124,17 @@ class Unit:
                     self._element = e
                     break
 
-        if self._element is not None and self._species is not None:
+        if self._species is not None:
             try:
-                factor = MolecularMass(self._species) / MolecularMass(self._element)
+                MolecularMass(self._species)
             except ValueError:
                 self._species = None
-                factor = 1
+        if self._element is not None and self._species is not None:
+            # try:
+            factor = MolecularMass(self._species) / MolecularMass(self._element)
+            # except ValueError:
+            #    self._species = None
+            #    factor = 1
         else:
             factor = 1
 

--- a/pyaerocom/units/units.py
+++ b/pyaerocom/units/units.py
@@ -130,11 +130,8 @@ class Unit:
             except ValueError:
                 self._species = None
         if self._element is not None and self._species is not None:
-            # try:
             factor = MolecularMass(self._species) / MolecularMass(self._element)
-            # except ValueError:
-            #    self._species = None
-            #    factor = 1
+
         else:
             factor = 1
 

--- a/tests/io/test_read_ebas.py
+++ b/tests/io/test_read_ebas.py
@@ -618,13 +618,6 @@ def test_read_file(reader: ReadEbas, ebas_issue_files: Path, vars_to_retrieve: s
     "issue_files,vars_to_retrieve,exception,error",
     [
         pytest.param(
-            "pm10_colsel",
-            "concpm10",
-            ValueError,
-            "failed to identify unique data column",
-            id="repeated column",
-        ),
-        pytest.param(
             "o3_neg_dt",
             "conco3",
             TemporalResolutionError,

--- a/tests/units/test_units.py
+++ b/tests/units/test_units.py
@@ -181,3 +181,10 @@ def test_unit_conversion2(from_unit: str, to_unit: str, aerocom_var: str, conver
 def test_unit_conversion_fails(from_unit: Unit, to_unit: Unit):
     with pytest.raises(Exception):
         from_unit.convert(1, to_unit)
+
+
+def test_units_species_concso4c():
+    u = Unit("mg S / m3", aerocom_var="concso4c")
+
+    assert u._species == "SO4"
+    assert u.convert(1, Unit("mg m-3", aerocom_var="concso4c")) == pytest.approx(2.99, abs=0.01)


### PR DESCRIPTION
## Change Summary

AFAICT this fixes the issues with deposition vars (eg. `drynh3`) in the EMEP evaluation, ~~though I'm still waiting for a confirmation run to see if it also fixes `concso4c`~~.

This changes behavior in the EBAS reader to pick a column arbitrarily when multiple columns have compatible units. I haven't found a case where such a case is not simply two columns that represent the same data in different units (eg. `mg S m-2` vs `mg m-2`).

It removes a test that no longer causes a unique column failure due to the above change.

## Related issue number

NA

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
