### PR TITLE
reduces var to only unique, returns totnum in _len_datapoints

### DIFF
--- a/pyaerocom/ungriddeddata.py
+++ b/pyaerocom/ungriddeddata.py
@@ -157,20 +157,20 @@ class UngriddedData(UngriddedDataMetadata):
         """Checks if all indices are assigned correctly"""
         assert len(self.meta_idx) == len(self.metadata), "Mismatch len(meta_idx) and len(metadata)"
 
-        assert sum(self.meta_idx) == sum(
-            self.metadata
-        ), "Mismatch between keys of metadata dict and meta_idx dict"
+        assert sum(self.meta_idx) == sum(self.metadata), (
+            "Mismatch between keys of metadata dict and meta_idx dict"
+        )
 
         _varnums = self._data[:, self._VARINDEX]
         var_indices = np.unique(_varnums[~np.isnan(_varnums)])
 
-        assert len(var_indices) == len(
-            self.var_idx
-        ), "Mismatch between number of variables in data array and var_idx attr."
+        assert len(var_indices) == len(self.var_idx), (
+            "Mismatch between number of variables in data array and var_idx attr."
+        )
 
-        assert sum(var_indices) == sum(
-            self.var_idx.values()
-        ), "Mismatch between variable indices in data array and var_idx attr."
+        assert sum(var_indices) == sum(self.var_idx.values()), (
+            "Mismatch between variable indices in data array and var_idx attr."
+        )
 
         vars_avail = self.var_idx
 
@@ -190,13 +190,13 @@ class UngriddedData(UngriddedDataMetadata):
                 if len(indices) == 0:
                     continue  # no data assigned for this metadata index
 
-                assert (
-                    var in meta["var_info"]
-                ), f"Var {var} is indexed in meta_idx[{idx}] but not in metadata[{idx}]"
+                assert var in meta["var_info"], (
+                    f"Var {var} is indexed in meta_idx[{idx}] but not in metadata[{idx}]"
+                )
                 var_idx_data = np.unique(self._data[indices, self._VARINDEX])
-                assert (
-                    len(var_idx_data) == 1
-                ), f"Found multiple variable indices for var {var}: {var_idx_data}"
+                assert len(var_idx_data) == 1, (
+                    f"Found multiple variable indices for var {var}: {var_idx_data}"
+                )
                 assert var_idx_data[0] == vars_avail[var], (
                     f"Mismatch between {var} index assigned in data and "
                     f"var_idx for {idx} in meta-block"
@@ -1164,6 +1164,8 @@ class UngriddedData(UngriddedDataMetadata):
             meta_idx = [meta_idx]
         if isinstance(var, str):
             var = [var]
+        if isinstance(var, list):
+            var = list(set(var))
         totnum = 0
         for m in meta_idx:
             for v in var:
@@ -1174,7 +1176,7 @@ class UngriddedData(UngriddedDataMetadata):
                         f"Ignoring variable {var} in meta block {meta_idx} "
                         f"since no data could be found"
                     )
-        return
+        return totnum
 
     def clear_meta_no_data(self, inplace=True):
         """Remove all metadata blocks that do not have data associated with it


### PR DESCRIPTION
## Change Summary

Something made the earlinet eval super slow. Some debugging lead me to ungriddeddata._len_datapoints. 

1. the var list has many thousands of copies of the same var. I guess this is an error? Made it so var = list(set(var)). The resulting totnum is drastically different
2. totnum was not actually returned

## Checklist

* [ ] Start with a draft-PR
* [ ] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
