### PR TITLE
bump aerovaldb version for dep-compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ requires-python = ">=3.10"
 dependencies = [
     # NOTE: Please also update dependency versions in pyaerocom_env.yml,
     # and minimum versions in the tox config at the bottom of this file!
-    "aerovaldb>=0.5.0, < 0.6.0",
+    "aerovaldb>=0.5.1, < 0.6.0",
     "scitools-iris>=3.11.0",
     "xarray>=2022.12.0",
     "cartopy>=0.21.1",
@@ -233,7 +233,7 @@ deps =
     # Will only run on lowest supported Python version CI test
     # (currently 3.10).
     # Should be incremented when changing dependencies above.
-    aerovaldb ==0.5.0; python_version < "3.11"
+    aerovaldb ==0.5.1; python_version < "3.11"
     scitools-iris ==3.11.0; python_version < "3.11"
     cartopy ==0.21.1; python_version < "3.11"
     matplotlib ==3.7.1; python_version < "3.11"


### PR DESCRIPTION
## Change Summary

aeroval 0.5.0 is incompatible with a newer version of one of it's dependencies `asyncio_alru`. This will crash
a lot of tests for pyaerocom, too. Bumping version to 0.5.1 solves the problem

## Checklist

* [ ] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
