### PR TITLE
Reintroduce units_override logic.

### DIFF
--- a/pyaerocom/aeroval/_processing_base.py
+++ b/pyaerocom/aeroval/_processing_base.py
@@ -9,6 +9,8 @@ from pyaerocom.colocation.colocation_setup import ColocationSetup
 from pyaerocom.colocation.colocator import Colocator
 from attrs import define, field
 
+from pyaerocom.units.helpers import set_unit_overrides
+
 logger = logging.getLogger(__name__)
 
 
@@ -31,6 +33,7 @@ class HasConfig:
     avdb: aerovaldb.AerovalDB = field()
 
     def __init__(self, cfg: EvalSetup):
+        set_unit_overrides(cfg.units_cfg.units)
         self.cfg = cfg
         self.exp_output = ExperimentOutput(cfg)
         self.avdb = self.exp_output.avdb


### PR DESCRIPTION
## Change Summary

Reintroduces `set_units_override()` which was previously removed [here](https://github.com/metno/pyaerocom/commit/52817871cab391d675fb295edf7aa77fe8528abd). This is needed for the Zhu dataset.

## Related issue number

Probably closes https://github.com/metno/AeroToolsIssues/issues/115 but I want to double check before closing it.

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
