### PR TITLE
Fix colocated time true and adapt to pandas 3.0

### DIFF
--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -12,7 +12,6 @@ from geonum.atmosphere import pressure
 
 from pyaerocom import __version__ as pya_ver
 from pyaerocom import const
-from pyaerocom.stationdata import StationData
 from pyaerocom._lowlevel_helpers import RegridResDeg
 from pyaerocom.climatology_config import ClimatologyConfig
 from pyaerocom.exceptions import (
@@ -26,15 +25,11 @@ from pyaerocom.exceptions import (
 from pyaerocom.filter import Filter
 from pyaerocom.griddeddata import GriddedData
 from pyaerocom.griddeddata_container import GriddedDataContainer
-
-from pyaerocom.ungridded_data_container import UngriddedDataContainer
-from pyaerocom.units.datetime import get_lowest_resolution, to_pandas_timestamp
-from pyaerocom.helpers import (
-    isnumeric,
-    make_datetime_index,
-)
+from pyaerocom.helpers import isnumeric, make_datetime_index
+from pyaerocom.stationdata import StationData
 from pyaerocom.time_resampler import TimeResampler
-from pyaerocom.units.datetime import TsType
+from pyaerocom.ungridded_data_container import UngriddedDataContainer
+from pyaerocom.units.datetime import TsType, get_lowest_resolution, to_pandas_timestamp
 
 from .colocated_data import ColocatedData
 
@@ -543,19 +538,18 @@ def _colocate_site_data_helper_timecol(
     # Save time indices of the observations and a mask of where it is NaN
     obs_idx = stat_data_ref[var_ref].index
     obs_isnan = stat_data_ref[var_ref].isnull()
-    mod_isnan = stat_data[var_ref].isnull()
+    # mod_idx = stat_data[var_ref].index
+    # mod_isnan = stat_data[var_ref].isnull()
 
     # now both StationData objects are in the same resolution, but they still
     # might have gaps in their time axis, thus concatenate them in a DataFrame,
     # which will merge the time index
     merged = pd.concat([stat_data_ref[var_ref], stat_data[var]], axis=1, keys=["ref", "data"])
-    # Set to NaN at times when model data was NaN originally, otherwise
-    # interpolation at next step will 'invent' model data
-    merged.loc[mod_isnan] = np.nan
     # Interpolate the model to the times of the observations
     # (for non-standard coltst it could be that 'resample_time'
     # has placed the model and observations at different time stamps)
-    merged = merged.interpolate("index").reindex(obs_idx).loc[obs_idx]
+    # ensure model data is not invented when not there
+    merged = merged.interpolate("index", limit=1).reindex(obs_idx).loc[obs_idx]
     # Set to NaN at times when observations were NaN originally
     # (because the interpolation will interpolate the 'ref' column as well)
     merged.loc[obs_isnan] = np.nan
@@ -988,7 +982,11 @@ def _get_stat_data_vec(
 ) -> tuple[list[StationData], list[StationData]]:
     obs_stat_pos = np.array(
         [
-            (*proj(station.latitude, station.longitude), station.latitude, station.longitude)
+            (
+                *proj(station.latitude, station.longitude),
+                station.latitude,
+                station.longitude,
+            )
             for station in unsorted_obs_stat_data
         ],
         np.dtype([("x", "f8"), ("y", "f8"), ("lat", "f8"), ("lon", "f8")]),

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -304,7 +304,7 @@ def colocate_gridded_gridded(
     if isinstance(data_ref_np, np.ma.core.MaskedArray):
         data_ref_np = data_ref_np.filled(np.nan)
     arr = np.asarray((data_ref_np, data_np))
-    time = data.time_stamps().astype("datetime64[ns]")
+    time = data.time_stamps().astype("datetime64[us]")
     lats = data.latitude_points
     lons = data.longitude_points
 

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -449,7 +449,7 @@ def _colocate_site_data_helper(
         )[var_ref]
 
     # fill up missing time stamps
-    return pd.concat([obs_ts, grid_ts], axis=1, keys=["ref", "data"])
+    return pd.concat([obs_ts, grid_ts], axis=1, keys=["ref", "data"], sort=True)
 
 
 def _colocate_site_data_helper_timecol(
@@ -542,7 +542,13 @@ def _colocate_site_data_helper_timecol(
     # now both StationData objects are in the same resolution, but they still
     # might have gaps in their time axis, thus concatenate them in a DataFrame,
     # which will merge the time index
-    merged = pd.concat([stat_data_ref[var_ref], stat_data[var]], axis=1, keys=["ref", "data"])
+    merged = pd.concat(
+        [stat_data_ref[var_ref], stat_data[var]],
+        axis=1,
+        keys=["ref", "data"],
+        sort=True,
+    )
+
     # Interpolate the model to the times of the observations
     # (for non-standard coltst it could be that 'resample_time'
     # has placed the model and observations at different time stamps)
@@ -555,7 +561,7 @@ def _colocate_site_data_helper_timecol(
     merged.loc[merged.data.isnull()] = np.nan
     # Ensure the whole timespan of the model is kept in "merged"
     stat_data[var].name = "tmp"
-    merged = pd.concat([merged, stat_data[var]], axis=1)
+    merged = pd.concat([merged, stat_data[var]], axis=1, sort=True)
     merged = merged[["ref", "data"]]
 
     grid_ts = merged["data"]
@@ -582,7 +588,8 @@ def _colocate_site_data_helper_timecol(
         min_num_obs=min_num_obs,
     )
     # fill up missing time stamps
-    return pd.concat([obs_ts, grid_ts], axis=1, keys=["ref", "data"])
+
+    return pd.concat([obs_ts, grid_ts], axis=1, keys=["ref", "data"], sort=True)
 
 
 def colocate_gridded_ungridded(

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -538,8 +538,6 @@ def _colocate_site_data_helper_timecol(
     # Save time indices of the observations and a mask of where it is NaN
     obs_idx = stat_data_ref[var_ref].index
     obs_isnan = stat_data_ref[var_ref].isnull()
-    # mod_idx = stat_data[var_ref].index
-    # mod_isnan = stat_data[var_ref].isnull()
 
     # now both StationData objects are in the same resolution, but they still
     # might have gaps in their time axis, thus concatenate them in a DataFrame,
@@ -548,7 +546,7 @@ def _colocate_site_data_helper_timecol(
     # Interpolate the model to the times of the observations
     # (for non-standard coltst it could be that 'resample_time'
     # has placed the model and observations at different time stamps)
-    # ensure model data is not invented when not there
+    # ensure model data is not over-interpolated when nan
     merged = merged.interpolate("index", limit=1).reindex(obs_idx).loc[obs_idx]
     # Set to NaN at times when observations were NaN originally
     # (because the interpolation will interpolate the 'ref' column as well)

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -543,11 +543,15 @@ def _colocate_site_data_helper_timecol(
     # Save time indices of the observations and a mask of where it is NaN
     obs_idx = stat_data_ref[var_ref].index
     obs_isnan = stat_data_ref[var_ref].isnull()
+    mod_isnan = stat_data[var_ref].isnull()
 
     # now both StationData objects are in the same resolution, but they still
     # might have gaps in their time axis, thus concatenate them in a DataFrame,
     # which will merge the time index
     merged = pd.concat([stat_data_ref[var_ref], stat_data[var]], axis=1, keys=["ref", "data"])
+    # Set to NaN at times when model data was NaN originally, otherwise
+    # interpolation at next step will 'invent' model data
+    merged.loc[mod_isnan] = np.nan
     # Interpolate the model to the times of the observations
     # (for non-standard coltst it could be that 'resample_time'
     # has placed the model and observations at different time stamps)

--- a/pyaerocom/helpers.py
+++ b/pyaerocom/helpers.py
@@ -5,6 +5,7 @@ General helper methods for the pyaerocom library.
 from __future__ import annotations
 
 import logging
+import math
 import math as ma
 from datetime import datetime
 
@@ -26,18 +27,16 @@ from pyaerocom.exceptions import (
     ResamplingError,
     VariableDefinitionError,
 )
+from pyaerocom.units import Unit
+from pyaerocom.units.datetime import TsType, is_year, to_pandas_timestamp
 from pyaerocom.units.datetime.time_config import (
     PANDAS_RESAMPLE_OFFSETS,
     TS_TYPE_DATETIME_CONV,
-    TS_TYPE_TO_PANDAS_FREQ,
     TS_TYPE_TO_FREQ_NAME,
     TS_TYPE_TO_NUMPY_FREQ,
+    TS_TYPE_TO_PANDAS_FREQ,
 )
-from pyaerocom.units.datetime import TsType, is_year, to_pandas_timestamp
 from pyaerocom.variable_helpers import get_variable
-
-from pyaerocom.units import Unit
-import math
 
 logger = logging.getLogger(__name__)
 
@@ -874,7 +873,7 @@ def resample_timeseries(ts, freq, how=None, min_num_obs=None):
         # df = resampler.agg([how, 'count'])
         invalid = numobs < min_num_obs
         if np.any(invalid):
-            data.values[invalid] = np.nan
+            data.mask(invalid, other=np.nan, inplace=True)
     if offset is not None:
         data.index = data.index + offset
     return data

--- a/pyaerocom/io/cams2_82/reader.py
+++ b/pyaerocom/io/cams2_82/reader.py
@@ -335,7 +335,7 @@ def parse_daterange(
         return dates
     if len(dates) != 2:
         raise ValueError("need 2 datetime objects to define a date_range")
-    return pd.date_range(*dates, freq="d")
+    return pd.date_range(*dates, freq="D")
 
 
 class ReadCAMS2_82(GriddedReader):

--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -100,7 +100,7 @@ def parse_daterange(
         return dates
     if len(dates) != 2:
         raise ValueError("need 2 datetime objects to define a date_range")
-    return pd.date_range(*dates, freq="d")
+    return pd.date_range(*dates, freq="D")
 
 
 def forecast_day(ds: xr.Dataset, *, day: int) -> xr.Dataset:

--- a/pyaerocom/units/datetime/time_config.py
+++ b/pyaerocom/units/datetime/time_config.py
@@ -50,8 +50,8 @@ TS_TYPE_TO_PANDAS_FREQ = {
     "yearly": "YS",
 }
 PANDAS_RESAMPLE_OFFSETS = {
-    "YS": pd.Timedelta(181, "d"),
-    "MS": pd.Timedelta(14, "d"),
+    "YS": pd.Timedelta(181, "D"),
+    "MS": pd.Timedelta(14, "D"),
     "D": pd.Timedelta(12, "h"),
     "h": pd.Timedelta(30, "m"),
 }

--- a/tests/colocation/test_colocation_utils.py
+++ b/tests/colocation/test_colocation_utils.py
@@ -34,7 +34,7 @@ S1 = create_fake_station_data(
     10,
     "2010-01-01",
     "2010-12-31",
-    "d",
+    "D",
     {"ts_type": "daily"},
 )
 
@@ -46,7 +46,7 @@ S2 = create_fake_station_data(
     10,
     "2010-01-01",
     "2010-12-31",
-    "d",
+    "D",
     {"ts_type": "daily"},
 )
 
@@ -56,7 +56,7 @@ S3 = create_fake_station_data(
     10,
     "2010-01-01",
     "2010-12-31",
-    "13d",
+    "13D",
     {"ts_type": "13daily"},
 )
 S3["concpm10"][1] = np.nan
@@ -68,7 +68,7 @@ S4 = create_fake_station_data(
     10,
     "2010-01-03",
     "2011-12-31",
-    "d",
+    "D",
     {"ts_type": "daily"},
 )
 

--- a/tests/colocation/test_colocation_utils.py
+++ b/tests/colocation/test_colocation_utils.py
@@ -90,8 +90,8 @@ S4["concpm10"][0:5] = range(5)
             10,
         ),
         (
-            S3,  # model data 13daily up to dec 2010
-            S4,
+            S3,  # model data 13daily for 2010
+            S4,  # obs data daily from 1st march 2010 to end of 2011
             "concpm10",
             "concpm10",
             "monthly",

--- a/tests/colocation/test_colocation_utils.py
+++ b/tests/colocation/test_colocation_utils.py
@@ -4,15 +4,15 @@ import pandas as pd
 import pytest
 from cf_units import Unit
 
-from pyaerocom import GriddedData, const, helpers, GriddedDataContainer
+from pyaerocom import GriddedData, GriddedDataContainer, const, helpers
 from pyaerocom.colocation.colocated_data import ColocatedData
 from pyaerocom.colocation.colocation_utils import (
     _colocate_site_data_helper,
     _colocate_site_data_helper_timecol,
+    _get_stat_data_vec,
     _regrid_gridded,
     colocate_gridded_gridded,
     colocate_gridded_ungridded,
-    _get_stat_data_vec,
 )
 from pyaerocom.config_reader import ALL_REGION_NAME
 from pyaerocom.exceptions import UnresolvableTimeDefinitionError
@@ -90,7 +90,7 @@ S4["concpm10"][0:5] = range(5)
             10,
         ),
         (
-            S3,
+            S3,  # model data 13daily up to dec 2010
             S4,
             "concpm10",
             "concpm10",
@@ -98,9 +98,9 @@ S4["concpm10"][0:5] = range(5)
             "mean",
             {"monthly": {"daily": 25}},
             False,
-            24,
+            11,
         ),
-        (S1, S2, "concpm10", "concpm10", "monthly", "mean", 25, {}, 12),
+        (S1, S2, "concpm10", "concpm10", "monthly", "mean", 25, {}, 11),
         (S2, S1, "concpm10", "concpm10", "monthly", "mean", 25, {}, 11),
     ],
 )

--- a/tests/colocation/test_colocator.py
+++ b/tests/colocation/test_colocator.py
@@ -527,8 +527,8 @@ def test_colocator_with_obs_data_dir_gridded(setup):
     cd = data["od550aer"]["od550aer"]
     assert isinstance(cd, ColocatedData)
     assert cd.ts_type == "monthly"
-    assert str(cd.start) == "2010-01-15T12:00:00.000000"
-    assert str(cd.stop) == "2010-12-15T12:00:00.000000"
+    assert str(cd.start.astype("datetime64[us]")) == "2010-01-15T12:00:00.000000"
+    assert str(cd.stop.astype("datetime64[us]")) == "2010-12-15T12:00:00.000000"
 
 
 ###################################

--- a/tests/colocation/test_colocator.py
+++ b/tests/colocation/test_colocator.py
@@ -495,8 +495,8 @@ def test_colocator_with_obs_data_dir_ungridded(setup):
     cd = data["od550aer"]["od550aer"]
     assert isinstance(cd, ColocatedData)
     assert cd.ts_type == "monthly"
-    assert str(cd.start) == "2010-01-15T00:00:00.000000"
-    assert str(cd.stop) == "2010-12-15T00:00:00.000000"
+    assert str(cd.start.astype("datetime64[us]")) == "2010-01-15T00:00:00.000000"
+    assert str(cd.stop.astype("datetime64[us]")) == "2010-12-15T00:00:00.000000"
 
 
 def test_colocator_with_model_data_dir_ungridded(setup):
@@ -511,8 +511,8 @@ def test_colocator_with_model_data_dir_ungridded(setup):
     cd = data["od550aer"]["od550aer"]
     assert isinstance(cd, ColocatedData)
     assert cd.ts_type == "monthly"
-    assert str(cd.start) == "2010-01-15T00:00:00.000000"
-    assert str(cd.stop) == "2010-12-15T00:00:00.000000"
+    assert str(cd.start.astype("datetime64[us]")) == "2010-01-15T00:00:00.000000"
+    assert str(cd.stop.astype("datetime64[us]")) == "2010-12-15T00:00:00.000000"
 
 
 def test_colocator_with_obs_data_dir_gridded(setup):
@@ -552,14 +552,14 @@ def test_colocation_pyaro(pyaro_testconfig, fake_aod_MSCWCtm_data_monthly_2010, 
     cd = data["od550aer"]["od550aer"]
     assert isinstance(cd, ColocatedData)
     assert cd.ts_type == "monthly"
-    assert str(cd.start) == "2010-01-15T00:00:00.000000"
-    assert str(cd.stop) == "2010-12-15T00:00:00.000000"
+    assert str(cd.start.astype("datetime64[us]")) == "2010-01-15T00:00:00.000000"
+    assert str(cd.stop.astype("datetime64[us]")) == "2010-12-15T00:00:00.000000"
 
     assert np.sum(np.isnan(cd.data[0, :].data)) == 0
 
     assert cd.data[0, :].data.shape[0] == 12
-    assert str(cd.start) == "2010-01-15T00:00:00.000000"
-    assert str(cd.stop) == "2010-12-15T00:00:00.000000"
+    assert str(cd.start.astype("datetime64[us]")) == "2010-01-15T00:00:00.000000"
+    assert str(cd.stop.astype("datetime64[us]")) == "2010-12-15T00:00:00.000000"
 
     assert np.sum(np.isnan(cd.data[0, :].data)) == 0
 

--- a/tests/colocation/test_colocator.py
+++ b/tests/colocation/test_colocator.py
@@ -527,8 +527,8 @@ def test_colocator_with_obs_data_dir_gridded(setup):
     cd = data["od550aer"]["od550aer"]
     assert isinstance(cd, ColocatedData)
     assert cd.ts_type == "monthly"
-    assert str(cd.start) == "2010-01-15T12:00:00.000000000"
-    assert str(cd.stop) == "2010-12-15T12:00:00.000000000"
+    assert str(cd.start) == "2010-01-15T12:00:00.000000"
+    assert str(cd.stop) == "2010-12-15T12:00:00.000000"
 
 
 ###################################

--- a/tests/colocation/test_colocator.py
+++ b/tests/colocation/test_colocator.py
@@ -5,7 +5,13 @@ import numpy as np
 import pytest
 from pydantic import ValidationError
 
-from pyaerocom import ColocatedData, GriddedData, UngriddedData, const, GriddedDataContainer
+from pyaerocom import (
+    ColocatedData,
+    GriddedData,
+    GriddedDataContainer,
+    UngriddedData,
+    const,
+)
 from pyaerocom.climatology_config import ClimatologyConfig
 from pyaerocom.colocation.colocation_setup import ColocationSetup
 from pyaerocom.colocation.colocator import Colocator
@@ -274,7 +280,10 @@ def test_Colocator_prepare_colocation_args(monkeypatch):
         fake_data = list(string.ascii_lowercase)
         for i, n in enumerate(fake_data):
             d.metadata[i] = dict(
-                data_id="testcase", station_name=n, station_type=n, var_info={"units": "1"}
+                data_id="testcase",
+                station_name=n,
+                station_type=n,
+                var_info={"units": "1"},
             )
         assert d.station_name == fake_data
         assert {"station_type" in dict for dict in d.metadata.values()} == {True}
@@ -308,7 +317,10 @@ def test_Colocator_prepare_colocation_args_malformed_metadata(monkeypatch):
         for i, n in enumerate(fake_data):
             if i > len(fake_data) / 2:
                 d.metadata[i] = dict(
-                    data_id="testcase", station_name=n, station_type=n, var_info={"units": "1"}
+                    data_id="testcase",
+                    station_name=n,
+                    station_type=n,
+                    var_info={"units": "1"},
                 )
             else:
                 d.metadata[i] = dict(data_id="testcase", station_name=n, var_info={"units": "1"})
@@ -483,8 +495,8 @@ def test_colocator_with_obs_data_dir_ungridded(setup):
     cd = data["od550aer"]["od550aer"]
     assert isinstance(cd, ColocatedData)
     assert cd.ts_type == "monthly"
-    assert str(cd.start) == "2010-01-15T00:00:00.000000000"
-    assert str(cd.stop) == "2010-12-15T00:00:00.000000000"
+    assert str(cd.start) == "2010-01-15T00:00:00.000000"
+    assert str(cd.stop) == "2010-12-15T00:00:00.000000"
 
 
 def test_colocator_with_model_data_dir_ungridded(setup):
@@ -499,8 +511,8 @@ def test_colocator_with_model_data_dir_ungridded(setup):
     cd = data["od550aer"]["od550aer"]
     assert isinstance(cd, ColocatedData)
     assert cd.ts_type == "monthly"
-    assert str(cd.start) == "2010-01-15T00:00:00.000000000"
-    assert str(cd.stop) == "2010-12-15T00:00:00.000000000"
+    assert str(cd.start) == "2010-01-15T00:00:00.000000"
+    assert str(cd.stop) == "2010-12-15T00:00:00.000000"
 
 
 def test_colocator_with_obs_data_dir_gridded(setup):
@@ -540,8 +552,14 @@ def test_colocation_pyaro(pyaro_testconfig, fake_aod_MSCWCtm_data_monthly_2010, 
     cd = data["od550aer"]["od550aer"]
     assert isinstance(cd, ColocatedData)
     assert cd.ts_type == "monthly"
-    assert str(cd.start) == "2010-01-15T00:00:00.000000000"
-    assert str(cd.stop) == "2010-12-15T00:00:00.000000000"
+    assert str(cd.start) == "2010-01-15T00:00:00.000000"
+    assert str(cd.stop) == "2010-12-15T00:00:00.000000"
+
+    assert np.sum(np.isnan(cd.data[0, :].data)) == 0
+
+    assert cd.data[0, :].data.shape[0] == 12
+    assert str(cd.start) == "2010-01-15T00:00:00.000000"
+    assert str(cd.stop) == "2010-12-15T00:00:00.000000"
 
     assert np.sum(np.isnan(cd.data[0, :].data)) == 0
 

--- a/tests/fixtures/mscw_ctm.py
+++ b/tests/fixtures/mscw_ctm.py
@@ -35,7 +35,7 @@ def create_fake_MSCWCtm_data(year="2019", numval=1, tst=None):
 
     start = datetime.strptime(f"{year}-01-01", "%Y-%m-%d")
     stop = datetime.strptime(f"{year}-12-31", "%Y-%m-%d")
-    _time_fake = pd.date_range(start, stop, freq=TsType(tst).to_pandas_freq())
+    _time_fake = pd.date_range(start, stop, freq=TsType(tst).to_pandas_freq(), unit="us")
     sh = (len(_time_fake), len(_lats_fake), len(_lons_fake))
     _data_fake = numval * np.ones(sh)
 

--- a/tests/fixtures/mscw_ctm.py
+++ b/tests/fixtures/mscw_ctm.py
@@ -35,7 +35,7 @@ def create_fake_MSCWCtm_data(year="2019", numval=1, tst=None):
 
     start = datetime.strptime(f"{year}-01-01", "%Y-%m-%d")
     stop = datetime.strptime(f"{year}-12-31", "%Y-%m-%d")
-    _time_fake = pd.date_range(start, stop, freq=TsType(tst).to_pandas_freq(), unit="us")
+    _time_fake = pd.date_range(start, stop, freq=TsType(tst).to_pandas_freq())
     sh = (len(_time_fake), len(_lats_fake), len(_lons_fake))
     _data_fake = numval * np.ones(sh)
 

--- a/tests/fixtures/stations.py
+++ b/tests/fixtures/stations.py
@@ -175,7 +175,7 @@ def create_fake_stationdata_list() -> list[StationData]:
         10,
         "2010-01-01",
         "2010-12-31",
-        "d",
+        "D",
         {
             "awesomeness": 10,
             "data_revision": 20120101,
@@ -193,7 +193,7 @@ def create_fake_stationdata_list() -> list[StationData]:
         20,
         "2010-06-01",
         "2011-12-31",
-        "d",
+        "D",
         {
             "awesomeness": 12,
             "data_revision": 20110101,
@@ -228,7 +228,7 @@ def create_fake_stationdata_list() -> list[StationData]:
         20,
         "1850",
         "2020",
-        "1000d",
+        "1000D",
         {
             "awesomeness": 15,
             "data_revision": 20130101,
@@ -264,7 +264,7 @@ def create_fake_stationdata_list() -> list[StationData]:
         0.1,
         "2008",
         "2009",
-        "60d",
+        "60D",
         {
             "awesomeness": 46,
             "data_revision": 20200101,
@@ -282,7 +282,7 @@ def create_fake_stationdata_list() -> list[StationData]:
         0.2,
         "2010",
         "2016",
-        "10d",
+        "10D",
         {
             "awesomeness": 30,
             "data_revision": 20200101,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -89,7 +89,7 @@ def test_merge_station_data_error(statlist, use, exception, error):
 
 def test__get_pandas_freq_and_offset():
     val = helpers._get_pandas_freq_and_offset("monthly")
-    assert val == ("MS", pd.Timedelta(14, "d"))
+    assert val == ("MS", pd.Timedelta(14, "D"))
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Change Summary

- try to prevent model data being 'invented' due to excessive interpolation when colocate_time is True
- adapt to pandas 3.0 since it landed while this PR was being tested


## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
