### PR TITLE
try to fix for good cumulation of periods  in the map files

### DIFF
--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1028,7 +1028,7 @@ def _process_map_and_scat(
     stats_dummy = _init_stats_dummy(drop_stats=drop_stats)
     scat_data = {}
     scat_dummy = [np.nan]
-    new_map_data = deepcopy(map_meta)
+    map_data = deepcopy(map_meta)
     for freq, cd in data.items():
         for per in periods:
             for season in seasons:
@@ -1044,7 +1044,7 @@ def _process_map_and_scat(
                         logger.warning(f"Could not process data: {e}")
                         continue
 
-                for i, map_stat in zip(site_indices, new_map_data):
+                for i, map_stat in zip(site_indices, map_data):
                     if freq not in map_stat:
                         map_stat[freq] = {}
 
@@ -1122,7 +1122,7 @@ def _process_map_and_scat(
                             "units": units,
                         }
 
-    return (new_map_data, scat_data)
+    return (map_data, scat_data)
 
 
 def _process_regional_timeseries(data, region_ids, regions_how, meta_glob):

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1040,8 +1040,9 @@ def _process_map_and_scat(
                         )
                         jsdate = subset.data.jsdate.values.tolist()
                         use_dummy = False
-                    except (DataCoverageError, TemporalResolutionError):
-                        pass
+                    except (DataCoverageError, TemporalResolutionError) as e:
+                        logger.warning(f"Could not process period {per}: {e}")
+                        continue
 
                 for i, map_stat in zip(site_indices, map_data):
                     if freq not in map_stat:
@@ -1121,7 +1122,7 @@ def _process_map_and_scat(
                             "units": units,
                         }
 
-                    new_map_data.append(map_stat)
+                    new_map_data.append(deepcopy(map_stat))
 
     return (new_map_data, scat_data)
 

--- a/pyaerocom/aeroval/coldatatojson_helpers.py
+++ b/pyaerocom/aeroval/coldatatojson_helpers.py
@@ -1011,7 +1011,7 @@ def _make_trends(obs_vals, mod_vals, time, freq, season, start, stop, min_yrs):
 
 def _process_map_and_scat(
     data: dict[str, ColocatedData | None],
-    map_data: list[dict],
+    map_meta: list[dict],
     site_indices: list[int],
     periods: list[str],
     scatter_freq: str,
@@ -1028,7 +1028,7 @@ def _process_map_and_scat(
     stats_dummy = _init_stats_dummy(drop_stats=drop_stats)
     scat_data = {}
     scat_dummy = [np.nan]
-    new_map_data: list[dict] = []
+    new_map_data = deepcopy(map_meta)
     for freq, cd in data.items():
         for per in periods:
             for season in seasons:
@@ -1041,10 +1041,10 @@ def _process_map_and_scat(
                         jsdate = subset.data.jsdate.values.tolist()
                         use_dummy = False
                     except (DataCoverageError, TemporalResolutionError) as e:
-                        logger.warning(f"Could not process period {per}: {e}")
+                        logger.warning(f"Could not process data: {e}")
                         continue
 
-                for i, map_stat in zip(site_indices, map_data):
+                for i, map_stat in zip(site_indices, new_map_data):
                     if freq not in map_stat:
                         map_stat[freq] = {}
 
@@ -1121,8 +1121,6 @@ def _process_map_and_scat(
                             "date": jsdate,
                             "units": units,
                         }
-
-                    new_map_data.append(deepcopy(map_stat))
 
     return (new_map_data, scat_data)
 


### PR DESCRIPTION
## Change Summary
The map files redundancy is still not fixed, as running IFS_new made clear, example: 
```
-rw-rw-r-- 1 ubuntu ubuntu   41M Oct 17 19:21 AirNow_vmro3_Surface_IFS-OSUITE_vmro3_2013-2025.json
-rw-rw-r-- 1 ubuntu ubuntu  110M Oct 17 19:21 AirNow_vmro3_Surface_IFS-OSUITE_vmro3_2013.json
-rw-rw-r-- 1 ubuntu ubuntu  147M Oct 17 19:21 AirNow_vmro3_Surface_IFS-OSUITE_vmro3_2014.json
-rw-rw-r-- 1 ubuntu ubuntu  184M Oct 17 19:21 AirNow_vmro3_Surface_IFS-OSUITE_vmro3_2015.json
-rw-rw-r-- 1 ubuntu ubuntu  220M Oct 17 19:21 AirNow_vmro3_Surface_IFS-OSUITE_vmro3_2016.json
-rw-rw-r-- 1 ubuntu ubuntu  257M Oct 17 19:22 AirNow_vmro3_Surface_IFS-OSUITE_vmro3_2017.json
-rw-rw-r-- 1 ubuntu ubuntu  294M Oct 17 19:22 AirNow_vmro3_Surface_IFS-OSUITE_vmro3_2018.json
-rw-rw-r-- 1 ubuntu ubuntu  330M Oct 17 19:22 AirNow_vmro3_Surface_IFS-OSUITE_vmro3_2019.json
-rw-rw-r-- 1 ubuntu ubuntu  367M Oct 17 19:22 AirNow_vmro3_Surface_IFS-OSUITE_vmro3_2020.json
-rw-rw-r-- 1 ubuntu ubuntu  403M Oct 17 19:22 AirNow_vmro3_Surface_IFS-OSUITE_vmro3_2021.json
```
the current code in main-dev after the first fix attempt #1730 actually makes the problem worse (even more redundancy)

this PR aims at fixing it for good

the object containing the list of dictionaries w stations metadata is now deepcopied at the very start of the `_process_map_and_scat` function to a fresh new object that will actually be modified and have its [freq][perstr] fields populated station by station, and will be returned by the function  
since the function is passed a `periods` argument that is just one period at a time, and its return goes straight into aerovaldb, this successfully writes `map` files that contain only data relative to each period

## Related issue number
closes #1726

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
