### PR TITLE
fix cams2_83 reader test date 

### DIFF
--- a/tests/io/cams2_83/test_reader.py
+++ b/tests/io/cams2_83/test_reader.py
@@ -11,7 +11,7 @@ from pyaerocom.io.cams2_83.reader import AEROCOM_NAMES, DATA_FOLDER_PATH
 from pyaerocom.io.cams2_83.reader import model_paths as find_model_paths
 from pyaerocom.io.cams2_83.reader import read_dataset
 
-TEST_DATE = datetime(2021, 12, 1)
+TEST_DATE = datetime(2024, 12, 1)
 TEST_DATES = [TEST_DATE + timedelta(days=d) for d in range(3)]
 
 


### PR DESCRIPTION
## Change Summary

update date used in test, since 2021 model data has been deleted


## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
