### PR TITLE
split fairmode output by model

### DIFF
--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -1008,7 +1008,14 @@ class ExperimentOutput(ProjectOutput):
 
         with self.avdb.lock():
             glob_stats = self.avdb.get_fairmode(
-                project, experiment, region, network, obsvar, layer, default={}
+                project,
+                experiment,
+                region,
+                network,
+                obsvar,
+                layer,
+                modelname,
+                default={},
             )
             glob_stats = recursive_defaultdict(glob_stats)
             glob_stats[obsvar][network][layer][modelname][modvar] = round_floats(entry)
@@ -1020,6 +1027,7 @@ class ExperimentOutput(ProjectOutput):
                 network,
                 obsvar,
                 layer,
+                modelname,
             )
 
     def add_heatmap_entry(

--- a/tests/aeroval/test_fairmode_statistics.py
+++ b/tests/aeroval/test_fairmode_statistics.py
@@ -235,7 +235,7 @@ def test_save_fairmode_stats(
 
     fileout = (
         tmp_path
-        / f"{fairmode_exp_output.cfg.proj_id}/{fairmode_exp_output.cfg.exp_id}/fairmode/{list(fairmode_stats_example.keys())[0]}_{obs_name}_{var_name_web}_{vert_code}.json"
+        / f"{fairmode_exp_output.cfg.proj_id}/{fairmode_exp_output.cfg.exp_id}/fairmode/{list(fairmode_stats_example.keys())[0]}_{obs_name}_{var_name_web}_{vert_code}_{modelname}.json"
     )
     assert fileout.is_file()
 


### PR DESCRIPTION
## Change Summary

fairmode files are split by region and component at the moment which makes it for json files big enough to make the frontend slow in the generation of reports and loading of the target plots. splitting by model will improve performance.   

Note: splitting by period requires a bit more work, and will be considered in a different PR.  
It is relatively easy for the case of the cams2_83-specific fairmode workflow (by moving this https://github.com/metno/pyaerocom/blob/main-dev/pyaerocom/scripts/cams2_83/engine.py#L281 at the right point in the loop on periods), but few more adjustments are necessary for the non-cams2_83-specific fairmode workflow (https://github.com/metno/pyaerocom/blob/main-dev/pyaerocom/aeroval/coldatatojson_engine.py#L579, because of the way the loop on period is packed into _calculate_fairmode).

## Related issue number

https://github.com/metno/pyaerocom/issues/1723

requires https://github.com/metno/aerovaldb/pull/145

## Checklist

* [x] Start with a draft-PR
* [ ] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
