### PR TITLE
add component mass_69_organic_compounds to variable vmrisop

### DIFF
--- a/pyaerocom/data/ebas_config.ini
+++ b/pyaerocom/data/ebas_config.ini
@@ -363,7 +363,7 @@ component=nitrogen_monoxide
 matrix=air
 
 [vmrisop]
-component=isoprene
+component=isoprene,mass_69_organic_compounds
 matrix=air
 
 [vmrhcho]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "pyaerocom"
-version = "0.38.dev0"
+version = "0.38.dev2026"
 authors = [{ name = "MET Norway" }]
 description = "pyaerocom model evaluation software"
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "pyaerocom"
-version = "0.38.dev2026"
+version = "0.38.dev0"
 authors = [{ name = "MET Norway" }]
 description = "pyaerocom model evaluation software"
 classifiers = [


### PR DESCRIPTION
## Change Summary

add component `mass_69_organic_compounds` to variable `vmrisop` for `EBASMC` network

## Related issue number

fix #1812 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
