### PR TITLE
Makes o3 resample as daily max instead of mean

### DIFF
--- a/pyaerocom/scripts/cams2_83/config.py
+++ b/pyaerocom/scripts/cams2_83/config.py
@@ -49,7 +49,7 @@ GLOBAL_CONFIG = dict(
     use_diurnal=False,
     # O3 is special, since we want to look at daily max
     # Here we say that we when O3(vmro3) is evaluated, the daily results will be the maximum for that day
-    resample_how={"vmro3": {"daily": {"hourly": "max"}}},
+    resample_how={"conco3": {"daily": {"hourly": "max"}}},
     # Assorted options, more info can be found in 'cfg_examples_examples1.py'
     # zeros_to_nan=False,
     zeros_to_nan=True,


### PR DESCRIPTION
## Change Summary

Makes o3 resample as daily max instead of mean. Done through an option in the config

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
