### PR TITLE
Lowlevel helpers weeding

### DIFF
--- a/pyaerocom/_lowlevel_helpers.py
+++ b/pyaerocom/_lowlevel_helpers.py
@@ -194,12 +194,9 @@ class BrowseDict(MutableMapping):
     assigned value is callable, it will be executed on demand).
     """
 
-    ADD_GLOB = []
     FORBIDDEN_KEYS = []
-    #: Keys to be ignored when converting to json
-    IGNORE_JSON = []
+
     MAXLEN_KEYS = 1e2
-    SETTER_CONVERT = {}
 
     def __init__(self, *args, **kwargs):
         self.update(*args, **kwargs)
@@ -209,10 +206,7 @@ class BrowseDict(MutableMapping):
         return _class_name(self)
 
     def keys(self):
-        return list(self.__dict__) + self.ADD_GLOB
-
-    def _get_glob_vals(self):
-        return [getattr(self, x) for x in self.ADD_GLOB]
+        return list(self.__dict__)
 
     def values(self):
         return [getattr(self, x) for x in self.keys()]
@@ -222,26 +216,12 @@ class BrowseDict(MutableMapping):
             yield key, getattr(self, key)
 
     def __setitem__(self, key, val) -> None:
-        key, val, ok = self._setitem_checker(key, val)
-        if not ok:
-            return
-        if bool(self.SETTER_CONVERT):
-            for fromtp, totp in self.SETTER_CONVERT.items():
-                if isinstance(val, fromtp):
-                    if fromtp is dict:
-                        val = totp(**val)
-                    else:
-                        val = totp(val)
-
         if isinstance(key, str):
             if len(key) > self.MAXLEN_KEYS:
                 raise KeyError(f"key {key} exceeds max length of {self.MAXLEN_KEYS}")
             if key in self.FORBIDDEN_KEYS:
                 raise KeyError(f"invalid key {key}")
         setattr(self, key, val)
-
-    def _setitem_checker(self, key, val):
-        return key, val, True
 
     def __getitem__(self, key):
         try:
@@ -284,145 +264,13 @@ class BrowseDict(MutableMapping):
         """
         output = {}
         for key, val in self.items():
-            if key in self.IGNORE_JSON:
-                continue
             if hasattr(val, "json_repr"):
                 val = val.json_repr()
             output[key] = val
         return output
 
-    def import_from(self, other) -> None:
-        """
-        Import key value pairs from other object
-
-        Other than :func:`update` this method will silently ignore input
-        keys that are not contained in this object.
-
-        Parameters
-        ----------
-        other : dict or BrowseDict
-            other dict-like object containing content to be updated.
-
-        Raises
-        ------
-        ValueError
-            If input is invalid type.
-
-        Returns
-        -------
-        None
-
-        """
-        if not isinstance(other, dict | BrowseDict):
-            raise ValueError("need dict-like object")
-        for key, val in other.items():
-            if key in self:
-                self[key] = val
-            elif key in self.FORBIDDEN_KEYS:
-                raise KeyError(f"invalid key {key}")
-
-    def pretty_str(self):
-        return dict_to_str(self.to_dict())
-
     def __str__(self):
         return str(self.to_dict())
-
-
-class ConstrainedContainer(BrowseDict):
-    """Restrictive dict-like class with fixed keys
-
-    This class enables to create dict-like objects that have a fixed set of
-    keys and value types (once assigned). Optional values may be instantiated
-    as None, in which case the first time instantiation defines its type.
-
-    Note
-    ----
-    The limitations for assignments are only restricted to setitem operations
-    and attr assignment via "." works like in every other class.
-
-    Example
-    -------
-    >>> class MyContainer(ConstrainedContainer):
-    ...    def __init__(self):
-    ...        self.val1 = 1
-    ...        self.val2 = 2
-    ...        self.option = None
-    >>> mc = MyContainer()
-    >>> mc['option'] = 42
-    """
-
-    CRASH_ON_INVALID = True
-
-    def __setitem__(self, key, val):
-        super().__setitem__(key, val)
-
-    def _invoke_dtype(self, current_tp, val):
-        return current_tp(**val)
-
-    def _check_valtype(self, key, val):
-        current_tp = type(self[key])
-        if type(val) is not current_tp and isinstance(self[key], BrowseDict):
-            val = current_tp(**val)
-        return val
-
-    def _setitem_checker(self, key, val):
-        """make sure no new attr is added
-
-        Note
-        ----
-        Only used in __setitem__ not in __setattr__.
-        """
-        if key not in dir(self):
-            if self.CRASH_ON_INVALID:
-                raise ValueError(f"Invalid key {key}")
-            logger.warning(f"Invalid key {key} in {self._class_name}. Will be ignored.")
-            return key, val, False
-
-        current = getattr(self, key)
-        val = self._check_valtype(key, val)
-        current_tp = type(current)
-
-        if current is not None and not isinstance(val, current_tp):
-            raise ValueError(
-                f"Invalid type {type(val)} for key: {key}. Need {current_tp} "
-                f"(Current value: {current})"
-            )
-        return key, val, True
-
-
-class NestedContainer(BrowseDict):
-    def _occurs_in(self, key) -> list:
-        objs = []
-        if key in self:
-            objs.append(self)
-        for k, v in self.items():
-            if isinstance(v, dict | BrowseDict) and key in v:
-                objs.append(v)
-            if len(objs) > 1:
-                print(key, "is contained in multiple containers ", objs)
-        return objs
-
-    def keys_unnested(self) -> list:
-        keys = []
-        for key, val in self.items():
-            keys.append(key)
-            if isinstance(val, NestedContainer):
-                keys.extend(val.keys_unnested())
-            elif isinstance(val, ConstrainedContainer | dict):
-                for subkey, subval in val.items():
-                    keys.append(subkey)
-        return keys
-
-    def update(self, **settings):
-        for key, val in settings.items():
-            to_update = self._occurs_in(key)
-            if len(to_update) == 0:
-                raise AttributeError(f"invalid key {key}")
-            for obj in to_update:
-                obj[key] = val
-
-    def __str__(self):
-        return dict_to_str(self)
 
 
 def merge_dicts(dict1, dict2, discard_failing=True):

--- a/pyaerocom/_lowlevel_helpers.py
+++ b/pyaerocom/_lowlevel_helpers.py
@@ -147,8 +147,17 @@ class AsciiFileLoc(Loc):
 class BrowseDict(MutableMapping):
     """Dictionary-like object with getattr and setattr options
 
-    Extended dictionary that supports dynamic value generation (i.e. if an
-    assigned value is callable, it will be executed on demand).
+    Dictionary that supports reading and writing values with . syntax.
+
+    For example:
+
+    d = BrowseDict()
+
+    d.a = 1
+    d["b"] = 2
+
+    print(d)
+    # BrowseDict: {'a': 1, 'b': 2}
     """
 
     FORBIDDEN_KEYS = []
@@ -168,22 +177,15 @@ class BrowseDict(MutableMapping):
 
     def items(self):
         for key in self.keys():
-            yield key, getattr(self, key)
+            yield key, self[key]
 
     def __setitem__(self, key, val) -> None:
-        if isinstance(key, str):
-            if key in self.FORBIDDEN_KEYS:
-                raise KeyError(f"invalid key {key}")
-        setattr(self, key, val)
+        if key in self.FORBIDDEN_KEYS:
+            raise KeyError(f"invalid key {key}")
+        self.__dict__[key] = val
 
     def __getitem__(self, key):
-        try:
-            return getattr(self, key)
-        except TypeError:
-            # if key is not str
-            return self.__dict__[key]
-        except AttributeError as e:
-            raise KeyError(e)
+        return self.__dict__[key]
 
     def __delitem__(self, key):
         del self.__dict__[key]

--- a/pyaerocom/_lowlevel_helpers.py
+++ b/pyaerocom/_lowlevel_helpers.py
@@ -78,43 +78,6 @@ def _class_name(obj):
     return type(obj).__name__
 
 
-# TODO: Check to see if instances of these classes can instead use pydantic
-class Validator(abc.ABC):
-    def __set_name__(self, owner, name):
-        self._name = name
-
-    def __get__(self, obj, objtype=None):
-        try:
-            return obj.__dict__[self._name]
-        except (AttributeError, KeyError):
-            raise AttributeError("value not set...")
-
-    def __set__(self, obj, val):
-        val = self.validate(val)
-        obj.__dict__[self._name] = val
-
-    @abc.abstractmethod
-    def validate(self, val):
-        pass
-
-
-class TypeValidator(Validator):
-    def __init__(self, type):
-        self._type = type
-
-    def validate(self, val):
-        if not isinstance(val, self._type):
-            raise ValueError(f"need instance of {self._type}")
-        return val
-
-
-class StrType(Validator):
-    def validate(self, val):
-        if not isinstance(val, str):
-            raise ValueError(f"need str, got {val}")
-        return val
-
-
 class Loc(abc.ABC):
     """Abstract descriptor representing a path location
 
@@ -173,12 +136,6 @@ class Loc(abc.ABC):
     @abc.abstractmethod
     def create(self, value):
         pass
-
-
-class DirLoc(Loc):
-    def create(self, value):
-        os.makedirs(value, exist_ok=True)
-        logger.info(f"created directory {value}")
 
 
 class AsciiFileLoc(Loc):

--- a/pyaerocom/_lowlevel_helpers.py
+++ b/pyaerocom/_lowlevel_helpers.py
@@ -153,8 +153,6 @@ class BrowseDict(MutableMapping):
 
     FORBIDDEN_KEYS = []
 
-    MAXLEN_KEYS = 1e2
-
     def __init__(self, *args, **kwargs):
         self.update(*args, **kwargs)
 
@@ -174,8 +172,6 @@ class BrowseDict(MutableMapping):
 
     def __setitem__(self, key, val) -> None:
         if isinstance(key, str):
-            if len(key) > self.MAXLEN_KEYS:
-                raise KeyError(f"key {key} exceeds max length of {self.MAXLEN_KEYS}")
             if key in self.FORBIDDEN_KEYS:
                 raise KeyError(f"invalid key {key}")
         setattr(self, key, val)

--- a/pyaerocom/aeroval/_processing_base.py
+++ b/pyaerocom/aeroval/_processing_base.py
@@ -1,16 +1,18 @@
 import abc
 import logging
 
-from pyaerocom._lowlevel_helpers import TypeValidator
+import aerovaldb
+
 from pyaerocom.aeroval import EvalSetup
 from pyaerocom.aeroval.experiment_output import ExperimentOutput
 from pyaerocom.colocation.colocation_setup import ColocationSetup
 from pyaerocom.colocation.colocator import Colocator
-
+from attrs import define, field
 
 logger = logging.getLogger(__name__)
 
 
+@define
 class HasConfig:
     """
     Base class that ensures that evaluation configuration is available
@@ -24,8 +26,9 @@ class HasConfig:
 
     """
 
-    cfg = TypeValidator(EvalSetup)
-    exp_output = TypeValidator(ExperimentOutput)
+    cfg: EvalSetup = field()
+    exp_output: ExperimentOutput = field()
+    avdb: aerovaldb.AerovalDB = field()
 
     def __init__(self, cfg: EvalSetup):
         self.cfg = cfg

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -8,9 +8,6 @@ import aerovaldb
 
 from pyaerocom import const
 from pyaerocom._lowlevel_helpers import (
-    DirLoc,
-    StrType,
-    TypeValidator,
     sort_dict_by_name,
 )
 from pyaerocom.aeroval import EvalSetup
@@ -35,17 +32,18 @@ from pyaerocom.stats.stats import _init_stats_dummy
 from pyaerocom.units.helpers import get_standard_unit
 from pyaerocom.utils import recursive_defaultdict
 from pyaerocom.variable_helpers import get_aliases
-
+from attrs import define, field
 
 logger = logging.getLogger(__name__)
 
 
+@define
 class ProjectOutput:
     """JSON output for project"""
 
-    proj_id = StrType()
-
-    json_basedir = DirLoc(assert_exists=True)
+    proj_id: str = field()
+    avdb: aerovaldb.AerovalDB = field()
+    json_basedir: str = field()
 
     def __init__(self, proj_id: str, resource: str | pathlib.Path | aerovaldb.AerovalDB):
         self.proj_id = proj_id
@@ -87,10 +85,12 @@ class ProjectOutput:
         return list(self.avdb.get_experiments(self.proj_id, default={}))
 
 
+@define
 class ExperimentOutput(ProjectOutput):
     """JSON output for experiment"""
 
-    cfg = TypeValidator(EvalSetup)
+    cfg: EvalSetup = field()
+    _invalid: dict[str, list] = field()
 
     def __init__(self, cfg: EvalSetup):
         self.cfg = cfg

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -115,7 +115,7 @@ def test_ExperimentOutput():
 
 
 def test_ExperimentOutput_error():
-    with pytest.raises(ValueError):
+    with pytest.raises(AttributeError):
         ExperimentOutput(None)
 
 

--- a/tests/aeroval/test_experiment_output.py
+++ b/tests/aeroval/test_experiment_output.py
@@ -48,7 +48,13 @@ def test_ProjectOutput(proj_id: str, json_basedir: str):
 @pytest.mark.parametrize(
     "proj_id,json_basedir,exception,error",
     [
-        pytest.param(42, None, ValueError, "need str, got 42", id="ValueError"),
+        pytest.param(
+            42,
+            None,
+            ValueError,
+            "Expected string or AerovalDB, got <class 'NoneType'>.",
+            id="ValueError",
+        ),
     ],
 )
 def test_ProjectOutput_error(proj_id, json_basedir, exception: type[Exception], error: str):

--- a/tests/test__lowlevel_helpers.py
+++ b/tests/test__lowlevel_helpers.py
@@ -5,6 +5,7 @@ from pyaerocom._lowlevel_helpers import (
     invalid_input_err_str,
     sort_dict_by_name,
     str_underline,
+    BrowseDict,
 )
 
 
@@ -42,3 +43,24 @@ def test_check_dir_access(dir, val):
 def test_sort_dict_by_name(input, pref_list, output_keys):
     sorted = sort_dict_by_name(input, pref_list)
     assert list(sorted.keys()) == output_keys
+
+
+def test_BrowseDict():
+    bd = BrowseDict(key=42)
+    assert bd["key"] == bd.key == 42
+
+
+def test_BrowseDict_assign():
+    bd = BrowseDict()
+
+    bd.key = "test"
+
+    assert bd["key"] == bd.key == "test"
+
+
+def test_BrowseDict_forbidden_keys():
+    bd = BrowseDict()
+    bd.FORBIDDEN_KEYS.append("forbidden")
+
+    with pytest.raises(KeyError):
+        bd["forbidden"] = "test"

--- a/tests/test__lowlevel_helpers.py
+++ b/tests/test__lowlevel_helpers.py
@@ -1,8 +1,6 @@
 import pytest
 
 from pyaerocom._lowlevel_helpers import (
-    ConstrainedContainer,
-    NestedContainer,
     check_dir_access,
     invalid_input_err_str,
     sort_dict_by_name,
@@ -21,20 +19,6 @@ def test_str_underline(title: str, indent: int):
     assert lines[0][:indent] == lines[1][:indent] == " " * indent
 
 
-class Constrainer(ConstrainedContainer):
-    def __init__(self):
-        self.bla = 42
-        self.blub = "str"
-        self.opt = None
-
-
-class NestedData(NestedContainer):
-    def __init__(self):
-        self.bla = dict(a=1, b=2)
-        self.blub = dict(c=3, d=4)
-        self.d = 42
-
-
 def test_invalid_input_err_str():
     st = invalid_input_err_str("bla", "42", (42, 43))
     assert st == "Invalid input for bla (42), choose from (42, 43)"
@@ -43,70 +27,6 @@ def test_invalid_input_err_str():
 @pytest.mark.parametrize("dir,val", [(".", True), ("/bla/blub", False), (42, False)])
 def test_check_dir_access(dir, val):
     assert check_dir_access(dir) == val
-
-
-def test_Constrainer():
-    cont = Constrainer()
-    assert cont.bla == 42
-    assert cont.blub == "str"
-    assert cont.opt is None
-
-
-def test_NestedData():
-    cont = NestedData()
-    assert cont.bla == dict(a=1, b=2)
-    assert cont.blub == dict(c=3, d=4)
-
-
-@pytest.mark.parametrize("kwargs", [dict(), dict(bla=400), dict(bla=45, opt={})])
-def test_ConstrainedContainer_update(kwargs):
-    cont = Constrainer()
-    cont.update(**kwargs)
-    for key, val in kwargs.items():
-        assert cont[key] == val
-
-
-@pytest.mark.parametrize("kwargs", [dict(blaaaa=400)])
-def test_ConstrainedContainer_update_error(kwargs):
-    cont = Constrainer()
-    with pytest.raises(ValueError):
-        cont.update(**kwargs)
-
-
-def test_NestedData_keys_unnested():
-    cont = NestedData()
-    keys = cont.keys_unnested()
-    assert sorted(keys) == ["a", "b", "bla", "blub", "c", "d", "d"]
-
-
-def test_NestedData___getitem__():
-    cont = NestedData()
-    assert cont["d"] == 42
-
-
-def test_NestedData___getitem___error():
-    cont = NestedData()
-    with pytest.raises(KeyError):
-        cont["a"]
-
-
-@pytest.mark.parametrize("kwargs", [dict(bla=42), dict(a=400), dict(d=400)])
-def test_NestedData_update(kwargs):
-    cont = NestedData()
-    cont.update(**kwargs)
-    for key, value in kwargs.items():
-        if key in cont.__dict__:  # toplevel entry
-            assert cont[key] == value
-        for val in cont.values():
-            if isinstance(val, dict) and key in val:
-                assert val[key] == value
-
-
-def test_NestedData_update_error():
-    cont = NestedData()
-    with pytest.raises(AttributeError) as e:
-        cont.update(abc=400)
-    assert str(e.value) == "invalid key abc"
 
 
 @pytest.mark.parametrize("input", [{"b": 1, "a": 2, "kl": 42}])


### PR DESCRIPTION
## Change Summary

An attempt at going through _lowlevel_helpers.py and keeping only functionality that is needed for the current pyaerocom. The main changes are:

- Remove Validators in favor of [attrs](https://www.attrs.org/en/stable/index.html).
- Remove unused functionality on `BrowseDict`, in particular `ADD_GLOB`, `IGNORE_JSON`, `MAXLEN_KEYS`, `SETTER_CONVERT` are not currently used in Pyaerocom.
  - Keeping `FORBIDDEN_KEYS` as it is used in `colocation_setup`.
- Removes unused `...Container` classes which were only used in tests.
- Update BrowseDict docs to actually reflect what it does.
- Streamlining implementations and basic testing of BrowseDict.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
