### PR TITLE
Adapt cams2_83 reader to mixed vars files

### DIFF
--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -190,7 +190,7 @@ def drop_standard_name(ds: xr.Dataset) -> xr.Dataset:
         attrs = ds[var_name].attrs
         attrs.pop("standard_name", None)
         ds[var_name] = ds[var_name].assign_attrs(attrs)
-        return ds
+    return ds
 
 
 def read_dataset(paths: list[Path], *, day: int) -> xr.Dataset:

--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -5,6 +5,7 @@ import re
 from collections.abc import Iterator
 from datetime import date, datetime, timedelta
 from pathlib import Path
+from copy import deepcopy
 
 import numpy as np
 import pandas as pd
@@ -29,6 +30,11 @@ AEROCOM_NAMES = dict(
     pm10_conc="concpm10",
     pm2p5_conc="concpm25",
     so2_conc="concso2",
+    pm2p5_so4_conc="concpm25so4",
+    pm2p5_no3_conc="concpm25no3",
+    pm2p5_nh4_conc="concpm25nh4",
+    ectot_conc="concectot",
+    pm2p5_total_om_conc="concpm25totalom",
 )
 
 FULL_NAMES = dict(
@@ -38,15 +44,11 @@ FULL_NAMES = dict(
     pm10_conc="PM10 Aerosol",
     pm2p5_conc="PM2.5 Aerosol",
     so2_conc="Sulphur Dioxide",
-)
-
-STANDARD_NAMES = dict(
-    co_conc="mass_concentration_of_carbon_monoxide_in_air",
-    no2_conc="mass_concentration_of_nitrogen_dioxide_in_air",
-    o3_conc="mass_concentration_of_ozone_in_air",
-    pm10_conc="mass_concentration_of_pm10_ambient_aerosol_in_air",
-    pm2p5_conc="mass_concentration_of_pm2p5_ambient_aerosol_in_air",
-    so2_conc="mass_concentration_of_sulfur_dioxide_in_air",
+    pm2p5_so4_conc="PM2.5 Sulphate",
+    pm2p5_no3_conc="PM2.5 Nitrate",
+    pm2p5_nh4_conc="PM2.5 Ammonium",
+    ectot_conc="Total Elementary Carbon",
+    pm2p5_total_om_conc="PM2.5 Aerosol from Total Organic Matter",
 )
 
 
@@ -159,27 +161,36 @@ def fix_names(ds: xr.Dataset) -> xr.Dataset:
 
 def fix_missing_vars(ds: xr.Dataset) -> xr.Dataset:
     """
-    TODO: Check if all variables are there. If not:
+    Check if all variables are there. If not:
     make the rest of the variables, filled with nans.
-    Log an error when this is done
-
-    Might not be possible...
+    Log a warning when this is done
     """
     vars_list = [i for i in ds.data_vars]
     nb_vars = len(vars_list)
-    if nb_vars < 6:
+    if nb_vars < 11:
         logger.warning(f"Found only {vars_list}. Filling the rest with NaNs")
 
-        dummy_var = ds[vars_list[0]]
+        dummy_var = deepcopy(ds[vars_list[0]])
         dummy_var_name = vars_list[0]
         for species in AEROCOM_NAMES:
             if species not in vars_list:
                 ds = ds.assign(**{species: dummy_var * np.nan})
-                attrs = ds[dummy_var_name].attrs
+                attrs = deepcopy(ds[dummy_var_name].attrs)
                 attrs["species"] = FULL_NAMES[species]
-                attrs["standard_name"] = STANDARD_NAMES[species]
                 ds[species] = ds[species].assign_attrs(attrs)
     return ds
+
+
+def drop_standard_name(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Drop standard_name attribute, since some of the variables have it as Not Defined,
+    which is not a valid CF standard_name, and conversion to iris cube will fail in those cases
+    """
+    for var_name in ds.data_vars:
+        attrs = ds[var_name].attrs
+        attrs.pop("standard_name", None)
+        ds[var_name] = ds[var_name].assign_attrs(attrs)
+        return ds
 
 
 def read_dataset(paths: list[Path], *, day: int) -> xr.Dataset:
@@ -189,7 +200,7 @@ def read_dataset(paths: list[Path], *, day: int) -> xr.Dataset:
         return ds.pipe(forecast_day, day=day).pipe(fix_missing_vars)
 
     ds = xr.open_mfdataset(paths, preprocess=preprocess, parallel=False, chunks={"time": 24})
-    return ds.pipe(fix_coord).pipe(fix_names)
+    return ds.pipe(fix_coord).pipe(fix_names).pipe(drop_standard_name)
 
 
 def check_files(paths: list[Path]) -> list[Path]:

--- a/pyaerocom/io/cams2_83/reader.py
+++ b/pyaerocom/io/cams2_83/reader.py
@@ -30,11 +30,11 @@ AEROCOM_NAMES = dict(
     pm10_conc="concpm10",
     pm2p5_conc="concpm25",
     so2_conc="concso2",
-    pm2p5_so4_conc="concpm25so4",
-    pm2p5_no3_conc="concpm25no3",
-    pm2p5_nh4_conc="concpm25nh4",
-    ectot_conc="concectot",
-    pm2p5_total_om_conc="concpm25totalom",
+    pm2p5_so4_conc="concso4pm25",
+    pm2p5_no3_conc="concno3pm25",
+    pm2p5_nh4_conc="concnh4pm25",
+    ectot_conc="concecpm25",
+    pm2p5_total_om_conc="concompm25",
 )
 
 FULL_NAMES = dict(

--- a/tests/io/cams2_83/test_reader.py
+++ b/tests/io/cams2_83/test_reader.py
@@ -61,6 +61,7 @@ def test_model_file_contents(model_dataset: xr.Dataset, steps: int):
     for var_name in AEROCOM_NAMES.values():
         assert var_name in model_dataset
     assert len(model_dataset.time) == steps
+    assert len(model_dataset.data_vars) == 11
 
 
 times = pd.date_range(start="2025-07-01", freq="1h", periods=12)

--- a/tests/io/cams2_83/test_reader.py
+++ b/tests/io/cams2_83/test_reader.py
@@ -16,6 +16,7 @@ from pyaerocom.io.cams2_83.reader import (
     fix_missing_vars,
     drop_standard_name,
     fix_names,
+    fix_coord,
 )
 
 TEST_DATE = datetime(2024, 12, 1)
@@ -108,7 +109,12 @@ def dummy_model_data():
     )
 
 
-def test_fix_missing_vars_drop_standard_name(dummy_model_data):
-    ds = dummy_model_data.pipe(fix_missing_vars).pipe(fix_names).pipe(drop_standard_name)
+def test_from_fix_missing_vars_to_drop_standard_name(dummy_model_data):
+    ds = (
+        dummy_model_data.pipe(fix_missing_vars)
+        .pipe(fix_coord)
+        .pipe(fix_names)
+        .pipe(drop_standard_name)
+    )
     assert len(ds.data_vars) == 11
     assert "standard_name" not in ds["concso4pm25"].attrs

--- a/tests/io/cams2_83/test_reader.py
+++ b/tests/io/cams2_83/test_reader.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import date, datetime, timedelta
 from pathlib import Path
+import pandas as pd
+import numpy as np
 
 import pytest
 import xarray as xr
@@ -9,7 +11,12 @@ import xarray as xr
 from pyaerocom.io.cams2_83.models import ModelName, RunType
 from pyaerocom.io.cams2_83.reader import AEROCOM_NAMES, DATA_FOLDER_PATH
 from pyaerocom.io.cams2_83.reader import model_paths as find_model_paths
-from pyaerocom.io.cams2_83.reader import read_dataset
+from pyaerocom.io.cams2_83.reader import (
+    read_dataset,
+    fix_missing_vars,
+    drop_standard_name,
+    fix_names,
+)
 
 TEST_DATE = datetime(2024, 12, 1)
 TEST_DATES = [TEST_DATE + timedelta(days=d) for d in range(3)]
@@ -53,3 +60,55 @@ def test_model_file_contents(model_dataset: xr.Dataset, steps: int):
     for var_name in AEROCOM_NAMES.values():
         assert var_name in model_dataset
     assert len(model_dataset.time) == steps
+
+
+times = pd.date_range(start="2025-07-01", freq="1h", periods=12)
+levels = np.arange(0, 1)
+latitudes = np.arange(20.0, -20.5, -0.5)
+longitudes = np.arange(0.0, 20.0, 0.5)
+
+
+@pytest.fixture
+def dummy_model_data():
+    return xr.Dataset(
+        {
+            "ectot_conc": xr.DataArray(
+                data=np.ones(shape=(len(times), len(levels), len(latitudes), len(longitudes))),
+                dims=["time", "level", "latitude", "longitude"],
+                coords={
+                    "time": times,
+                    "level": levels,
+                    "latitude": latitudes,
+                    "longitude": longitudes,
+                },
+                attrs={
+                    "species": "Total Elementary Carbon",
+                    "units": "µg/m3",
+                    "value": "hourly values",
+                    "standard_name": "Not Defined",
+                },
+            ),
+            "pm10_conc": xr.DataArray(
+                data=np.ones(shape=(len(times), len(levels), len(latitudes), len(longitudes))),
+                dims=["time", "level", "latitude", "longitude"],
+                coords={
+                    "time": times,
+                    "level": levels,
+                    "latitude": latitudes,
+                    "longitude": longitudes,
+                },
+                attrs={
+                    "species": "PM10 Aerosol",
+                    "units": "µg/m3",
+                    "value": "hourly values",
+                    "standard_name": "mass_concentration_of_pm10_ambient_aerosol_in_air",
+                },
+            ),
+        }
+    )
+
+
+def test_fix_missing_vars_drop_standard_name(dummy_model_data):
+    ds = dummy_model_data.pipe(fix_missing_vars).pipe(fix_names).pipe(drop_standard_name)
+    assert len(ds.data_vars) == 11
+    assert "standard_name" not in ds["concso4pm25"].attrs

--- a/tests/io/cams2_83/test_reader.py
+++ b/tests/io/cams2_83/test_reader.py
@@ -66,7 +66,7 @@ def test_model_file_contents(model_dataset: xr.Dataset, steps: int):
 times = pd.date_range(start="2025-07-01", freq="1h", periods=12)
 levels = np.arange(0, 1)
 latitudes = np.arange(20.0, -20.5, -0.5)
-longitudes = np.arange(0.0, 20.0, 0.5)
+longitudes = np.arange(0.0, 320.0, 0.5)
 
 
 @pytest.fixture
@@ -118,3 +118,4 @@ def test_from_fix_missing_vars_to_drop_standard_name(dummy_model_data):
     )
     assert len(ds.data_vars) == 11
     assert "standard_name" not in ds["concso4pm25"].attrs
+    assert ds.longitude.max() == 180.0


### PR DESCRIPTION
## Change Summary

This extends the cams2_83 reader so that having on disk files that contain the extra variables will not blow up the memory, even though the variables are, at this stage, not read in. 
The extra variables are kept instead of being dropped in preparation for having to actually use them... 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
