### PR TITLE
fix open_mfdataset join to old default

### DIFF
--- a/pyaerocom/io/mscw_ctm/reader.py
+++ b/pyaerocom/io/mscw_ctm/reader.py
@@ -611,7 +611,9 @@ class ReadMscwCtm(GriddedReader):
                 )
 
         logger.info(f"Opening {fps}")
-        ds = xr.open_mfdataset(fps, chunks={"time": 24}, decode_timedelta=True)
+        # join="exact" became new default in xarray 2025.08.0 with `use_new_combine_kwarg_defaults`
+        # use join="outer" since trend-runs might not be 100% homogeneous
+        ds = xr.open_mfdataset(fps, chunks={"time": 24}, decode_timedelta=True, join="outer")
 
         self._private.filedata = ds
 


### PR DESCRIPTION
## Change Summary

To avoid FutureWarnings, in October 2025 pyaerocom enabled `use_new_combine_kwarg_defaults`. This changes the default for join-operations from `outer` to `exact`.

Trend runs are often inhomogeneous with older years having less variables. Therefore, for the mscw-Reader, an explicit `join="outer"` is needed for `open_mfdataset`.

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [ ] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
