### PR TITLE
Changes where where is added in RMSU, to not trigger numpy square bug

### DIFF
--- a/pyaerocom/aeroval/fairmode_statistics.py
+++ b/pyaerocom/aeroval/fairmode_statistics.py
@@ -242,7 +242,8 @@ class FairmodeStatistics:
             return UrRV * np.sqrt(in_sqrt)
 
         return beta * np.sqrt(
-            np.nanmean(np.square(obsuncertainty(obsvals, var_name), where=mask), axis=0)
+            np.nanmean(np.square(obsuncertainty(obsvals, var_name)), where=mask, axis=0)
+            # np.nanmean(np.square(obsuncertainty(obsvals, var_name), where=mask), axis=0)
         )
 
     @staticmethod

--- a/pyaerocom/aeroval/fairmode_statistics.py
+++ b/pyaerocom/aeroval/fairmode_statistics.py
@@ -243,7 +243,6 @@ class FairmodeStatistics:
 
         return beta * np.sqrt(
             np.nanmean(np.square(obsuncertainty(obsvals, var_name)), where=mask, axis=0)
-            # np.nanmean(np.square(obsuncertainty(obsvals, var_name), where=mask), axis=0)
         )
 
     @staticmethod


### PR DESCRIPTION
## Change Summary

Removes "where" argument from np.square for cams283. This function created random values where the mask was false, leading to strange, random bugs

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
