### PR TITLE
prevent attributes of original variables to be edited

### DIFF
--- a/pyaerocom/io/cams2_82/reader.py
+++ b/pyaerocom/io/cams2_82/reader.py
@@ -4,6 +4,7 @@ import logging
 from collections.abc import Iterator
 from datetime import date, datetime
 from pathlib import Path
+from copy import deepcopy
 
 import numpy as np
 import pandas as pd
@@ -256,12 +257,12 @@ def fix_missing_vars(ds: xr.Dataset) -> xr.Dataset:
     if nb_vars < 6:
         logger.warning(f"Found only {vars_list}. Filling the rest with NaNs")
 
-        dummy_var = ds[vars_list[0]]
+        dummy_var = deepcopy(ds[vars_list[0]])
         dummy_var_name = vars_list[0]
         for species in AEROCOM_NAMES:
             if species not in vars_list:
                 ds = ds.assign(**{species: dummy_var * np.nan})
-                attrs = ds[dummy_var_name].attrs
+                attrs = deepcopy(ds[dummy_var_name].attrs)
                 attrs["species"] = FULL_NAMES[species]
                 attrs["standard_name"] = STANDARD_NAMES[species]
                 ds[species] = ds[species].assign_attrs(attrs)


### PR DESCRIPTION
## Change Summary

fix small bug where the attributes of the variable used in the fix_missing_variables function of the cams2_82 reader were destroyed

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
