### PR TITLE
Fixes small error in the colocator

### DIFF
--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -855,7 +855,8 @@ class Colocator:
         except DataCoverageError:
             vert_which_alt = self._try_get_vert_which_alt(is_model, var_name)
             data.read_data(
-                var_name,
+                readers,
+                var_name=var_name,
                 start=start,
                 stop=stop,
                 ts_type=ts_type_read,


### PR DESCRIPTION
## Change Summary
Fixes small error with the arguments used when the colocator calls GriddedDataContainer.read_data. The list of readers was missing in call with vert_which_alt

## Checklist

* [ ] Start with a draft-PR
* [ ] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
