### PR TITLE
use a time-independent name for the metadata file for cams2_83 obs

### DIFF
--- a/pyaerocom/io/cams2_83/obs.py
+++ b/pyaerocom/io/cams2_83/obs.py
@@ -19,7 +19,7 @@ CAMS2_50_DOMAIN = SimpleNamespace(
     lon=(-25, 45),  # °E
 )
 
-DEFAULT_METADATA_NAME = "mf_stations_list_classification_2025.csv"
+DEFAULT_METADATA_NAME = "mf_stations_list_classification.csv"
 
 
 class Domain(Protocol):


### PR DESCRIPTION

## Change Summary

The hard-coded filename was chosen to be mf_stations_list_classification_2025.csv with a reference to the creation year, but since it turns out it needs to be updated every year, a more generic filaneme is preferrable. On disk this will be a symlink to mf_stations_list_classification_[LATESTYEARAVAILABLE].csv

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
