### PR TITLE
add wild fire flux pm25 variable 

### DIFF
--- a/pyaerocom/aeroval/data/var_scale_colmap.ini
+++ b/pyaerocom/aeroval/data/var_scale_colmap.ini
@@ -142,6 +142,10 @@ colmap = coolwarm
 scale = [0.0, 5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 35.0, 40.0, 45.0]
 colmap = coolwarm
 
+[wffpm25]
+scale = [0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0]
+colmap = coolwarm
+
 [conco3]
 scale = [0.0, 15.0, 30.0, 45.0, 60.0, 75.0, 90.0, 105.0, 120.0]
 colmap = coolwarm

--- a/pyaerocom/aeroval/data/var_web_info.ini
+++ b/pyaerocom/aeroval/data/var_web_info.ini
@@ -399,6 +399,11 @@ menu_name = PM<sub>2.5</sub>
 vertical_type = 3D
 category = Particle concentrations
 
+[wffpm25]
+menu_name = PM<sub>2.5</sub> Wildfire flux
+vertical_type = 3D
+category = Surface emission
+
 [concNno3pm10]
 menu_name = NO<sub>3</sub><sup>-</sup> PM<sub>10</sub>
 vertical_type = 3D

--- a/pyaerocom/data/variables.ini
+++ b/pyaerocom/data/variables.ini
@@ -2945,6 +2945,13 @@ unit = ug m-3
 minimum = 0
 maximum = 1000
 
+[wffpm25]
+description = Wildfire flux of Particulate Matter PM2.5
+unit = ug m-2 s-1
+#only_use_in = maps
+var_name = wffpm25
+comments_and_purpose = At surface.
+
 [concpm1]
 description= Mass concentration of pm1
 standard_name = mass_concentration_of_pm1_ambient_aerosol_particles_in_air


### PR DESCRIPTION
this is for cams2_71, to visualize GFAS contours for wildfire_flux_of_particulate_matter_d_2_5_µm

## Change Summary

adding new variable

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
