### PR TITLE
tweak _colocate_site_data_helper_timecol even more

### DIFF
--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -535,6 +535,11 @@ def _colocate_site_data_helper_timecol(
         inplace=True,
     )
 
+    # zero the obs if there is a matching model timestamp where data in NaN
+    nanmodtimes = stat_data[var_ref].index[np.where(stat_data[var_ref].isna())]
+    if set(nanmodtimes).issubset(stat_data_ref[var_ref].index):
+        stat_data_ref[var_ref].loc[nanmodtimes] = np.nan
+
     # Save time indices of the observations and a mask of where it is NaN
     obs_idx = stat_data_ref[var_ref].index
     obs_isnan = stat_data_ref[var_ref].isnull()

--- a/pyaerocom/colocation/colocation_utils.py
+++ b/pyaerocom/colocation/colocation_utils.py
@@ -536,7 +536,7 @@ def _colocate_site_data_helper_timecol(
     )
 
     # zero the obs if there is a matching model timestamp where data in NaN
-    nanmodtimes = stat_data[var_ref].index[np.where(stat_data[var_ref].isna())]
+    nanmodtimes = stat_data[var].index[np.where(stat_data[var].isna())]
     if set(nanmodtimes).issubset(stat_data_ref[var_ref].index):
         stat_data_ref[var_ref].loc[nanmodtimes] = np.nan
 

--- a/tests/colocation/test_colocation_utils.py
+++ b/tests/colocation/test_colocation_utils.py
@@ -74,13 +74,26 @@ S4 = create_fake_station_data(
 
 S4["concpm10"][0:5] = range(5)
 
+S5 = create_fake_station_data(
+    "concpm10",
+    {"concpm10": {"units": "ug m-3"}},
+    10,
+    "2010-01-01",
+    "2010-12-31",
+    "D",
+    {"ts_type": "daily"},
+)
+
+S5["concpm10"][23] = np.nan
+S5["concpm10"][66] = np.nan
+
 
 @pytest.mark.parametrize(
     "stat_data,stat_data_ref,var,var_ref,ts_type,resample_how,min_num_obs, use_climatology_ref,num_valid",
     [
         (
-            S4,
-            S3,
+            S4,  # model data daily from 1st march 2020 to end of 2011
+            S3,  # obs data 13daily for 2010
             "concpm10",
             "concpm10",
             "monthly",
@@ -100,6 +113,7 @@ S4["concpm10"][0:5] = range(5)
             False,
             11,
         ),
+        (S5, S2, "concpm10", "concpm10", "daily", "mean", 25, {}, 363),
         (S1, S2, "concpm10", "concpm10", "monthly", "mean", 25, {}, 11),
         (S2, S1, "concpm10", "concpm10", "monthly", "mean", 25, {}, 11),
     ],


### PR DESCRIPTION
if resampled time series match in `_colocate_site_data_helper_timecol`(which is used used if option `colocate_time` is active in colocation routine `colocate_gridded_ungridded`), set obs data as null a priori if matching model data is null


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- WARNING: please use "fix #123" style references so the issue is closed when this PR is merged. -->

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
