### PR TITLE
Fix 1770

### DIFF
--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -780,7 +780,7 @@ class ExperimentOutput(ProjectOutput):
                     )
                     if not first_with_mod_name:  # should already be taken care of in new
                         continue
-                    obs_name = first_with_mod_name[0]
+                    obs_name = self.cfg.obs_cfg.get_entry(first_with_mod_name[0]).obs_name
                     all_combinations.remove(first_with_mod_name)
                 else:
                     logger.warning(

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -764,8 +764,8 @@ class ExperimentOutput(ProjectOutput):
                         if var in self.cfg.obs_cfg.get_entry(o).obs_vars:
                             vert_code = self.cfg.obs_cfg.get_entry(o).obs_vert_type
                     if not vert_code:
-                        if var == "conco3mda8":
-                            vert_code = "Surface"
+                        if var == "conco3mda8":  # computation happened in the map engine
+                            vert_code = self.cfg.obs_cfg.get_entry("conco3").obs_vert_type
                         else:
                             raise ValueError(
                                 "Failed to infer vert_code in an only_model_maps experiment"

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -764,9 +764,12 @@ class ExperimentOutput(ProjectOutput):
                         if var in self.cfg.obs_cfg.get_entry(o).obs_vars:
                             vert_code = self.cfg.obs_cfg.get_entry(o).obs_vert_type
                     if not vert_code:
-                        raise ValueError(
-                            "Failed to infer vert_code in an only_model_maps experiment"
-                        )
+                        if var == "conco3mda8":
+                            vert_code = "Surface"
+                        else:
+                            raise ValueError(
+                                "Failed to infer vert_code in an only_model_maps experiment"
+                            )
                     first_with_mod_name = next(
                         (
                             item

--- a/pyaerocom/aeroval/experiment_output.py
+++ b/pyaerocom/aeroval/experiment_output.py
@@ -765,7 +765,9 @@ class ExperimentOutput(ProjectOutput):
                             vert_code = self.cfg.obs_cfg.get_entry(o).obs_vert_type
                     if not vert_code:
                         if var == "conco3mda8":  # computation happened in the map engine
-                            vert_code = self.cfg.obs_cfg.get_entry("conco3").obs_vert_type
+                            vert_code = self.cfg.obs_cfg.get_entry(
+                                self.cfg.obs_cfg.keylist()[0]
+                            ).obs_vert_type
                         else:
                             raise ValueError(
                                 "Failed to infer vert_code in an only_model_maps experiment"

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -184,49 +184,60 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
             cmapinfo = var_ranges_defaults["default"]
             varinfo = VarinfoWeb(var, cmap=cmapinfo["colmap"], cmap_bins=cmapinfo["scale"])
 
-        data = self._check_dimensions(data)
+        if var == "conco3" and isinstance(data, list):
+            datalist = data
+        else:
+            datalist = [data]
 
-        freq = self._get_maps_freq()
-        tst = TsType(data.ts_type)
+        idx = 0
+        for data in datalist:
+            data = self._check_dimensions(data)
 
-        if tst < freq:
-            raise TemporalResolutionError(f"need {freq} or higher, got{tst}")
-        elif tst > freq:
-            data = data.resample_time(str(freq))
+            freq = self._get_maps_freq()
+            tst = TsType(data.ts_type)
 
-        data.check_unit()
+            if tst < freq:
+                raise TemporalResolutionError(f"need {freq} or higher, got{tst}")
+            elif tst > freq:
+                data = data.resample_time(str(freq))
 
-        if not reanalyse_existing:
-            # check if all files have already been produced
-            # if even just one is missing, all is gonna be recomputed
-            ts = _jsdate_list(data)
+            data.check_unit()
 
-            uris_contour = self.avdb.query(
-                aerovaldb.routes.Route.CONTOUR_TIMESPLIT,
-                project=self.exp_output.proj_id,
-                experiment=self.exp_output.exp_id,
-            )
-            all_times = [int(uri.meta["timestep"]) for uri in uris_contour]
+            if not reanalyse_existing:
+                # check if all files have already been produced
+                # if even just one is missing, all is gonna be recomputed
+                ts = _jsdate_list(data)
 
-            if all([date in all_times for date in ts]):
-                logger.info(
-                    f"Skipping contour processing of {var}_{model_name}: data already exists {uris_contour}."
+                uris_contour = self.avdb.query(
+                    aerovaldb.routes.Route.CONTOUR_TIMESPLIT,
+                    project=self.exp_output.proj_id,
+                    experiment=self.exp_output.exp_id,
                 )
-                return
+                all_times = [int(uri.meta["timestep"]) for uri in uris_contour]
 
-        # first calculate and save geojson with contour levels
-        contourjson = calc_contour_json(data, cmap=varinfo.cmap, cmap_bins=varinfo.cmap_bins)
+                if all([date in all_times for date in ts]):
+                    logger.info(
+                        f"Skipping contour processing of {var}_{model_name}: data already exists {uris_contour}."
+                    )
+                    return
 
-        with self.avdb.lock():
-            for time, contour in contourjson.items():
-                self.avdb.put_contour(
-                    contour,
-                    self.exp_output.proj_id,
-                    self.exp_output.exp_id,
-                    self.cfg.model_cfg.get_entry(model_name).model_rename_vars.get(var, var),
-                    model_name,
-                    timestep=time,
-                )
+            # first calculate and save geojson with contour levels
+            contourjson = calc_contour_json(data, cmap=varinfo.cmap, cmap_bins=varinfo.cmap_bins)
+
+            if idx == 1:  # it's conco3mda8
+                var = "conco3mda8"
+            with self.avdb.lock():
+                for time, contour in contourjson.items():
+                    self.avdb.put_contour(
+                        contour,
+                        self.exp_output.proj_id,
+                        self.exp_output.exp_id,
+                        self.cfg.model_cfg.get_entry(model_name).model_rename_vars.get(var, var),
+                        model_name,
+                        timestep=time,
+                    )
+
+            idx += 1
 
     def _process_overlay_map_var(self, model_name, var, reanalyse_existing):  # pragma: no cover
         """Process overlay map (pixels) for either model or obserations
@@ -383,7 +394,9 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         logger.info(f"Found coarsest freq available as model data: {freq}")
         return freq
 
-    def _read_model_data(self, model_name: str, var: str) -> GriddedDataContainer:
+    def _read_model_data(
+        self, model_name: str, var: str
+    ) -> GriddedDataContainer | list[GriddedDataContainer]:
         """
         Function for reading the model data without going through the colocation object.
         This means that none of the checks normally done in the colocation class are run.
@@ -452,11 +465,17 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                     self.cfg.colocation_opts.ts_type
                 )  # emulates the old way closer than None
 
+        if var == "conco3":
+            conco3mda8formaps = True
+        else:
+            conco3mda8formaps = False
+
         data = reader.read_var(
             var,
             start=start,
             stop=stop,
             ts_type=ts_type_read,
+            conco3mda8formaps=conco3mda8formaps,
             vert_which=self.cfg.colocation_opts.obs_vert_type,
             flex_ts_type=self.cfg.colocation_opts.flex_ts_type,
             **kwargs,
@@ -464,6 +483,10 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
 
         rm_outliers = self.cfg.colocation_opts.model_remove_outliers
         outlier_ranges = self.cfg.colocation_opts.model_outlier_ranges
+
+        if conco3mda8formaps:
+            datao3mda8 = data[1]
+            data = data[0]
 
         if rm_outliers:
             if var in outlier_ranges:
@@ -473,9 +496,15 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                 low, high = var_info.minimum, var_info.maximum
 
             data.remove_outliers(low, high, inplace=True)
+            if conco3mda8formaps:
+                datao3mda8.remove_outliers(low, high, inplace=True)
 
         data.convert_unit(get_standard_unit(data.var_name))
-        return data
+        if conco3mda8formaps:
+            datao3mda8.convert_unit(get_standard_unit(data.var_name))
+            return [data, datao3mda8]
+        else:
+            return data
 
     def _check_ts_for_only_model_maps(
         self, name: str, var: str, dates: list[int], data: xr.Dataset

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -667,9 +667,3 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
         data = data.transpose("time", "latitude", "longitude")
         data = data.sortby(["latitude", "longitude"])
         return data
-        coldata = ColocatedData(data=file_to_convert[0])
-        data = coldata.data.sel(data_source=model_name)
-        data = data.drop_vars("data_source")
-        data = data.transpose("time", "latitude", "longitude")
-        data = data.sortby(["latitude", "longitude"])
-        return data

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -1,5 +1,6 @@
 import glob
 import logging
+from datetime import datetime, timedelta
 
 import aerovaldb
 import xarray as xr
@@ -236,6 +237,10 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
 
             with self.avdb.lock():
                 for time, contour in contourjson.items():
+                    if var == "conco3mda8":
+                        # we need to shift 1 h because the frontend expects coherence with the timeseries in ts, which have 13:00 as hour
+                        newtime = datetime.fromtimestamp(int(time) / 1000) + timedelta(hours=1)
+                        time = str(int(newtime.timestamp() * 1000))
                     self.avdb.put_contour(
                         contour,
                         self.exp_output.proj_id,

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -4,7 +4,14 @@ import logging
 import aerovaldb
 import xarray as xr
 
-from pyaerocom import ColocatedData, GriddedData, GriddedDataContainer, TsType, __version__, const
+from pyaerocom import (
+    ColocatedData,
+    GriddedData,
+    GriddedDataContainer,
+    TsType,
+    __version__,
+    const,
+)
 from pyaerocom.aeroval._processing_base import DataImporter, ProcessingEngine
 from pyaerocom.aeroval.json_utils import round_floats
 from pyaerocom.aeroval.modelmaps_helpers import (
@@ -28,7 +35,6 @@ from pyaerocom.exceptions import (
     VarNotAvailableError,
 )
 from pyaerocom.units.helpers import get_standard_unit
-
 
 logger = logging.getLogger(__name__)
 
@@ -176,21 +182,25 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                 f"Cannot read data for model {model_name} (variable {var}): {e}"
             )
 
-        var_ranges_defaults = self.cfg.var_scale_colmap
-        if var in var_ranges_defaults.keys():
-            cmapinfo = var_ranges_defaults[var]
-            varinfo = VarinfoWeb(var, cmap=cmapinfo["colmap"], cmap_bins=cmapinfo["scale"])
-        else:
-            cmapinfo = var_ranges_defaults["default"]
-            varinfo = VarinfoWeb(var, cmap=cmapinfo["colmap"], cmap_bins=cmapinfo["scale"])
-
         if var == "conco3" and isinstance(data, list):
             datalist = data
         else:
             datalist = [data]
 
+        var_ranges_defaults = self.cfg.var_scale_colmap
+
         idx = 0
         for data in datalist:
+            if idx == 1:  # it's conco3mda8
+                var = "conco3mda8"
+
+            if var in var_ranges_defaults.keys():
+                cmapinfo = var_ranges_defaults[var]
+                varinfo = VarinfoWeb(var, cmap=cmapinfo["colmap"], cmap_bins=cmapinfo["scale"])
+            else:
+                cmapinfo = var_ranges_defaults["default"]
+                varinfo = VarinfoWeb(var, cmap=cmapinfo["colmap"], cmap_bins=cmapinfo["scale"])
+
             data = self._check_dimensions(data)
 
             freq = self._get_maps_freq()
@@ -224,8 +234,6 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
             # first calculate and save geojson with contour levels
             contourjson = calc_contour_json(data, cmap=varinfo.cmap, cmap_bins=varinfo.cmap_bins)
 
-            if idx == 1:  # it's conco3mda8
-                var = "conco3mda8"
             with self.avdb.lock():
                 for time, contour in contourjson.items():
                     self.avdb.put_contour(
@@ -646,6 +654,12 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                 "whereas the coldata_dir does not."
             )
 
+        coldata = ColocatedData(data=file_to_convert[0])
+        data = coldata.data.sel(data_source=model_name)
+        data = data.drop_vars("data_source")
+        data = data.transpose("time", "latitude", "longitude")
+        data = data.sortby(["latitude", "longitude"])
+        return data
         coldata = ColocatedData(data=file_to_convert[0])
         data = coldata.data.sel(data_source=model_name)
         data = data.drop_vars("data_source")

--- a/pyaerocom/aeroval/modelmaps_engine.py
+++ b/pyaerocom/aeroval/modelmaps_engine.py
@@ -478,28 +478,30 @@ class ModelMapsEngine(ProcessingEngine, DataImporter):
                     self.cfg.colocation_opts.ts_type
                 )  # emulates the old way closer than None
 
-        if var == "conco3":
-            conco3mda8formaps = True
-        else:
-            conco3mda8formaps = False
-
         data = reader.read_var(
             var,
             start=start,
             stop=stop,
             ts_type=ts_type_read,
-            conco3mda8formaps=conco3mda8formaps,
             vert_which=self.cfg.colocation_opts.obs_vert_type,
             flex_ts_type=self.cfg.colocation_opts.flex_ts_type,
+            from_map_engine=True,
             **kwargs,
         )
 
         rm_outliers = self.cfg.colocation_opts.model_remove_outliers
         outlier_ranges = self.cfg.colocation_opts.model_outlier_ranges
 
-        if conco3mda8formaps:
-            datao3mda8 = data[1]
-            data = data[0]
+        conco3mda8formaps = False
+        if var == "conco3" and isinstance(data, list):
+            try:
+                datao3mda8 = data[1]
+                data = data[0]
+                conco3mda8formaps = True
+            except IndexError as e:
+                logger.error(
+                    f"Reader is expected to return a list with data for o3 and o3mda8 in this case: {e}"
+                )
 
         if rm_outliers:
             if var in outlier_ranges:

--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -451,7 +451,6 @@ class ReadCAMS2_83(GriddedReader):
 
         if conco3mda8formaps and var_name == "conco3" and ts_type == "hourly":
             ds = self.filedata[var_name].copy()
-            breakpoint()
             o3mda8 = (
                 ds.rolling(time=8, center=False, min_periods=6)
                 .mean("time")

--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -14,6 +14,7 @@ from tqdm import tqdm
 from pyaerocom.griddeddata import GriddedData
 from pyaerocom.io.cams2_83.models import ModelData, ModelName, RunType
 from pyaerocom.io.gridded_reader import GriddedReader
+from pyaerocom.stats.mda8.mda8 import min_periods_max
 
 """
 TODO:
@@ -450,11 +451,12 @@ class ReadCAMS2_83(GriddedReader):
 
         if conco3mda8formaps and var_name == "conco3" and ts_type == "hourly":
             ds = self.filedata[var_name].copy()
+            breakpoint()
             o3mda8 = (
-                ds.rolling(time=8, min_periods=6)
+                ds.rolling(time=8, center=False, min_periods=6)
                 .mean("time")
-                .resample(time="D")
-                .max()
+                .resample(time="24h", origin="start_day", label="left", offset="1h")
+                .reduce(lambda x, axis: np.apply_along_axis(min_periods_max, 0, x, min_periods=18))
                 .rename("conco3mda8")
                 .assign_attrs(
                     long_name="conco3mda8",

--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -462,6 +462,9 @@ class ReadCAMS2_83(GriddedReader):
                     species="O3 MDA8",
                 )
             )
+            o3mda8.coords.update(
+                {"time": o3mda8.get_index("time") + pd.tseries.frequencies.to_offset("12h")}
+            )
             cubeo3mda8 = o3mda8.to_iris()
             griddedo3mda8 = GriddedData(
                 cubeo3mda8,

--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -412,7 +412,9 @@ class ReadCAMS2_83(GriddedReader):
         """
         return var_name in AEROCOM_NAMES.values()
 
-    def read_var(self, var_name: str, ts_type: str | None = None, **kwargs) -> GriddedData:
+    def read_var(
+        self, var_name: str, ts_type: str | None = None, conco3mda8formaps: bool = False, **kwargs
+    ) -> GriddedData | list[GriddedData]:
         """Load data for given variable.
 
         Parameters
@@ -445,7 +447,32 @@ class ReadCAMS2_83(GriddedReader):
             convert_unit_on_init=True,
         )
         gridded.metadata["data_id"] = self.data_id
-        return gridded
+
+        if conco3mda8formaps and var_name == "conco3" and ts_type == "hourly":
+            ds = self.filedata[var_name].copy()
+            o3mda8 = (
+                ds.rolling(time=8, min_periods=6)
+                .mean("time")
+                .resample(time="D")
+                .max()
+                .rename("conco3mda8")
+                .assign_attrs(
+                    long_name="conco3mda8",
+                    species="O3 MDA8",
+                )
+            )
+            cubeo3mda8 = o3mda8.to_iris()
+            griddedo3mda8 = GriddedData(
+                cubeo3mda8,
+                var_name="conco3mda8",
+                ts_type=ts_type,
+                check_unit=True,
+                convert_unit_on_init=True,
+            )
+            griddedo3mda8.metadata["data_id"] = self.data_id
+            return gridded, griddedo3mda8
+        else:
+            return gridded
 
 
 if __name__ == "__main__":

--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -414,7 +414,7 @@ class ReadCAMS2_83(GriddedReader):
         return var_name in AEROCOM_NAMES.values()
 
     def read_var(
-        self, var_name: str, ts_type: str | None = None, conco3mda8formaps: bool = False, **kwargs
+        self, var_name: str, ts_type: str | None = None, from_map_engine: bool = False, **kwargs
     ) -> GriddedData | list[GriddedData]:
         """Load data for given variable.
 
@@ -449,7 +449,7 @@ class ReadCAMS2_83(GriddedReader):
         )
         gridded.metadata["data_id"] = self.data_id
 
-        if conco3mda8formaps and var_name == "conco3" and ts_type == "hourly":
+        if from_map_engine and var_name == "conco3":
             ds = self.filedata[var_name].copy()
             o3mda8 = (
                 ds.rolling(time=8, center=False, min_periods=6)

--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -462,9 +462,6 @@ class ReadCAMS2_83(GriddedReader):
                     species="O3 MDA8",
                 )
             )
-            o3mda8.coords.update(
-                {"time": o3mda8.get_index("time") + pd.tseries.frequencies.to_offset("12h")}
-            )
             cubeo3mda8 = o3mda8.to_iris()
             griddedo3mda8 = GriddedData(
                 cubeo3mda8,

--- a/pyaerocom/io/readgridded.py
+++ b/pyaerocom/io/readgridded.py
@@ -1222,6 +1222,7 @@ class ReadGridded(GriddedReader):
         try_convert_units=True,
         aux_add_args=None,
         rename_var=None,
+        from_map_engine=False,
         **kwargs,
     ):
         """Compute auxiliary variable
@@ -1317,6 +1318,7 @@ class ReadGridded(GriddedReader):
                 prefer_longer=prefer_longer,
                 try_convert_units=try_convert_units,
                 rename_var=None,
+                from_map_engine=from_map_engine,
                 **kwargs,
             )
             data.append(aux_data)
@@ -1584,6 +1586,7 @@ class ReadGridded(GriddedReader):
         constraints=None,
         try_convert_units=True,
         rename_var=None,
+        from_map_engine=False,
         **kwargs,
     ):
         """Read model data for a specific variable
@@ -1686,6 +1689,7 @@ class ReadGridded(GriddedReader):
             prefer_longer,
             try_convert_units=try_convert_units,
             rename_var=rename_var,
+            from_map_engine=from_map_engine,
             **kwargs,
         )
 
@@ -1849,6 +1853,7 @@ class ReadGridded(GriddedReader):
         prefer_longer,
         try_convert_units,
         rename_var,
+        from_map_engine,
         **kwargs,
     ):
         """Helper method used in :func:`read_var`
@@ -1867,6 +1872,7 @@ class ReadGridded(GriddedReader):
                 prefer_longer=prefer_longer,
                 try_convert_units=try_convert_units,
                 rename_var=rename_var,
+                from_map_engine=from_map_engine,
                 **kwargs,
             )
 
@@ -1883,6 +1889,7 @@ class ReadGridded(GriddedReader):
                 prefer_longer=prefer_longer,
                 try_convert_units=try_convert_units,
                 rename_var=rename_var,
+                from_map_engine=from_map_engine,
                 **kwargs,
             )
 
@@ -1899,6 +1906,7 @@ class ReadGridded(GriddedReader):
                     prefer_longer=prefer_longer,
                     try_convert_units=try_convert_units,
                     rename_var=rename_var,
+                    from_map_engine=from_map_engine,
                     **kwargs,
                 )
         # this input variable was explicitly set to be computed, in which
@@ -2107,6 +2115,7 @@ class ReadGridded(GriddedReader):
         prefer_longer,
         try_convert_units,
         rename_var,
+        from_map_engine,
         **kwargs,
     ):
         """Find files corresponding to input specs and load into GriddedData


### PR DESCRIPTION
## Change Summary

conco3mda calculation in the cams283 reader to be consumed by the map engine 

doing the calculation of conco3mda8 directly in modelmaps_engine.py, say after conco3 model data has been read https://github.com/metno/pyaerocom/blob/main-dev/pyaerocom/aeroval/modelmaps_engine.py#L173, poses the problem that the returned object is a GriddedDataContainer that is based on an iris cube for cams2_83 but might be different for different cases

this branch is an attempt to put the conco3mda8 calculation logic into the (cams2-83) reader, and in the map engine just open up for the possibility that the returned object from _read_model_data might be a list of GriddedDataContainers

this is ugly and very slow

the calculation of conco3mda8 is otherwise supposed to be coherent with the one baked in the colocation

the timestamps of the geojson files are brute-force shifted by 1h which is necessary because aeroval expects them to be identical to the timestamps in the ts files

## Related issue number

fixes #1770 

## Checklist

* [x] Start with a draft-PR
* [ ] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
