### PR TITLE
More informative units exceptions + harmonization is based on data var_name (relevant when use_model_vars is used)

### DIFF
--- a/pyaerocom/colocation/colocation_setup.py
+++ b/pyaerocom/colocation/colocation_setup.py
@@ -411,11 +411,11 @@ class ColocationSetup(BaseModel):
     model_name: str | None = None
     model_data_dir: Path | str | None = None
 
-    model_read_opts: dict | None = {}
+    model_read_opts: dict = {}
 
-    model_use_vars: dict[str, str] | None = {}
+    model_use_vars: dict[str, str] = {}
     model_rename_vars: dict[str, str] | None = {}
-    model_add_vars: dict[str, tuple[str, ...]] | None = {}
+    model_add_vars: dict[str, tuple[str, ...]] = {}
     model_to_stp: bool = False
 
     model_ts_type_read: str | dict | None = None

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -91,6 +91,7 @@ class Colocator:
         self._obs_reader: Any | None = None
         self._obs_is_vertical_profile: bool = False
         self.obs_filters: dict = colocation_setup.obs_filters.copy()
+        self._original_obs_var_names: dict[str, str] = {}
 
     @property
     def model_vars(self):
@@ -713,6 +714,9 @@ class Colocator:
         for ovar in self.colocation_setup.obs_vars:
             mvar = muv.get(ovar, ovar)
 
+            # Keep track of original var name, such that it can be used in units harmonization.
+            self._original_obs_var_names[mvar] = ovar
+
             self._check_add_model_read_aux(mvar)
             if modreader.has_var(mvar):
                 var_matches[mvar] = ovar
@@ -1002,7 +1006,11 @@ class Colocator:
 
         if self.colocation_setup.harmonise_units:
             model_data, obs_data = harmonise_units(
-                model_data, obs_data, var=model_var, var_ref=obs_var, inplace=True
+                model_data,
+                obs_data,
+                var=model_var,
+                var_ref=self._original_obs_var_names.get(obs_var, obs_var),
+                inplace=True,
             )
 
         if getattr(obs_data, "is_vertical_profile", None):

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -81,10 +81,10 @@ class Colocator:
 
         self.colocation_setup = colocation_setup
         self.logging: bool = True
-        self._loaded_model_data: dict | None = {}
+        self._loaded_model_data: dict[str, GriddedData] = {}
         self.data: dict = {}
 
-        self._processing_status: list[str] = []
+        self._processing_status: list[tuple[str | None, str | None, int]] = []
         self.files_written: list[str] = []
 
         self._model_reader: ReadGridded | ReadMscwCtm | ReadCAMS2_83 | None = None
@@ -299,7 +299,7 @@ class Colocator:
             raise AttributeError("stop time is not set")
         return to_datestring_YYYYMMDD(to_pandas_timestamp(self.stop))
 
-    def prepare_run(self, var_list: list[str] | None = None) -> dict:
+    def prepare_run(self, var_list: list[str] | None = None) -> dict[str, str]:
         """
         Prepare colocation run for current setup.
 
@@ -403,11 +403,11 @@ class Colocator:
                         )
                         data_out[f"{mod_var}mda8"][f"{obs_var}mda8"] = mda8
 
-                self._processing_status.append([mod_var, obs_var, 1])
+                self._processing_status.append((mod_var, obs_var, 1))
             except Exception:
                 msg = f"Failed to perform analysis: {traceback.format_exc()} ❌ \n"
                 logger.warning(msg)
-                self._processing_status.append([mod_var, obs_var, 5])
+                self._processing_status.append((mod_var, obs_var, 5))
                 if self.colocation_setup.raise_exceptions:
                     self._print_processing_status()
                     logger.critical("ABORTED: raise_exceptions is True 🛑 \n")
@@ -471,7 +471,9 @@ class Colocator:
 
         return valid
 
-    def _filter_var_matches_varlist(self, vars_to_process, var_list) -> dict:
+    def _filter_var_matches_varlist(
+        self, vars_to_process: dict[str, str], var_list: list[str]
+    ) -> dict[str, str]:
         _vars_to_process = {}
         if isinstance(var_list, str):
             var_list = [var_list]
@@ -531,7 +533,9 @@ class Colocator:
                 if ovar not in self.colocation_setup.obs_filters:
                     self.obs_filters[ovar] = {}
 
-    def _check_load_model_data(self, var_matches):
+    def _check_load_model_data(
+        self, var_matches: dict[str, str]
+    ) -> tuple[dict[str, str], dict[str, str]]:
         """
         Try to preload modeldata for input variable matches
 
@@ -570,7 +574,7 @@ class Colocator:
             except Exception as e:
                 msg = f"Failed to load model data: {self.colocation_setup.model_id} ({mvar}). Reason {e}  ❌"
                 logger.warning(msg)
-                self._processing_status.append([mvar, ovar, 4])
+                self._processing_status.append((mvar, ovar, 4))
                 if self.colocation_setup.raise_exceptions:
                     raise ColocationError(msg)
         return filtered, ts_types
@@ -670,7 +674,7 @@ class Colocator:
                     logger.warning(
                         f"Obs variable {ovar} is not available in {self.colocation_setup.obs_id} and will be ignored 🚫"
                     )
-                    self._processing_status.append([None, ovar, 3])
+                    self._processing_status.append((None, ovar, 3))
 
             if self.colocation_setup.raise_exceptions:
                 invalid = [var for var in self.colocation_setup.obs_vars if var not in avail]
@@ -707,15 +711,13 @@ class Colocator:
         muv = self.colocation_setup.model_use_vars
         modreader = self.model_reader
         for ovar in self.colocation_setup.obs_vars:
-            if ovar in muv:
-                mvar = muv[ovar]
-            else:
-                mvar = ovar
+            mvar = muv.get(ovar, ovar)
+
             self._check_add_model_read_aux(mvar)
             if modreader.has_var(mvar):
                 var_matches[mvar] = ovar
             else:
-                self._processing_status.append([mvar, ovar, 2])
+                self._processing_status.append((mvar, ovar, 2))
                 all_ok = False
 
             if ovar in self.colocation_setup.model_add_vars:  # observation variable
@@ -725,7 +727,7 @@ class Colocator:
                     if modreader.has_var(addvar):
                         var_matches[addvar] = ovar
                     else:
-                        self._processing_status.append([addvar, ovar, 2])
+                        self._processing_status.append((addvar, ovar, 2))
                         all_ok = False
 
         if not all_ok and self.colocation_setup.raise_exceptions:
@@ -762,7 +764,7 @@ class Colocator:
             if tst == "":
                 tst = self.colocation_setup.ts_type
         elif not is_model and self.colocation_setup.obs_ts_type_read is not None:
-            tst = self.obs_ts_type_read
+            tst = self.colocation_setup.obs_ts_type_read
         if isinstance(tst, dict):
             if var_name in tst:
                 tst = tst[var_name]

--- a/pyaerocom/units/units.py
+++ b/pyaerocom/units/units.py
@@ -231,11 +231,13 @@ class Unit:
 
         if cf_units_only:
             if not self._cfunit.is_convertible(other._cfunit):
-                raise ValueError(f"Unit '{self._cfunit}' is not convertible to '{other._cfunit}'.")
+                raise ValueError(
+                    f"cfunit '{self._cfunit}' is not convertible to cfunit '{other._cfunit}'."
+                )
 
         if not compatible_element:
             raise ValueError(
-                f"Unit '{self}' is not convertible to '{other}'. Element '{self._element}' is not compatible with '{other._element}'."
+                f"Element '{self._element}' is not compatible with '{other._element}'."
             )
 
         if same_species and same_variable:
@@ -246,7 +248,9 @@ class Unit:
 
         if (self._element == other._element) and same_variable:
             if not self._cfunit.is_convertible(other._cfunit):
-                raise ValueError(f"Unit '{self._cfunit}' is not convertible to '{other._cfunit}'.")
+                raise ValueError(
+                    f"cfunit '{self._cfunit}' is not convertible to cfunit '{other._cfunit}'."
+                )
 
     def is_convertible(self, other: str | Unit) -> bool:
         """
@@ -370,10 +374,8 @@ class Unit:
             assert isinstance(other, Unit)
             to_unit = other
 
-        if not self.is_convertible(to_unit):
-            raise ValueError(
-                f"Unable to convert units. Got incompatible units '{repr(self)}' and '{repr(to_unit)}'."
-            )
+        self._validate_convertible(other)
+
         to_unit_cf = to_unit._cfunit
         factor = float(self._cfunit.convert(1, to_unit_cf, inplace=False))
 

--- a/pyaerocom/units/units.py
+++ b/pyaerocom/units/units.py
@@ -129,7 +129,7 @@ class Unit:
                 MolecularMass(self._species)
             except ValueError:
                 self._species = None
-        if self.has_element_mass and self._species is not None:
+        if self._element is not None and self._species is not None:
             factor = MolecularMass(self._species) / MolecularMass(self._element)
 
         else:
@@ -199,6 +199,42 @@ class Unit:
 
         return ""
 
+    def _validate_convertible(self, other: str | Unit) -> None:
+        if isinstance(other, str):
+            other = Unit(other)
+
+        cf_units_only = self._element is None and other._element is None
+        compatible_element = (
+            (self._element is None)
+            or (other._element is None)
+            or (self._element == other._element)
+        )
+        same_species = (self._species is not None and other._species is not None) and (
+            self._species == other._species
+        )
+        same_variable = (self._aerocom_var is None and other._aerocom_var is None) or (
+            self._aerocom_var == other._aerocom_var
+        )
+
+        if cf_units_only:
+            if not self._cfunit.is_convertible(other._cfunit):
+                raise ValueError(f"Unit '{self._cfunit}' is not convertible to '{other._cfunit}'.")
+
+        if not compatible_element:
+            raise ValueError(
+                f"Unit '{self}' is not convertible to '{other}'. Element '{self._element}' is not compatible with '{other._element}'."
+            )
+
+        if same_species and same_variable:
+            if not self._cfunit.is_convertible(other._cfunit):
+                raise ValueError(
+                    f"cfunit '{self._cfunit}' is not convertible to cfunit '{other._cfunit}'."
+                )
+
+        if (self._element == other._element) and same_variable:
+            if not self._cfunit.is_convertible(other._cfunit):
+                raise ValueError(f"Unit '{self._cfunit}' is not convertible to '{other._cfunit}'.")
+
     def is_convertible(self, other: str | Unit) -> bool:
         """
         Return whether this unit is convertible to other. It handles a couple of
@@ -211,6 +247,12 @@ class Unit:
 
         :param other: Other Unit.
         """
+        try:
+            self._validate_convertible(other)
+        except ValueError:
+            return False
+
+        return True
         if isinstance(other, str):
             other = Unit(other)
 

--- a/pyaerocom/units/units.py
+++ b/pyaerocom/units/units.py
@@ -200,6 +200,19 @@ class Unit:
         return ""
 
     def _validate_convertible(self, other: str | Unit) -> None:
+        """
+        Validates whether the unit is convertible to another by raising an exception
+        if not convertible:
+
+        - Units that contain elements (eg. kg N m-2) need to have compatible mass ratios:
+           - This is assumed to be the case if element and species are the same, the aerocom
+           variable is the same (to account for variables that don't have a clear mass ratio —
+           eg. wetrdn.)
+
+        :param other: Other Unit.
+
+        :raises ValueError: If unit is not convertible.
+        """
         if isinstance(other, str):
             other = Unit(other)
 
@@ -253,35 +266,6 @@ class Unit:
             return False
 
         return True
-        if isinstance(other, str):
-            other = Unit(other)
-
-        cf_units_only = self._element is None and other._element is None
-        compatible_element = (
-            (self._element is None)
-            or (other._element is None)
-            or (self._element == other._element)
-        )
-        same_species = (self._species is not None and other._species is not None) and (
-            self._species == other._species
-        )
-        same_variable = (self._aerocom_var is None and other._aerocom_var is None) or (
-            self._aerocom_var == other._aerocom_var
-        )
-
-        if cf_units_only:
-            return self._cfunit.is_convertible(other._cfunit)
-
-        if not compatible_element:
-            return False
-
-        if same_species and same_variable:
-            return self._cfunit.is_convertible(other._cfunit)
-
-        if (self._element == other._element) and same_variable:
-            return self._cfunit.is_convertible(other._cfunit)
-
-        return False
 
     def is_dimensionless(self) -> bool:
         """

--- a/pyaerocom/units/units.py
+++ b/pyaerocom/units/units.py
@@ -129,7 +129,7 @@ class Unit:
                 MolecularMass(self._species)
             except ValueError:
                 self._species = None
-        if self._element is not None and self._species is not None:
+        if self.has_element_mass and self._species is not None:
             factor = MolecularMass(self._species) / MolecularMass(self._element)
 
         else:

--- a/pyaerocom/units/units_helpers.py
+++ b/pyaerocom/units/units_helpers.py
@@ -76,7 +76,7 @@ def convert_unit(
         )
     except ValueError as e:
         raise UnitConversionError(
-            f"failed to convert unit from {str(from_unit)} to {to_unit}"
+            f"Failed to convert unit from {str(from_unit)} to {to_unit}. Reason: {e}."
         ) from e
 
     return data

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -75,7 +75,7 @@ def test_merge_station_data(
 @pytest.mark.parametrize(
     "use,exception,error",
     [
-        ("concpm10_X2", UnitConversionError, "failed to convert unit from mole mole-1 to ug m-3"),
+        ("concpm10_X2", UnitConversionError, "Failed to convert unit from mole mole-1 to ug m-3"),
         ("concpm10_X", TemporalResolutionError, "Invalid input for ts_type daily"),
         ("od550aer", DataCoverageError, "All input stations must contain concpm10 data"),
     ],

--- a/tests/test_stationdata.py
+++ b/tests/test_stationdata.py
@@ -127,7 +127,7 @@ def test_StationData_check_var_unit_aerocom():
             stat3.copy(),
             "concso4",
             UnitConversionError,
-            "failed to convert unit from 1 to ug m-3",
+            "Failed to convert unit from 1 to ug m-3",
             id="can not convert",
         ),
     ],
@@ -137,7 +137,7 @@ def test_StationData_check_var_unit_aerocom_error(
 ):
     with pytest.raises(exception) as e:
         stat.check_var_unit_aerocom(var_name)
-    assert str(e.value) == error
+    assert error in str(e.value)
 
 
 def test_StationData_check_unit():
@@ -162,7 +162,7 @@ def test_StationData_convert_unit():
 def test_StationData_convert_unit_error():
     with pytest.raises(UnitConversionError) as e:
         stat3.convert_unit("concso4", "kg m-3")
-    assert str(e.value) == "failed to convert unit from 1 to kg m-3"
+    assert "Failed to convert unit from 1 to kg m-3" in str(e.value)
 
 
 def test_StationData_dist_other():

--- a/tests/units/test_units_helpers.py
+++ b/tests/units/test_units_helpers.py
@@ -56,4 +56,4 @@ def test_get_unit_conversion_fac(
 def test_get_unit_conversion_fac_error(from_unit: str, to_unit: str, var_name: str | None):
     with pytest.raises(UnitConversionError) as e:
         get_unit_conversion_fac(from_unit, to_unit, var_name)
-    assert str(e.value) == f"failed to convert unit from {from_unit} to {to_unit}"
+    assert f"Failed to convert unit from {from_unit} to {to_unit}" in str(e.value)


### PR DESCRIPTION
## Change Summary

A couple of units related changes.

- Unit conversion should exposed more detailed information about *why* unit conversion fails in exceptions it raises.
- Unit harmonization is performed on data var_name, not varname from `use_model_vars` (see https://github.com/metno/AeroToolsIssues/issues/115)
- Type hints :)

## Related issue number

- https://github.com/metno/AeroToolsIssues/issues/115

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
