### PR TITLE
fix min_num_obs, data is 3-hourly

### DIFF
--- a/pyaerocom/scripts/cams2_82/config.py
+++ b/pyaerocom/scripts/cams2_82/config.py
@@ -77,8 +77,8 @@ GLOBAL_CONFIG = dict(
     ],
     min_num_obs=dict(
         # yearly=dict(monthly=9),
-        monthly=dict(daily=21, weekly=3),
-        daily=dict(hourly=18),
+        # monthly=dict(daily=21, weekly=3), # not used
+        daily=dict(hourly=6), # 3-hourly data
     ),
 )
 


### PR DESCRIPTION
## Change Summary

data is 3hourly for cams282 so 
```
"min_num_obs": {
    "monthly": {
      "daily": 21,
      "weekly": 3
    },
    "daily": {
      "hourly": 18
    }
  },
  ```
  does not make sense  
  back to 
  ```
   "daily": {
      "hourly": 6
   }
  ```

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
