### PR TITLE
Fix variable getting in _create_menu_dict for overlay and contour case

### DIFF
--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -734,11 +734,13 @@ class ExperimentOutput(ProjectOutput):
                 if not all_combinations:
                     break
 
-                try:
+                try:  # overlay case
                     src_name = uri.meta["source"]
-                except KeyError:
+                    var = uri.meta["variable"]
+                except KeyError:  # contour case
                     src_name = uri.meta["model"]
-                var = uri.meta["variable"]
+                    var = uri.meta["obsvar"]
+
                 obs_var = var
                 mod_var = var
 


### PR DESCRIPTION
## Change Summary

Put the var declaration in the same try/except block

## Related issue number

Should complete #1703

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
