### PR TITLE
add comment about use_meteorological_seasons in the docs

### DIFF
--- a/docs/_static/aeroval/cfg_examples_example1.py
+++ b/docs/_static/aeroval/cfg_examples_example1.py
@@ -157,7 +157,8 @@ GLOB_CFG = dict(
     # (if available) and Jan/Feb of the same year, while if use_meteorological_seasons=False,
     # it will refer to data from Jan/Feb and December of the same year. (The ['all'] (whole year) key
     # for the year in question will not be affected, so it will refer to data from January 1st to
-    # December 31st.
+    # December 31st. This applies at the moment only to the statistics that make use of
+    # `_select_period_season_coldata`,so not diurnal statistics.
     use_meteorological_seasons=False,
     # Whether or not to add trends output to the analysis. Trends analysis
     # needs at least 7 years of data, so this is skipped here for this


### PR DESCRIPTION
`use_meteorological_seasons` plays a role only in the computations that make use of `_select_period_season_coldata`  

since the diurnal statistics are computed in a completely different/separate way, and they never make use of  this function, this means that at the moment `use_meteorological_seasons` has no effect on those.  
Unclear if this should be changed or not, but at least a note in the docs about this is desirable at this stage.


## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
