### PR TITLE
Adds gt to region sorting

### DIFF
--- a/pyaerocom/region.py
+++ b/pyaerocom/region.py
@@ -360,6 +360,9 @@ class RegionName(str):
         if str(self) == ALL_REGION_NAME:
             return True
 
+        if str(other) == ALL_REGION_NAME:
+            return False
+
         return str(self).lower() < str(other).lower()
 
     def __gt__(self, other) -> bool:
@@ -368,5 +371,8 @@ class RegionName(str):
 
         if str(self) == ALL_REGION_NAME:
             return False
+
+        if str(other) == ALL_REGION_NAME:
+            return True
 
         return str(self).lower() > str(other).lower()

--- a/pyaerocom/region.py
+++ b/pyaerocom/region.py
@@ -361,3 +361,12 @@ class RegionName(str):
             return True
 
         return str(self).lower() < str(other).lower()
+
+    def __gt__(self, other) -> bool:
+        if str(self).lower() == str(other).lower():
+            return False
+
+        if str(self) == ALL_REGION_NAME:
+            return False
+
+        return str(self).lower() > str(other).lower()

--- a/pyaerocom/region.py
+++ b/pyaerocom/region.py
@@ -364,15 +364,3 @@ class RegionName(str):
             return False
 
         return str(self).lower() < str(other).lower()
-
-    def __gt__(self, other) -> bool:
-        if str(self).lower() == str(other).lower():
-            return False
-
-        if str(self) == ALL_REGION_NAME:
-            return False
-
-        if str(other) == ALL_REGION_NAME:
-            return True
-
-        return str(self).lower() > str(other).lower()

--- a/tests/test_region.py
+++ b/tests/test_region.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pyaerocom.region import Region, get_regions_coord
+from pyaerocom.region import Region, get_regions_coord, RegionName
 
 
 @pytest.mark.parametrize(
@@ -61,3 +61,23 @@ def test_get_regions_coord_with_supplied_regions_dict(region_name, lat, lon):
     candidate_regions = {"OCN": oceans, "SAM": sam, "ASIA": asia}
     reg = Region(region_name)
     assert reg.region_id in get_regions_coord(lat, lon, candidate_regions)
+
+
+def test_Region_name():
+    world = RegionName("ALL")
+    alg = RegionName("Algeria")
+    bel = RegionName("Belgium")
+
+    correct = ["ALL", "Algeria", "Belgium"]
+    mix = ["Belgium", "Algeria", "ALL"]
+
+    assert sorted(mix, key=lambda x: RegionName(x)) == correct
+
+    assert world < alg
+    assert alg > world
+
+    assert not world > alg
+    assert not alg < world
+
+    assert alg < bel
+    assert bel > world


### PR DESCRIPTION
## Change Summary

Fixes how the region sorting is done by just adding a dunder gt to RegionNames

## Related issue number

Albania was before ALL in regions.json

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
