### PR TITLE
pm10 proxy variables x cams2_71

### DIFF
--- a/pyaerocom/__init__.py
+++ b/pyaerocom/__init__.py
@@ -29,7 +29,9 @@ from .config_reader import ConfigReader
 try:
     # Opt in to new defaults introduced by xarray 2025.08.0
     # https://docs.xarray.dev/en/stable/whats-new.html#v2025-08-0-august-14-2025
-    xarray.set_options(use_new_combine_kwarg_defaults=True)
+    xarray.set_options(
+        use_new_combine_kwarg_defaults=True, netcdf_engine_order=["netcdf4", "scipy", "h5netcdf"]
+    )
 except ValueError:
     # xarray < 2025.08.0 so doesn't apply.
     pass

--- a/pyaerocom/aeroval/data/var_web_info.ini
+++ b/pyaerocom/aeroval/data/var_web_info.ini
@@ -359,6 +359,21 @@ menu_name = PM<sub>10</sub>
 vertical_type = 3D
 category = Particle concentrations
 
+[proxyconcpm10dust]
+menu_name = PM<sub>10</sub> (Dust)
+vertical_type = 3D
+category = Particle concentrations
+
+[proxyconcpm10wf]
+menu_name = PM<sub>10</sub>(Wild Fires)
+vertical_type = 3D
+category = Particle concentrations
+
+[proxyconcpm10ss]
+menu_name = PM<sub>10</sub>(Sea Salt)
+vertical_type = 3D
+category = Particle concentrations
+
 [concpm10pbap]
 menu_name = PM<sub>10</sub> PBAP
 vertical_type = 3D

--- a/pyaerocom/aeroval/data/var_web_info.ini
+++ b/pyaerocom/aeroval/data/var_web_info.ini
@@ -365,12 +365,12 @@ vertical_type = 3D
 category = Particle concentrations
 
 [proxyconcpm10wf]
-menu_name = PM<sub>10</sub>(Wild Fires)
+menu_name = PM<sub>10</sub> (Wild Fires)
 vertical_type = 3D
 category = Particle concentrations
 
 [proxyconcpm10ss]
-menu_name = PM<sub>10</sub>(Sea Salt)
+menu_name = PM<sub>10</sub> (Sea Salt)
 vertical_type = 3D
 category = Particle concentrations
 

--- a/pyaerocom/data/variables.ini
+++ b/pyaerocom/data/variables.ini
@@ -92,7 +92,7 @@ var_name = od550aerh2o
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to water
 standard_name = atmosphere_optical_thickness_due_to_water_in_ambient_aerosol_particles
-only_use_in = maps.php
+only_use_in = maps
 var_name = proxyod550aerh2o
 
 [od550bc]
@@ -105,7 +105,7 @@ var_name = od550bc
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to elemental carbon
 standard_name = atmosphere_optical_thickness_due_to_elemental_carbon_ambient_aerosol_particles
-only_use_in = maps.php
+only_use_in = maps
 var_name = proxyod550bc
 
 [od550dust]
@@ -118,7 +118,7 @@ var_name = od550dust
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to dust
 standard_name = atmosphere_optical_thickness_due_to_dust_ambient_aerosol_particles
-only_use_in = maps.php
+only_use_in = maps
 var_name = proxyod550dust
 
 [od550nh4]
@@ -131,7 +131,7 @@ var_name = od550nh4
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to Ammonium
 standard_name = atmosphere_optical_thickness_due_to_ammonium_ambient_aerosol_particles
-only_use_in = maps.php
+only_use_in = maps
 var_name = proxyod550nh4
 
 [od550no3]
@@ -144,7 +144,7 @@ var_name = od550no3
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to Nitrate
 standard_name = atmosphere_optical_thickness_due_to_nitrate_ambient_aerosol_particles
-only_use_in = maps.php
+only_use_in = maps
 var_name = proxyod550no3
 
 [od550oa]
@@ -157,7 +157,7 @@ var_name = od550oa
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to organic matter
 standard_name = atmosphere_optical_thickness_due_to_particulate_organic_matter_ambient_aerosol_particles
-only_use_in = maps.php
+only_use_in = maps
 var_name = proxyod550oa
 
 [od550pm1]
@@ -206,7 +206,7 @@ var_name = od550so4
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to SO4
 standard_name = atmosphere_optical_thickness_due_to_sulfate_ambient_aerosol_particles
-only_use_in = maps.php
+only_use_in = maps
 var_name = proxyod550so4
 
 [od550ss]
@@ -219,7 +219,7 @@ var_name = od550ss
 use=od550aer
 description = Aerosol optical depth (AOD) at 550 nm due to sea salt
 standard_name = atmosphere_optical_thickness_due_to_seasalt_ambient_aerosol_particles
-only_use_in  = maps.php
+only_use_in  = maps
 var_name = proxyod550ss
 
 [od550lt1ss]
@@ -2906,21 +2906,21 @@ use=concpm10
 description = Mass concentration of aerosol pm10 from dust
 standard_name = mass_concentration_of_dust_in_air
 unit = ug m-3
-only_use_in = maps.php
+only_use_in = maps
 var_name = proxyconcpm10dust
 
 [proxyconcpm10ss]
 use=concpm10
 description = Mass concentration of aerosol pm10 from sea salt
 unit = ug m-3
-only_use_in = maps.php
+only_use_in = maps
 var_name = proxyconcpm10ss
 
 [proxyconcpm10wf]
 use=concpm10
 description = Mass concentration of aerosol pm10 from wild fires
 unit = ug m-3
-only_use_in = maps.php
+only_use_in = maps
 var_name = proxyconcpm10wf
 
 [concpm25]

--- a/pyaerocom/data/variables.ini
+++ b/pyaerocom/data/variables.ini
@@ -2901,6 +2901,28 @@ unit = ug m-3
 minimum = 0
 maximum = 1000
 
+[proxyconcpm10dust]
+use=concpm10
+description = Mass concentration of aerosol pm10 from dust
+standard_name = mass_concentration_of_dust_in_air
+unit = ug m-3
+only_use_in = maps.php
+var_name = proxyconcpm10dust
+
+[proxyconcpm10ss]
+use=concpm10
+description = Mass concentration of aerosol pm10 from sea salt
+unit = ug m-3
+only_use_in = maps.php
+var_name = proxyconcpm10ss
+
+[proxyconcpm10wf]
+use=concpm10
+description = Mass concentration of aerosol pm10 from wild fires
+unit = ug m-3
+only_use_in = maps.php
+var_name = proxyconcpm10wf
+
 [concpm25]
 description =Mass concentration of pm2.5
 standard_name = mass_concentration_of_pm2p5_ambient_aerosol_particles_in_air

--- a/pyaerocom/io/pyaro/postprocess.py
+++ b/pyaerocom/io/pyaro/postprocess.py
@@ -2,14 +2,13 @@ import dataclasses
 
 import numpy as np
 import numpy.typing as npt
-
 from pyaro.timeseries import (
-    Reader,
     Data,
+    Reader,
 )
 
+from pyaerocom.units.constants import M_N, M_O, M_S
 from pyaerocom.units.units_helpers import get_unit_conversion_fac
-from pyaerocom.units.constants import M_N, M_S, M_O
 
 
 @dataclasses.dataclass
@@ -44,6 +43,27 @@ class VariableCombiner:
 
 
 TRANSFORMATIONS = {
+    "proxyconcpm10dust_from_concpm10": VariableScaling(
+        REQ_VAR="concpm10",
+        IN_UNIT="ug m-3",
+        OUT_UNIT="ug m-3",
+        SCALING_FACTOR=1,
+        OUT_VARNAME="proxyconcpm10dust",
+    ),
+    "proxyconcpm10wf_from_concpm10": VariableScaling(
+        REQ_VAR="concpm10",
+        IN_UNIT="ug m-3",
+        OUT_UNIT="ug m-3",
+        SCALING_FACTOR=1,
+        OUT_VARNAME="proxyconcpm10wf",
+    ),
+    "proxyconcpm10ss_from_concpm10": VariableScaling(
+        REQ_VAR="concpm10",
+        IN_UNIT="ug m-3",
+        OUT_UNIT="ug m-3",
+        SCALING_FACTOR=1,
+        OUT_VARNAME="proxyconcpm10ss",
+    ),
     "concNno_from_concno": VariableScaling(
         REQ_VAR="concno",
         IN_UNIT="ug m-3",

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -17,7 +17,7 @@ dependencies:
   - requests
   - tqdm
   - openpyxl
-  - typer >=0.7.0
+  - typer >=0.19.2
   - pydantic ~= 2.7
   - pyproj >= 3.0.0
   - pooch >=1.7.0

--- a/pyaerocom_env.yml
+++ b/pyaerocom_env.yml
@@ -17,7 +17,7 @@ dependencies:
   - requests
   - tqdm
   - openpyxl
-  - typer >=0.19.2
+  - typer >=0.7.0
   - pydantic ~= 2.7
   - pyproj >= 3.0.0
   - pooch >=1.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "geocoder_reverse_natural_earth",
     "tqdm",
     "openpyxl",
-    "typer>=0.19.2",
+    "typer>=0.7.0",
     # python < 3.11
     'tomli>=2.0.1; python_version < "3.11"',
     'importlib-resources>=5.10; python_version < "3.11"',
@@ -239,7 +239,7 @@ deps =
     numpy ==1.25.0; python_version < "3.11"
     seaborn ==0.12.2; python_version < "3.11"
     geonum ==1.5.0; python_version < "3.11"
-    typer ==0.19.2; python_version < "3.11"
+    typer ==0.7.0; python_version < "3.11"
     tomli ==2.0.1; python_version < "3.11"
     importlib-resources ==5.10; python_version < "3.11"
     typing-extensions ==4.6.1; python_version < "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "geocoder_reverse_natural_earth",
     "tqdm",
     "openpyxl",
-    "typer>=0.7.0",
+    "typer>=0.19.2",
     # python < 3.11
     'tomli>=2.0.1; python_version < "3.11"',
     'importlib-resources>=5.10; python_version < "3.11"',
@@ -239,7 +239,7 @@ deps =
     numpy ==1.25.0; python_version < "3.11"
     seaborn ==0.12.2; python_version < "3.11"
     geonum ==1.5.0; python_version < "3.11"
-    typer ==0.7.0; python_version < "3.11"
+    typer ==0.19.2; python_version < "3.11"
     tomli ==2.0.1; python_version < "3.11"
     importlib-resources ==5.10; python_version < "3.11"
     typing-extensions ==4.6.1; python_version < "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,7 @@ deps =
     seaborn ==0.12.2; python_version < "3.11"
     geonum ==1.5.0; python_version < "3.11"
     typer ==0.7.0; python_version < "3.11"
+    click ==8.1.0; python_version < "3.11"
     tomli ==2.0.1; python_version < "3.11"
     importlib-resources ==5.10; python_version < "3.11"
     typing-extensions ==4.6.1; python_version < "3.11"


### PR DESCRIPTION
## Change Summary

- pm10-derived proxy variables added to pyaerocom as needed by cams2_71  
- `only_use_in =` syntax updated in variables.ini also for proxy variables already there

## Related issue number

closes #1733, #1735

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [x] Make PR ready to review
