### PR TITLE
Add functions needed to evaluate so2 from EEA and CNEMC

### DIFF
--- a/pyaerocom/io/cnemc/aux_vars.py
+++ b/pyaerocom/io/cnemc/aux_vars.py
@@ -28,3 +28,7 @@ def vmro3max_from_ds(ds: xr.Dataset) -> xr.DataArray:
 
 def vmrno2_from_ds(ds: xr.Dataset) -> xr.DataArray:
     return conc_to_vmr(ds["concno2"], vmr="vmrno2")
+
+
+def vmrso2_from_ds(ds: xr.Dataset) -> xr.DataArray:
+    return conc_to_vmr(ds["concso2"], vmr="vmrso2")

--- a/pyaerocom/io/cnemc/reader.py
+++ b/pyaerocom/io/cnemc/reader.py
@@ -14,7 +14,7 @@ from pyaerocom.io.readungriddedbase import ReadUngriddedBase
 from pyaerocom.stationdata import StationData
 from pyaerocom.ungriddeddata import UngriddedData
 
-from .aux_vars import vmrno2_from_ds, vmro3_from_ds, vmro3max_from_ds
+from .aux_vars import vmrso2_from_ds, vmrno2_from_ds, vmro3_from_ds, vmro3max_from_ds
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +83,7 @@ class ReadCNEMC(ReadUngriddedBase):
         "vmro3": vmro3_from_ds,
         "vmro3max": vmro3max_from_ds,
         "vmrno2": vmrno2_from_ds,
+        "vmrso2": vmrso2_from_ds,
     }
 
     VAR_MAPPING = {

--- a/pyaerocom/io/pyaro/postprocess.py
+++ b/pyaerocom/io/pyaro/postprocess.py
@@ -109,6 +109,14 @@ TRANSFORMATIONS = {
         OUT_VARNAME="vmrno2",
         NOTE="The vmrno2_from_concno2 transform is only valid at T=20C, p=1013hPa",
     ),
+    "vmrso2_from_concso2": VariableScaling(
+        REQ_VAR="concso2",
+        IN_UNIT="ug m-3",
+        OUT_UNIT="ppb",
+        SCALING_FACTOR=0.3758,  # 20C and 1013 hPa
+        OUT_VARNAME="vmrso2",
+        NOTE="The vmrso2_from_concso2 transform is only valid at T=20C, p=1013hPa",
+    ),
     "vmrox_from_vmrno2_vmro3": VariableCombiner(
         REQ_VARS=("vmrno2", "vmro3"),
         IN_UNITS=("nmol mol-1", "nmol mol-1"),

--- a/pyaerocom/io/pyaro/postprocess.py
+++ b/pyaerocom/io/pyaro/postprocess.py
@@ -107,7 +107,7 @@ TRANSFORMATIONS = {
         OUT_UNIT="ppb",
         SCALING_FACTOR=0.5229,  # 20C and 1013 hPa
         OUT_VARNAME="vmrno2",
-        NOTE="The vmrno2_from_conco3 transform is only valid at T=20C, p=1013hPa",
+        NOTE="The vmrno2_from_concno2 transform is only valid at T=20C, p=1013hPa",
     ),
     "vmrox_from_vmrno2_vmro3": VariableCombiner(
         REQ_VARS=("vmrno2", "vmro3"),

--- a/tests/io/cnemc/test_reader.py
+++ b/tests/io/cnemc/test_reader.py
@@ -9,7 +9,7 @@ from pyaerocom.io.cnemc.reader import ReadCNEMC
 
 STATION_NAMES = ("1478A", "2706A", "3377A")
 VARS_DEFAULT = {"concco", "concno2", "conco3", "concpm10", "concpm25", "concso2"}
-VARS_PROVIDED = VARS_DEFAULT | {"vmro3", "vmro3max", "vmrno2"}
+VARS_PROVIDED = VARS_DEFAULT | {"vmro3", "vmro3max", "vmrno2", "vmrso2"}
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Change Summary

- added vmrso2_from_concso2 
- added vmrso2_from_ds 


## Related issue number

closes #1760

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
