### PR TITLE
Fix filters

### DIFF
--- a/pyaerocom/aeroval/config/emep/reporting_base.py
+++ b/pyaerocom/aeroval/config/emep/reporting_base.py
@@ -6,8 +6,11 @@ import copy
 import functools
 import logging
 import os
+import fnmatch
 
 import yaml
+
+import configparser
 
 from pyaerocom.data import resources
 
@@ -15,6 +18,45 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_OMIT_STATION_PATH = "./omit_stations.yaml"
+
+EXTRA_EBAS_SPECIES = [
+    "concNhno3",
+    "concNtno3",
+    "concNtnh",
+    "concNnh3",
+    "concnh4",
+    "prmm",
+    "concpm10",
+    "concpm25",
+    "concSso2",
+    "concNno2",
+    "vmrco",
+    "vmro3max",
+    "vmro3",
+    "concNno",
+    "concCecpm25",
+    "concCocpm25",
+    "concom1",
+    "concCecpm10",
+    "concCocpm10",
+    #        "concnh4pm10", # no output in the model
+    "concnh4pm25",
+    "concnh4pm1",
+    #        "concso4pm10", # no output in the model
+    "concso4pm25",
+    "concso4pm1",
+    "concno3pm10",
+    "concno3pm25",
+    "concno3pm1",
+    "concsspm10",
+    "concsspm25",
+    "concso4t",
+    "concso4c",
+    "wetoxs",
+    "wetoxn",
+    "wetrdn",
+    "vmrox",
+]
 
 
 # Constraints
@@ -88,6 +130,36 @@ def _get_ignore_stations(specy, year, omit_stations_path):
             if yearstart <= year <= yearend:
                 retvals.append(station)
     return retvals
+
+
+def _get_ebas_species():
+    with resources.path(__package__, "../../../data/ebas_config.ini") as filename:
+        config = configparser.ConfigParser()
+        config.read(filename.resolve())
+        ebas_species = config.sections()
+    complete_list = ebas_species + EXTRA_EBAS_SPECIES
+    return list(set(complete_list))
+
+
+def clean_filters(cfg: dict, obs_pattern: str) -> dict:
+    CFG = copy.deepcopy(cfg)
+
+    for network in CFG["obs_cfg"]:
+        if fnmatch.fnmatchcase(network, obs_pattern):
+            vs = CFG["obs_cfg"][network]["obs_vars"]
+            new_filters = {}
+            for v in vs:
+                if v not in CFG["obs_cfg"][network]["obs_filters"]:
+                    raise KeyError(f"Could not find filter for {v}")
+                new_filters[v] = CFG["obs_cfg"][network]["obs_filters"][v]
+
+            CFG["obs_cfg"][network]["obs_filters"] = copy.deepcopy(new_filters)
+            assert (
+                list(CFG["obs_cfg"][network]["obs_filters"].keys())
+                == CFG["obs_cfg"][network]["obs_vars"]
+            )
+
+    return CFG
 
 
 def get_CFG(reportyear, year, model_dir, omit_stations_path=DEFAULT_OMIT_STATION_PATH) -> dict:
@@ -456,45 +528,6 @@ def get_CFG(reportyear, year, model_dir, omit_stations_path=DEFAULT_OMIT_STATION
 
     # Station filters
 
-    ebas_species = [
-        "concNhno3",
-        "concNtno3",
-        "concNtnh",
-        "concNnh3",
-        "concnh4",
-        "prmm",
-        "concpm10",
-        "concpm25",
-        "concSso2",
-        "concNno2",
-        "vmrco",
-        "vmro3max",
-        "vmro3",
-        "concNno",
-        "concCecpm25",
-        "concCocpm25",
-        "concom1",
-        "concCecpm10",
-        "concCocpm10",
-        #        "concnh4pm10", # no output in the model
-        "concnh4pm25",
-        "concnh4pm1",
-        #        "concso4pm10", # no output in the model
-        "concso4pm25",
-        "concso4pm1",
-        "concno3pm10",
-        "concno3pm25",
-        "concno3pm1",
-        "concsspm10",
-        "concsspm25",
-        "concso4t",
-        "concso4c",
-        "wetoxs",
-        "wetoxn",
-        "wetrdn",
-        "vmrox",
-    ]
-
     # This list of stations was generated using the script found here:
     # https://gist.github.com/thorbjoernl/b7946882f1696722742053406d056e12.
     # It excludes stations with a relative altitude (Elevation difference to the lowest
@@ -617,7 +650,7 @@ def get_CFG(reportyear, year, model_dir, omit_stations_path=DEFAULT_OMIT_STATION
             station_id=_get_ignore_stations(key, year, omit_stations_path) + height_ignore_ebas,
             negate="station_id",
         )
-        for key in ebas_species
+        for key in _get_ebas_species()
     }
 
     EEA_FILTER = {

--- a/tests/aeroval/test_aeroval_config_emep.py
+++ b/tests/aeroval/test_aeroval_config_emep.py
@@ -1,5 +1,5 @@
 from pyaerocom.aeroval import EvalSetup
-from pyaerocom.aeroval.config.emep.reporting_base import get_CFG
+from pyaerocom.aeroval.config.emep.reporting_base import get_CFG, clean_filters
 
 
 def test_aeroval_config_emep():
@@ -36,3 +36,34 @@ def test_aeroval_config_emep():
     assert stp.periods == ["2021"]
     assert stp.exp_pi == "S. Tsyro, A. Nyiri, H. Klein"
     assert stp.proj_id == "emep"
+
+
+def test_aeroval_config_emep_clean_filters():
+    # Setup for models used in analysis
+    CFG = get_CFG(
+        reportyear=2024,
+        year=2021,
+        model_dir="/lustre/storeB/project/fou/kl/emep/ModelRuns/2024_REPORTING/EMEP01_rv5.3_metyear2021_emis2022",
+    )
+
+    CFG.update(
+        dict(
+            exp_id="test-2021met_2022emis",
+            exp_name="Test runs for 2024 EMEP reporting",
+            exp_descr=(
+                "Test run from Agnes for 2024_REPORTING/EMEP01_rv5.3_metyear2021_emis2022, i.e. 2021met and 2022emis"
+            ),
+            exp_pi="S. Tsyro, A. Nyiri, H. Klein",
+        )
+    )
+
+    CFG_clean = clean_filters(CFG, "EBAS-d-tc")
+
+    assert (
+        list(CFG_clean["obs_cfg"]["EBAS-d-tc"]["obs_filters"].keys())
+        == CFG_clean["obs_cfg"]["EBAS-d-tc"]["obs_vars"]
+    )
+
+    assert len(list(CFG["obs_cfg"]["EBAS-d-tc"]["obs_filters"].keys())) > len(
+        list(CFG_clean["obs_cfg"]["EBAS-d-tc"]["obs_filters"].keys())
+    )


### PR DESCRIPTION
## Change Summary

Makes so all ebas species are used to make filters in get_CFG. Adds a clean_filters function that removes all filters for species which are not used in the network. This function is optional, and used if one wants a cleaner output cfg file. Must be called after all species are added

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
