### PR TITLE
make variables `concoa` and `concbc` work again (NorESM)

### DIFF
--- a/pyaerocom/units/molecular_mass.py
+++ b/pyaerocom/units/molecular_mass.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import sys
 
 if sys.version_info >= (3, 12):
@@ -38,12 +39,19 @@ _MOLMASSES = {
     # Override molecular masses used for species that do not constitute molecular
     # formulas with only single letter elements.
     "air_dry": 28.9647,
+    "concpm10": 28.9647,
+    "concpm25": 28.9647,
+    "concoa": 28.9647,
+    "concbc": 28.9647,
     "isop": 68.12,
     "glyoxal": 58.036,
     "glyox": 58.036,
 }
 
-_SPECIES_OVERRIDE = {"concso4c": "SO4"}
+_SPECIES_OVERRIDE = {
+    "concso4c": "SO4",
+    "concso4t": "SO4",
+}
 
 
 class UnknownSpeciesError(ValueError):


### PR DESCRIPTION
## Change Summary
As of today, the variables `concoa` and `concbc` aren't usable in pyaerocom anymore. The issue is showing this for the EBASMC network.

This PR tries to solve this. but the Units module seems to account to chemical species only atm. (e.g. concso4).
But there's also 
- concoa
- concbc
- concpm10
- concpm25

## Related issue number
#1810 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [ ] Make PR ready to review
