### PR TITLE
Appends new EBAS obs to std config

### DIFF
--- a/pyaerocom/aeroval/config/emep/reporting_base.py
+++ b/pyaerocom/aeroval/config/emep/reporting_base.py
@@ -162,6 +162,36 @@ def clean_filters(cfg: dict, obs_pattern: str) -> dict:
     return CFG
 
 
+def add_EBAS_with_station_classification(cfg: dict, station_classification: str):
+    """
+    Adds new EBAS networks for only given station_classification (U, R or G). The networks are appended to the
+    list of networks, with new names
+    """
+    if station_classification not in ["U", "R", "G"]:
+        raise ValueError(f"station_classification {station_classification} must be U, R or G")
+
+    CFG = copy.deepcopy(cfg)
+    for network in cfg["obs_cfg"].keys():
+        if network.startswith("EBAS"):
+            new_network = network + f"-{station_classification}"
+            CFG["obs_cfg"][new_network] = copy.deepcopy(cfg["obs_cfg"][network])
+            for v in CFG["obs_cfg"][new_network]["obs_filters"]:
+                print(v)
+                if not isinstance(CFG["obs_cfg"][new_network]["obs_filters"][v], dict):
+                    continue
+                nf = CFG["obs_cfg"][new_network]["obs_filters"][v]["station_id"]
+
+                if f"*{station_classification}" in nf:
+                    raise ValueError(
+                        f"Filter for {new_network} is already ignoring all stations with classification {station_classification}"
+                    )
+                CFG["obs_cfg"][new_network]["obs_filters"][v]["station_id"] += [
+                    f"*{i}" for i in "UGR".replace(station_classification, "")
+                ]
+
+    return CFG
+
+
 def get_CFG(reportyear, year, model_dir, omit_stations_path=DEFAULT_OMIT_STATION_PATH) -> dict:
     """Get a configuration usable for emep reporting
 

--- a/pyaerocom/aeroval/config/emep/reporting_base.py
+++ b/pyaerocom/aeroval/config/emep/reporting_base.py
@@ -162,7 +162,9 @@ def clean_filters(cfg: dict, obs_pattern: str) -> dict:
     return CFG
 
 
-def add_EBAS_with_station_classification(cfg: dict, station_classification: str):
+def add_EBAS_with_station_classification(
+    cfg: dict, station_classification: str
+):  # pragma: no cover
     """
     Adds new EBAS networks for only given station_classification (U, R or G). The networks are appended to the
     list of networks, with new names

--- a/pyaerocom/io/aux_components_fun.py
+++ b/pyaerocom/io/aux_components_fun.py
@@ -123,7 +123,7 @@ def calc_concno3pm25(concno3f, concno3c, fine_from_coarse_fraction: float = 0.13
     # mult_fun = CUBE_MATHS["multiply"]
     # concno3pm25 = add_cubes(concno3f, mult_fun(concno3c, fine_from_coarse_fraction))
 
-    return concno3f
+    return concno3f.cube
 
 
 def calc_concno3pm10(concno3f, concno3c):


### PR DESCRIPTION
## Change Summary

Adds a function to add new EBAS networks for only station classification U, R or G. This is done so that people can look at only stations of said classification. Wish from David and Hilde


## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
