### PR TITLE
Fix CAMS2_83 model maps bug 

### DIFF
--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -734,7 +734,10 @@ class ExperimentOutput(ProjectOutput):
                 if not all_combinations:
                     break
 
-                src_name = uri.meta["source"]
+                try:
+                    src_name = uri.meta["source"]
+                except KeyError:
+                    src_name = uri.meta["model"]
                 var = uri.meta["variable"]
                 obs_var = var
                 mod_var = var


### PR DESCRIPTION
## Change Summary

Put a try/except block on the `src_name` in `ExperimentOutput._create_menu_dict` due to mismatching interface in aerovaldc for contour and overlay maps.

## Related issue number
NA, see pyaerocom chat

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
