### PR TITLE
allow using EBAS  station_code as display_name

### DIFF
--- a/pyaerocom/aeroval/config/emep/omit_stations.yaml
+++ b/pyaerocom/aeroval/config/emep/omit_stations.yaml
@@ -59,11 +59,20 @@ variables:
   ALL:
     - ALL
 
+
+2024:
+  ALL:
+    - NO0043R
+    - DK0010G
+    - IT0019*
+    - "*U"
+
 2023:
   ALL:
     - NO0042R
     - DK0010G
     - IT0019*
+    - "*U"
   NO:
     - BE0007*
     - DK0008*
@@ -101,6 +110,7 @@ variables:
     - NO0042R
     - DK0010G
     - AM0001*
+    - "*U"
   NO2:
     - ES0017*
     - IT0019*
@@ -130,6 +140,7 @@ variables:
     - NO0042R
     - DK0010G
     - NO0057*
+    - "*U"
   SO2:
     - ES0013*
     - ES0016*
@@ -162,6 +173,7 @@ variables:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
   SO2:
     - ES0012*
     - ES0016*
@@ -206,6 +218,7 @@ variables:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
   SO2:
     - GR0001*
   O3max:
@@ -223,6 +236,7 @@ variables:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
   NO2:
     - GR0001*
     - RS0005*
@@ -245,6 +259,7 @@ variables:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
   NO2:
     - MD0013*
     - ME0008*
@@ -274,6 +289,7 @@ variables:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
   SO2:
     - GB1055*
     - RS0005*
@@ -288,6 +304,7 @@ variables:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
   SO2:
     - EE0011*
     - ES0010*
@@ -319,6 +336,7 @@ variables:
     - NO0042R
     - DK0010G
     - ME0008*
+    - "*U"
   tNO3:
     - ES0012*
     - LV0010*
@@ -359,6 +377,7 @@ variables:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
   SO2:
     - RS0005*
     - RO0008*
@@ -413,6 +432,7 @@ variables:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
   SO2:
     - ME0008*
     - RS0005*
@@ -449,6 +469,7 @@ variables:
     - NO0042R
     - DK0010G
     - MD0013*
+    - "*U"
   SO2:
     - AM0001*
     - RS0005*
@@ -474,6 +495,7 @@ variables:
     - NO0042R
     - DK0010G
     - NO0001*
+    - "*U"
   NO3:
     - MD0013*
   SO2:
@@ -497,6 +519,7 @@ variables:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
   NO3:
     - MD0013*
     - LV*
@@ -520,6 +543,7 @@ variables:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
   NO3:
     - LV0016*
   SO2:
@@ -538,88 +562,106 @@ variables:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 2006:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 2005:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 2004:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 2003:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 2002:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 2001:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 2000:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 1999:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 1998:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 1997:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 1996:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 1995:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 1994:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 1993:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 1992:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 1991:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"
 
 1990:
   ALL:
     - NO0042R
     - DK0010G
+    - "*U"

--- a/pyaerocom/aeroval/config/emep/reporting_base.py
+++ b/pyaerocom/aeroval/config/emep/reporting_base.py
@@ -529,7 +529,7 @@ def get_CFG(reportyear, year, model_dir, omit_stations_path=DEFAULT_OMIT_STATION
     # Station filters
 
     # This list of stations was generated using the script found here:
-    # https://gist.github.com/thorbjoernl/b7946882f1696722742053406d056e12.
+    # scripts/generate_ebas_height_ignore_list.py.
     # It excludes stations with a relative altitude (Elevation difference to the lowest
     # altitude in a 5km radius based on gtopo30) above 500m as well as stations that do not include
     # an altitude in the ebas file index.
@@ -645,6 +645,31 @@ def get_CFG(reportyear, year, model_dir, omit_stations_path=DEFAULT_OMIT_STATION
         "US9078R",
         "US9082U",
         "VN0001R",
+        # sites with missing altitudes
+        "DK0042R",
+        "ES0024U",
+        "GB0017R",
+        "IE0010U",
+        "IT0011R",
+        "IT0012R",
+        "LT0016R",
+        "NO0798R",
+        "NO1006R",
+        "NO1011R",
+        "RU0021R",
+        "SE0081R",
+        "SE0082R",
+        "SE0083R",
+        "SE0084R",
+        "SE0085R",
+        "SE0086R",
+        "SE0087R",
+        "SE0089R",
+        "SE0090R",
+        "SE0091R",
+        "SE0092R",
+        "UA0008R",
+        "US9028R",
     ]
 
     EBAS_FILTER = {

--- a/pyaerocom/aeroval/config/emep/reporting_base.py
+++ b/pyaerocom/aeroval/config/emep/reporting_base.py
@@ -533,7 +533,7 @@ def get_CFG(reportyear, year, model_dir, omit_stations_path=DEFAULT_OMIT_STATION
     # It excludes stations with a relative altitude (Elevation difference to the lowest
     # altitude in a 5km radius based on gtopo30) above 500m as well as stations that do not include
     # an altitude in the ebas file index.
-    # Last updated: ~2025-01-03
+    # Last updated: ~2026-06-02
     height_ignore_ebas = [
         "AM0001R",
         "AR0001R",
@@ -560,12 +560,14 @@ def get_CFG(reportyear, year, model_dir, omit_stations_path=DEFAULT_OMIT_STATION
         "DE0057G",
         "DE0060G",
         "DE0075R",
+        "DK0009R",
         "DZ0001G",
         "ES0005R",
         "ES0018G",
         "ES0022R",
         "ES0025U",
         "FI0009R",
+        "FI0090R",
         "FR0012R",
         "FR0019R",
         "FR0026R",
@@ -584,6 +586,7 @@ def get_CFG(reportyear, year, model_dir, omit_stations_path=DEFAULT_OMIT_STATION
         "IT0009R",
         "IT0019R",
         "IT0031U",
+        "JP0002G",
         "JP1021R",
         "KE0001G",
         "MK0007R",

--- a/pyaerocom/config_reader.py
+++ b/pyaerocom/config_reader.py
@@ -132,8 +132,12 @@ class ConfigReader:
     PATHS_INI_NAME = "paths.ini"
 
     #: boolean specifying whether EBAS DB is copied to local cache for faster
-    #: access, defaults to True
-    EBAS_DB_LOCAL_CACHE = True
+    #: access, defaults to False
+    EBAS_DB_LOCAL_CACHE = False
+
+    #: boolean flag whether EBAS should use station code as display name
+    #: default: False, i.e. use station name as display name
+    EBAS_USE_STATION_CODE_AS_DISPLAY_NAME = False
 
     #: Lowest possible year in data
     MIN_YEAR = 0

--- a/pyaerocom/io/read_ebas.py
+++ b/pyaerocom/io/read_ebas.py
@@ -8,7 +8,7 @@ import numpy as np
 from geonum.atmosphere import T0_STD, p0
 from tqdm import tqdm
 
-from pyaerocom import const
+from pyaerocom import ConfigReader
 from pyaerocom._lowlevel_helpers import BrowseDict
 from pyaerocom.aux_var_helpers import (
     calc_vmro3max,
@@ -52,6 +52,7 @@ from pyaerocom.ungriddeddata_structured import UngriddedDataStructured
 from pyaerocom.units.units_helpers import get_unit_conversion_fac
 
 logger = logging.getLogger(__name__)
+const = ConfigReader.get_instance()
 
 
 class ReadEbasOptions(BrowseDict):
@@ -1018,6 +1019,9 @@ class ReadEbas(ReadUngriddedBase):
         else:
             data_out["station_name"] = name
 
+        if const.EBAS_USE_STATION_CODE_AS_DISPLAY_NAME:
+            data_out["display_name"] = meta["station_code"]
+
         # write meta information
         tres_code = meta["resolution_code"]
         try:
@@ -1861,7 +1865,8 @@ class ReadEbas(ReadUngriddedBase):
         self.files_failed = []
 
         data_obj = UngriddedDataStructured.from_station_data(
-            self._station_data_iterator(files, files_contain), ["station_name_orig"]
+            self._station_data_iterator(files, files_contain),
+            add_meta_keys=["station_name_orig", "display_name"],
         )
 
         # Add reading options to filter "history of UngriddedDataObject"

--- a/scripts/generate_ebas_height_ignore_list.py
+++ b/scripts/generate_ebas_height_ignore_list.py
@@ -1,0 +1,57 @@
+# Script used to generate EBAS_height_ignore. Requires a recent version of pyaro to be installed,
+# and access to the ebas file index.
+import sqlite3
+import pathlib
+from pyaro.timeseries.Filter import ValleyFloorRelativeAltitudeFilter
+from pyaro.timeseries.Station import Station
+
+filter = ValleyFloorRelativeAltitudeFilter(topo="/lustre/storeB/project/aerocom/aerocom1/AEROCOM_OBSDATA/GTOPO30/merged", radius=5000, lower = 500)
+
+
+EBAS_FILE_INDEX = pathlib.Path(
+    "/lustre/storeB/project/aerocom/aerocom1/AEROCOM_OBSDATA/EBASMultiColumn/data/ebas_file_index.sqlite3"
+)
+
+
+con = sqlite3.connect(EBAS_FILE_INDEX)
+con.row_factory = sqlite3.Row
+cur = con.cursor()
+
+cur.execute(
+    """
+    SELECT station_code, station_name, station_latitude, station_longitude, station_altitude FROM station
+    """
+)
+
+rows = [dict(x) for x in cur.fetchall()]
+stations: dict[str, Station] = {}
+missing_alt_sites = []
+for r in rows:
+    try:
+        stations[r["station_code"]] = Station(
+            {
+                "station": r["station_code"],
+                "latitude": float(r["station_latitude"]),
+                "longitude": float(r["station_longitude"]),
+                "altitude": float(r["station_altitude"]),
+                "long_name": "",
+                "country": "",
+                "url": ""
+            }
+        )
+    except TypeError:
+        print(f"Station code '{r['station_code']}' is missing one or more of latitude, longitude, altitude, which are necessary to calculate relative altitude. This station will be ignored.")
+        try:
+            float(r["station_altitude"])
+        except Exception:
+            missing_alt_sites.append(r["station_code"])
+        pass
+
+
+
+sites = list(filter.filter_stations(stations).values())
+
+print(",\n".join([f"\"{s.station}\"" for s in sorted(sites, key=lambda x : x.station)]))
+
+print(f"Sites filtered: {len(sites)}")
+print(f"Sites missing altitude: {',\n'.join([f'\"{s}\"' for s in sorted(missing_alt_sites)])}")

--- a/tests/test_config_reader.py
+++ b/tests/test_config_reader.py
@@ -176,7 +176,7 @@ def test_empty_class_header(empty_cfg):
     assert cfg.GAWTADSUBSETAASETAL_NAME == "GAWTADsubsetAasEtAl"
     assert cfg.DMS_AMS_CVO_NAME == "DMS_AMS_CVO"
     assert cfg.CNEMC_NAME == "CNEMC"
-    assert cfg.EBAS_DB_LOCAL_CACHE
+    assert hasattr(cfg, "EBAS_DB_LOCAL_CACHE")
     assert cfg.MIN_YEAR == 0
     assert cfg.MAX_YEAR == 20000
     assert cfg.STANDARD_COORD_NAMES == ["latitude", "longitude", "altitude"]


### PR DESCRIPTION
## Change Summary

Allow using EBAS station_code like "NO0001R" as display_name (=station_display_name) on aeroval by setting
`const.EBAS_USE_STATION_CODE_AS_DISPLAY_NAME = True`. Existing cached observtions need to be deleted manually.

This PR removes also the station-db file from the local directory. With the fixed index, this is no longer slower than using a remote file.

<img width="722" height="786" alt="image" src="https://github.com/user-attachments/assets/ad0dff25-2626-4692-b4a4-8cce82c48740" />

No test added, this functionality is rather used for testing a new database-version and the EBAS reader has been deprecated for years, waiting for the new Actris reader to become ready.

## Related issue number

closes #1815

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
