### PR TITLE
Split fairmode output by model and period

### DIFF
--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -1,7 +1,8 @@
 import logging
 import os
-from numpy.typing import ArrayLike
 from time import time
+
+from numpy.typing import ArrayLike
 
 from pyaerocom import ColocatedData, TsType, const
 from pyaerocom.aeroval._processing_base import ProcessingEngine
@@ -567,21 +568,28 @@ class ColdataToJsonEngine(ProcessingEngine):
             fm_data = data[freq]
         (ts_objs, map_meta, site_indices) = _process_sites(data, regs, regions_how, meta_glob)
 
-        stats = _calculate_fairmode(
+        _calculate_fairmode(
             fm_data,
             fairmode_statistics,
+            self.exp_output,
+            obs_name,
+            var_name_web,
+            vert_code,
+            model_name,
+            model_var,
             map_meta,
             obs_var,
             periods,
             seasons,
             use_meteorological_seasons,
         )
-        fairmode_statistics.save_fairmode_stats(
-            self.exp_output,
-            stats,
-            obs_name,
-            var_name_web,
-            vert_code,
-            model_name,
-            model_var,
-        )
+        # fairmode_statistics.save_fairmode_stats(
+        #    self.exp_output,
+        #    stats,
+        #    obs_name,
+        #    var_name_web,
+        #    vert_code,
+        #    model_name,
+        #    model_var,
+        # )
+        # )

--- a/pyaerocom/aeroval/coldatatojson_engine.py
+++ b/pyaerocom/aeroval/coldatatojson_engine.py
@@ -583,13 +583,3 @@ class ColdataToJsonEngine(ProcessingEngine):
             seasons,
             use_meteorological_seasons,
         )
-        # fairmode_statistics.save_fairmode_stats(
-        #    self.exp_output,
-        #    stats,
-        #    obs_name,
-        #    var_name_web,
-        #    vert_code,
-        #    model_name,
-        #    model_var,
-        # )
-        # )

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -5,9 +5,9 @@ Helpers for conversion of ColocatedData to JSON files for web interface.
 import logging
 from collections.abc import Callable
 from copy import deepcopy
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Literal
-from dataclasses import dataclass
 
 import numpy as np
 import pandas as pd
@@ -16,6 +16,8 @@ import xarray as xr
 from pyaerocom import ColocatedData
 from pyaerocom._warnings import ignore_warnings
 from pyaerocom.aeroval.exceptions import ConfigError, TrendsError
+
+# from pyaerocom.aeroval.experiment_output import ExperimentOutput
 from pyaerocom.aeroval.fairmode_stats import fairmode_stats
 from pyaerocom.aeroval.helpers import (
     _get_min_max_year_periods,
@@ -1827,6 +1829,12 @@ def _process_statistics_timeseries_single_region(
 def _calculate_fairmode(
     coldata: ColocatedData,
     fairmode_statistics,  #: FairmodeStatistics,
+    exp_output,  #: ExperimentOutput,
+    obs_name: str,
+    var_name_web: str,
+    vert_code: str,
+    model_name: str,
+    model_var: str,
     map_meta: list[dict],
     obs_var: str = None,
     periods: tuple[str, ...] | None = None,
@@ -1860,4 +1868,14 @@ def _calculate_fairmode(
 
                 results[region][perstr][station_name] = fm_stats[station_name]
                 results["ALL"][perstr][station_name] = fm_stats[station_name]
-    return results
+
+        fairmode_statistics.save_fairmode_stats(
+            exp_output,
+            results,
+            obs_name,
+            var_name_web,
+            vert_code,
+            model_name,
+            model_var,
+            per,
+        )

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1881,5 +1881,3 @@ def _calculate_fairmode(
                 per,
                 reg,
             )
-
-    return results

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1841,8 +1841,8 @@ def _calculate_fairmode(
     seasons: tuple[str, ...] | None = None,
     use_meteorological_seasons: bool = False,
 ):
-    results = {"ALL": {}}
     for per in periods:
+        results = {"ALL": {}}
         for season in seasons:
             try:
                 subset = _select_period_season_coldata(
@@ -1869,13 +1869,15 @@ def _calculate_fairmode(
                 results[region][perstr][station_name] = fm_stats[station_name]
                 results["ALL"][perstr][station_name] = fm_stats[station_name]
 
-        fairmode_statistics.save_fairmode_stats(
-            exp_output,
-            results,
-            obs_name,
-            var_name_web,
-            vert_code,
-            model_name,
-            model_var,
-            per,
-        )
+        for reg in results:
+            fairmode_statistics.save_fairmode_stats(
+                exp_output,
+                results[reg],
+                obs_name,
+                var_name_web,
+                vert_code,
+                model_name,
+                model_var,
+                per,
+                reg,
+            )

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1872,7 +1872,7 @@ def _calculate_fairmode(
         for reg in results:
             fairmode_statistics.save_fairmode_stats(
                 exp_output,
-                results[reg],
+                results,
                 obs_name,
                 var_name_web,
                 vert_code,
@@ -1881,3 +1881,5 @@ def _calculate_fairmode(
                 per,
                 reg,
             )
+
+    return results

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -993,6 +993,7 @@ class ExperimentOutput(ProjectOutput):
         layer: str,
         modelname: str,
         modvar: str,
+        period: str,
     ):
         """Adds a fairmode entry to fairmode
 
@@ -1015,6 +1016,7 @@ class ExperimentOutput(ProjectOutput):
                 obsvar,
                 layer,
                 modelname,
+                period.replace("/", ""),  # Remove slashes in CAMS2_83 period,
                 default={},
             )
             glob_stats = recursive_defaultdict(glob_stats)
@@ -1028,6 +1030,7 @@ class ExperimentOutput(ProjectOutput):
                 obsvar,
                 layer,
                 modelname,
+                period.replace("/", ""),  # Remove slashes in CAMS2_83 period,
             )
 
     def add_heatmap_entry(

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -1008,7 +1008,14 @@ class ExperimentOutput(ProjectOutput):
 
         with self.avdb.lock():
             glob_stats = self.avdb.get_fairmode(
-                project, experiment, region, network, obsvar, layer, default={}
+                project,
+                experiment,
+                region,
+                network,
+                obsvar,
+                layer,
+                modelname,
+                default={},
             )
             glob_stats = recursive_defaultdict(glob_stats)
             glob_stats[obsvar][network][layer][modelname][modvar] = round_floats(entry)
@@ -1020,6 +1027,7 @@ class ExperimentOutput(ProjectOutput):
                 network,
                 obsvar,
                 layer,
+                modelname,
             )
 
     def add_heatmap_entry(

--- a/pyaerocom/aeroval/fairmode_statistics.py
+++ b/pyaerocom/aeroval/fairmode_statistics.py
@@ -86,18 +86,18 @@ class FairmodeStatistics:
         modelname: str,
         model_var: str,
         period: str,
+        regname: str,
     ):
-        for regname in fairmode_stats:
-            exp_output.add_fairmode_entry(
-                fairmode_stats[regname],
-                regname,
-                obs_name,
-                var_name_web,
-                vert_code,
-                modelname,
-                model_var,
-                period,
-            )
+        exp_output.add_fairmode_entry(
+            fairmode_stats[regname],
+            regname,
+            obs_name,
+            var_name_web,
+            vert_code,
+            modelname,
+            model_var,
+            period,
+        )
 
     def fairmode_statistics(self, coldata: ColocatedData, var_name: str):
         return self._get_stats(coldata.data, var_name, False)

--- a/pyaerocom/aeroval/fairmode_statistics.py
+++ b/pyaerocom/aeroval/fairmode_statistics.py
@@ -13,16 +13,40 @@ logger = logging.getLogger(__name__)
 
 SPECIES = dict(
     concno2=dict(
-        UrRV=0.24, RV=200, alpha=0.2, freq=TsType("hourly"), percentile=99.8, Np=5.2, Nnp=5.5
+        UrRV=0.24,
+        RV=200,
+        alpha=0.2,
+        freq=TsType("hourly"),
+        percentile=99.8,
+        Np=5.2,
+        Nnp=5.5,
     ),
     conco3mda8=dict(
-        UrRV=0.18, RV=120, alpha=0.79, freq=TsType("daily"), percentile=92.9, Np=11.0, Nnp=3.0
+        UrRV=0.18,
+        RV=120,
+        alpha=0.79,
+        freq=TsType("daily"),
+        percentile=92.9,
+        Np=11.0,
+        Nnp=3.0,
     ),
     concpm10=dict(
-        UrRV=0.28, RV=50, alpha=0.25, freq=TsType("daily"), percentile=90.1, Np=20.0, Nnp=1.5
+        UrRV=0.28,
+        RV=50,
+        alpha=0.25,
+        freq=TsType("daily"),
+        percentile=90.1,
+        Np=20.0,
+        Nnp=1.5,
     ),
     concpm25=dict(
-        UrRV=0.36, RV=25, alpha=0.5, freq=TsType("daily"), percentile=90.1, Np=20.0, Nnp=1.5
+        UrRV=0.36,
+        RV=25,
+        alpha=0.5,
+        freq=TsType("daily"),
+        percentile=90.1,
+        Np=20.0,
+        Nnp=1.5,
     ),
 )
 
@@ -61,6 +85,7 @@ class FairmodeStatistics:
         vert_code: str,
         modelname: str,
         model_var: str,
+        period: str,
     ):
         for regname in fairmode_stats:
             exp_output.add_fairmode_entry(
@@ -71,6 +96,7 @@ class FairmodeStatistics:
                 vert_code,
                 modelname,
                 model_var,
+                period,
             )
 
     def fairmode_statistics(self, coldata: ColocatedData, var_name: str):

--- a/pyaerocom/scripts/cams2_83/engine.py
+++ b/pyaerocom/scripts/cams2_83/engine.py
@@ -52,7 +52,9 @@ class CAMS2_83_Engine(ProcessingEngine):
                     f"No variables found in colocated data var_list={var_list}, found_vars={found_vars}"
                 )
                 return
-        elif var_list == ["conco3"] or (len(var_list) > 1 and "conco3" in var_list and "conco3mda8" not in var_list):
+        elif var_list == ["conco3"] or (
+            len(var_list) > 1 and "conco3" in var_list and "conco3mda8" not in var_list
+        ):
             var_list_2 = list(var_list)
             var_list_2.append("conco3mda8")
         else:
@@ -262,6 +264,22 @@ class CAMS2_83_Engine(ProcessingEngine):
 
                     results[f"{regname}"][f"{perstr}"] = stats_list
 
+                if use_fairmode and var_name in SPECIES:
+                    fairmode_statistics.save_fairmode_stats(
+                        self.exp_output,
+                        results_fairmode,
+                        obs_name,
+                        var_name_web,
+                        vert_code,
+                        (
+                            modelname
+                            if (modelname == "ENS" or modelname == "MOS")
+                            else model.webname
+                        ),  # MOS/ENS evaluation special case
+                        model_var,
+                        per,
+                    )
+
             if calc_medianscores:
                 self.exp_output.add_forecast_entry(
                     results[regname],
@@ -276,21 +294,6 @@ class CAMS2_83_Engine(ProcessingEngine):
                     ),  # MOS/ENS evaluation special case
                     model_var,
                 )
-
-        if use_fairmode and var_name in SPECIES:
-            fairmode_statistics.save_fairmode_stats(
-                self.exp_output,
-                results_fairmode,
-                obs_name,
-                var_name_web,
-                vert_code,
-                (
-                    modelname
-                    if (modelname == "ENS" or modelname == "MOS")
-                    else model.webname
-                ),  # MOS/ENS evaluation special case
-                model_var,
-            )
 
     def _get_median_stats_point(
         self, data: xr.DataArray, use_weights: bool

--- a/pyaerocom/scripts/cams2_83/engine.py
+++ b/pyaerocom/scripts/cams2_83/engine.py
@@ -144,7 +144,7 @@ class CAMS2_83_Engine(ProcessingEngine):
 
         for regid, regname in regnames.items():
             results[regname] = {}
-            results_fairmode[regname] = {}
+            #results_fairmode[regname] = {}
             logger.info(f"Creating subset for {regname}")
             try:
                 subset_region = [
@@ -162,6 +162,7 @@ class CAMS2_83_Engine(ProcessingEngine):
                 )
                 continue
             for per in periods:
+                results_fairmode[regname] = {}
                 for season in seasons:
                     perstr = f"{per}-{season}"
 
@@ -265,6 +266,7 @@ class CAMS2_83_Engine(ProcessingEngine):
                     results[f"{regname}"][f"{perstr}"] = stats_list
 
                 if use_fairmode and var_name in SPECIES:
+
                     fairmode_statistics.save_fairmode_stats(
                         self.exp_output,
                         results_fairmode,
@@ -278,6 +280,7 @@ class CAMS2_83_Engine(ProcessingEngine):
                         ),  # MOS/ENS evaluation special case
                         model_var,
                         per,
+                        regname,
                     )
 
             if calc_medianscores:

--- a/pyaerocom/scripts/cams2_83/engine.py
+++ b/pyaerocom/scripts/cams2_83/engine.py
@@ -144,7 +144,6 @@ class CAMS2_83_Engine(ProcessingEngine):
 
         for regid, regname in regnames.items():
             results[regname] = {}
-            #results_fairmode[regname] = {}
             logger.info(f"Creating subset for {regname}")
             try:
                 subset_region = [

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -32,7 +32,7 @@ dependencies:
   - pip
   - pip:
     - geocoder_reverse_natural_earth >= 0.0.2
-    - aerovaldb >= 0.4.6, < 0.5.0
+    - aerovaldb >= 0.5.0
     - pyaro >= 0.2.0, < 0.3
     - pyaro-readers >=0.1.4, < 0.2.0
 ## testing

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -32,7 +32,7 @@ dependencies:
   - pip
   - pip:
     - geocoder_reverse_natural_earth >= 0.0.2
-    - aerovaldb >= 0.5.0
+    - aerovaldb >= 0.5.0, < 0.6.0
     - pyaro >= 0.2.0, < 0.3
     - pyaro-readers >=0.1.4, < 0.2.0
 ## testing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10"
 dependencies = [
     # NOTE: Please also update dependency versions in pyaerocom_env.yml,
     # and minimum versions in the tox config at the bottom of this file!
-    "aerovaldb>=0.5.0",
+    "aerovaldb>=0.5.0, < 0.6.0",
     "scitools-iris>=3.11.0, < 3.13.0",
     "xarray>=2022.12.0",
     "cartopy>=0.21.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10"
 dependencies = [
     # NOTE: Please also update dependency versions in pyaerocom_env.yml,
     # and minimum versions in the tox config at the bottom of this file!
-    "aerovaldb>=0.4.6, <0.5.0",
+    "aerovaldb>=0.5.0",
     "scitools-iris>=3.11.0, < 3.13.0",
     "xarray>=2022.12.0",
     "cartopy>=0.21.1",
@@ -230,7 +230,7 @@ deps =
     # Will only run on lowest supported Python version CI test
     # (currently 3.10).
     # Should be incremented when changing dependencies above.
-    aerovaldb ==0.4.6; python_version < "3.11"
+    aerovaldb ==0.5.0; python_version < "3.11"
     scitools-iris ==3.11.0; python_version < "3.11"
     cartopy ==0.21.1; python_version < "3.11"
     matplotlib ==3.7.1; python_version < "3.11"

--- a/tests/aeroval/test_coldatatojson_helpers2.py
+++ b/tests/aeroval/test_coldatatojson_helpers2.py
@@ -1,6 +1,9 @@
 # ToDo: merge with test_coldatatojson_helpers.py
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import numpy as np
 import pytest
 import xarray
@@ -416,14 +419,14 @@ def test_calculate_fairmode(eval_config: dict, caplog):
 
     period = "2010"
     season = "DJF"
-    model_name = "DUMMY"
-    obs_name = obs_var = var_name_web = model_var = "concno2"
+    model_name = obs_name = "DUMMY"
+    obs_var = var_name_web = model_var = "concno2"
     vert_code = "Surface"
 
     # we ignore here the fact that the data is monthly and for od550aer, the data is basically to be considered dummy
     # since we bypass the guards on frequency and variable, _calculate_fairmode will not question the data at this point
     # and treat it as if it's concno2 hourly
-    results = _calculate_fairmode(
+    _calculate_fairmode(
         data["monthly"],
         fairmode_statistics,
         exp_output,  #: ExperimentOutput,
@@ -439,19 +442,68 @@ def test_calculate_fairmode(eval_config: dict, caplog):
         use_meteorological_seasons=False,
     )
 
-    assert results["ALL"][f"{period}-{season}"]["Agoufou"]["station_type"] == np.str_(fake_type)
-    assert all(
-        results["ALL"][f"{period}-{season}"]["Agoufou"][item] == SPECIES["concno2"][item]
-        for item in ["freq", "alpha", "percentile", "RV", "UrRV"]
+    base_path = Path(
+        f"{eval_config['json_basedir']}/{eval_config['proj_id']}/{eval_config['exp_id']}/fairmode"
     )
-    assert all(
-        item in results["ALL"][f"{period}-{season}"]["Agoufou"]
-        for item in ["RMSU", "sign", "beta_mqi", "MPI_Hperc", "crms", "rms"]
-    )
+    f1 = base_path / f"ALL_{obs_name}_{model_var}_{vert_code}_{model_name}_{period}.json"
+    assert f1.is_file()
+    f2 = base_path / f"SAMERICA_{obs_name}_{model_var}_{vert_code}_{model_name}_{period}.json"
+    assert f2.is_file()
+    f3 = base_path / f"EUROPE_{obs_name}_{model_var}_{vert_code}_{model_name}_{period}.json"
+    assert f3.is_file()
+    f4 = base_path / f"CHINA_{obs_name}_{model_var}_{vert_code}_{model_name}_{period}.json"
+    assert f4.is_file()
+
+    with open(f1, encoding="utf-8") as infile:
+        results = json.load(infile)
+        assert results[obs_var][obs_name][vert_code][model_name][model_var][f"{period}-{season}"][
+            "Agoufou"
+        ]["station_type"] == np.str_(fake_type)
+        assert all(
+            results[obs_var][obs_name][vert_code][model_name][model_var][f"{period}-{season}"][
+                "Agoufou"
+            ][item]
+            == SPECIES["concno2"][item]
+            for item in ["freq", "alpha", "percentile", "RV", "UrRV"]
+        )
+        assert list(
+            results[obs_var][obs_name][vert_code][model_name][model_var][f"{period}-{season}"][
+                "Agoufou"
+            ].keys()
+        ) == [
+            "exceedances_obs",
+            "MPI_mean",
+            "MPI_R_t",
+            "MPI_bias_t",
+            "MPI_std_t",
+            "MPI_R_s",
+            "MPI_std_s",
+            "MPI_Hperc",
+            "fa",
+            "ma",
+            "gan",
+            "gap",
+            "bias",
+            "NMB",
+            "RMSU",
+            "sign",
+            "crms",
+            "rms",
+            "beta_mqi",
+            "persistence_model",
+            "station_type",
+            "UrRV",
+            "RV",
+            "alpha",
+            "freq",
+            "percentile",
+            "Np",
+            "Nnp",
+        ]
 
     wrongperiod = "2025"
     # here we pass the wrong period to test the case when the coldata subset fails
-    resultsempty = _calculate_fairmode(
+    _calculate_fairmode(
         data["monthly"],
         fairmode_statistics,
         exp_output,  #: ExperimentOutput,
@@ -461,13 +513,12 @@ def test_calculate_fairmode(eval_config: dict, caplog):
         model_name,
         model_var,
         map_meta,
-        "concno2",
+        obs_var,
         [wrongperiod],
         [season],
         use_meteorological_seasons=False,
     )
 
-    assert resultsempty == {"ALL": {}}
     assert (
         f"Failed to access subset coldata: No data available in period {wrongperiod}"
         in caplog.text

--- a/tests/aeroval/test_coldatatojson_helpers2.py
+++ b/tests/aeroval/test_coldatatojson_helpers2.py
@@ -6,6 +6,7 @@ import pytest
 import xarray
 
 from pyaerocom import ColocatedData, TsType
+from pyaerocom.aeroval import EvalSetup
 from pyaerocom.aeroval.coldatatojson_helpers import (
     _calculate_fairmode,
     _create_diurnal_weekly_data_object,
@@ -21,6 +22,7 @@ from pyaerocom.aeroval.coldatatojson_helpers import (
     _select_period_season_coldata,
 )
 from pyaerocom.aeroval.exceptions import TrendsError
+from pyaerocom.aeroval.experiment_output import ExperimentOutput
 from pyaerocom.aeroval.fairmode_statistics import SPECIES, FairmodeStatistics
 from pyaerocom.exceptions import TemporalResolutionError, UnknownRegion
 from tests.fixtures.collocated_data import COLDATA
@@ -406,12 +408,17 @@ def test_calculate_fairmode(eval_config: dict, caplog):
     (ts_objs, map_meta, site_indices) = _process_sites(data, None, "default", meta_glob)
 
     fairmode_statistics = FairmodeStatistics()
+    setup = EvalSetup(**eval_config)
+    exp_output = ExperimentOutput(setup)
 
     # fill nans
     np.nan_to_num(data["monthly"].data, copy=False, nan=1)
 
     period = "2010"
     season = "DJF"
+    model_name = "DUMMY"
+    obs_name = obs_var = var_name_web = model_var = "concno2"
+    vert_code = "Surface"
 
     # we ignore here the fact that the data is monthly and for od550aer, the data is basically to be considered dummy
     # since we bypass the guards on frequency and variable, _calculate_fairmode will not question the data at this point
@@ -419,8 +426,14 @@ def test_calculate_fairmode(eval_config: dict, caplog):
     results = _calculate_fairmode(
         data["monthly"],
         fairmode_statistics,
+        exp_output,  #: ExperimentOutput,
+        obs_name,
+        var_name_web,
+        vert_code,
+        model_name,
+        model_var,
         map_meta,
-        "concno2",
+        obs_var,
         [period],
         [season],
         use_meteorological_seasons=False,
@@ -441,6 +454,12 @@ def test_calculate_fairmode(eval_config: dict, caplog):
     resultsempty = _calculate_fairmode(
         data["monthly"],
         fairmode_statistics,
+        exp_output,  #: ExperimentOutput,
+        obs_name,
+        var_name_web,
+        vert_code,
+        model_name,
+        model_var,
         map_meta,
         "concno2",
         [wrongperiod],

--- a/tests/aeroval/test_fairmode_statistics.py
+++ b/tests/aeroval/test_fairmode_statistics.py
@@ -235,7 +235,7 @@ def test_save_fairmode_stats(
 
     fileout = (
         tmp_path
-        / f"{fairmode_exp_output.cfg.proj_id}/{fairmode_exp_output.cfg.exp_id}/fairmode/{list(fairmode_stats_example.keys())[0]}_{obs_name}_{var_name_web}_{vert_code}.json"
+        / f"{fairmode_exp_output.cfg.proj_id}/{fairmode_exp_output.cfg.exp_id}/fairmode/{list(fairmode_stats_example.keys())[0]}_{obs_name}_{var_name_web}_{vert_code}_{modelname}.json"
     )
     assert fileout.is_file()
 

--- a/tests/aeroval/test_fairmode_statistics.py
+++ b/tests/aeroval/test_fairmode_statistics.py
@@ -224,6 +224,7 @@ def test_save_fairmode_stats(
     modelname = "modelname"
     model_var = "modelvar"
     period = "2015"
+    region = "ALL"
     fairmode_statistics.save_fairmode_stats(
         fairmode_exp_output,
         fairmode_stats_example,
@@ -233,6 +234,7 @@ def test_save_fairmode_stats(
         modelname,
         model_var,
         period,
+        region,
     )
 
     fileout = (

--- a/tests/aeroval/test_fairmode_statistics.py
+++ b/tests/aeroval/test_fairmode_statistics.py
@@ -223,6 +223,7 @@ def test_save_fairmode_stats(
     vert_code = "Surface"
     modelname = "modelname"
     model_var = "modelvar"
+    period = "2015"
     fairmode_statistics.save_fairmode_stats(
         fairmode_exp_output,
         fairmode_stats_example,
@@ -231,11 +232,12 @@ def test_save_fairmode_stats(
         vert_code,
         modelname,
         model_var,
+        period,
     )
 
     fileout = (
         tmp_path
-        / f"{fairmode_exp_output.cfg.proj_id}/{fairmode_exp_output.cfg.exp_id}/fairmode/{list(fairmode_stats_example.keys())[0]}_{obs_name}_{var_name_web}_{vert_code}_{modelname}.json"
+        / f"{fairmode_exp_output.cfg.proj_id}/{fairmode_exp_output.cfg.exp_id}/fairmode/{list(fairmode_stats_example.keys())[0]}_{obs_name}_{var_name_web}_{vert_code}_{modelname}_{period}.json"
     )
     assert fileout.is_file()
 


### PR DESCRIPTION
## Change Summary

fairmode files are split by region and component at the moment which makes it for json files big enough to make the frontend slow in the generation of reports and loading of the target plots. splitting by model and period should improve performance.


## Related issue number

https://github.com/metno/pyaerocom/issues/1723

requires https://github.com/metno/aerovaldb/pull/146 to be merged for tests to pass

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
