### PR TITLE
Only try somo30/mda8 on hourly data

### DIFF
--- a/pyaerocom/colocation/colocated_data.py
+++ b/pyaerocom/colocation/colocated_data.py
@@ -1230,12 +1230,13 @@ class ColocatedData(BaseModel):
     @staticmethod
     def _build_netcdf_encoding(ds: xr.Dataset) -> dict:
         encoding = {}
-        for name, da in ds.data_vars.items():
+        nc_vars = list(ds.data_vars.keys()) + list(ds.coords.keys())
+        for nc_var in nc_vars:
             var_encoding = {
                 "zlib": True,
                 "complevel": 1,
             }
-            encoding[name] = var_encoding
+            encoding[nc_var] = var_encoding
         return encoding
 
     def to_netcdf(self, out_dir, savename=None, **kwargs):

--- a/pyaerocom/colocation/colocated_data.py
+++ b/pyaerocom/colocation/colocated_data.py
@@ -1227,6 +1227,17 @@ class ColocatedData(BaseModel):
                 meta_out[key] = val
         return meta_out
 
+    @staticmethod
+    def _build_netcdf_encoding(ds: xr.Dataset) -> dict:
+        encoding = {}
+        for name, da in ds.data_vars.items():
+            var_encoding = {
+                "zlib": True,
+                "complevel": 1,
+            }
+            encoding[name] = var_encoding
+        return encoding
+
     def to_netcdf(self, out_dir, savename=None, **kwargs):
         """Save data object as NetCDF file
 
@@ -1256,8 +1267,11 @@ class ColocatedData(BaseModel):
             savename = f"{savename}.nc"
         arr = self.data.copy()
         arr.attrs = self._prepare_meta_to_netcdf()
+        ds = arr.to_dataset()
+        if "encoding" not in kwargs:
+            kwargs["encoding"] = self._build_netcdf_encoding(ds)
         fp = os.path.join(out_dir, savename)
-        arr.to_netcdf(path=fp, **kwargs)
+        ds.to_netcdf(path=fp, **kwargs)
         return fp
 
     def _meta_from_netcdf(self, imported_meta):

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -432,41 +432,42 @@ class Colocator:
                 )  # note this can be ColocatedData or ColocatedDataLists
                 data_out[mod_var][obs_var] = coldata
 
-                if calc_mda8 and (obs_var in MDA8_INPUT_VARS):
-                    try:
-                        mda8 = mda8_colocated_data(
-                            coldata, obs_var=f"{obs_var}mda8", mod_var=f"{mod_var}mda8"
-                        )
-                    except Exception as e:
-                        logger.error(
-                            f"Exception during colocation of mda8: {e} {traceback.format_exc()} ❌"
-                        )
-                    else:
-                        self._save_coldata(mda8)
-                        logger.info(
-                            "Successfully calculated mda8 for [%s, %s]. 🟢",
-                            obs_var,
-                            mod_var,
-                        )
-                        data_out[f"{mod_var}mda8"][f"{obs_var}mda8"] = mda8
+                if coldata.ts_type == "hourly":
+                    if calc_mda8 and (obs_var in MDA8_INPUT_VARS):
+                        try:
+                            mda8 = mda8_colocated_data(
+                                coldata, obs_var=f"{obs_var}mda8", mod_var=f"{mod_var}mda8"
+                            )
+                        except Exception as e:
+                            logger.error(
+                                f"Exception during colocation of mda8: {e} {traceback.format_exc()} ❌"
+                            )
+                        else:
+                            self._save_coldata(mda8)
+                            logger.info(
+                                "Successfully calculated mda8 for [%s, %s]. 🟢",
+                                obs_var,
+                                mod_var,
+                            )
+                            data_out[f"{mod_var}mda8"][f"{obs_var}mda8"] = mda8
 
-                if calc_somo30 and (obs_var in SOMO30_INPUT_VARS):
-                    try:
-                        somo30 = somo30_colocated_data(
-                            coldata, obs_var=f"{obs_var}somo30", mod_var=f"{mod_var}somo30"
-                        )
-                    except Exception as e:
-                        logger.error(
-                            f"Exception during colocation of somo30: {e} {traceback.format_exc()} ❌"
-                        )
-                    else:
-                        self._save_coldata(somo30)
-                        logger.info(
-                            "Successfully calculated somo30 for [%s, %s]. 🟢",
-                            obs_var,
-                            mod_var,
-                        )
-                        data_out[f"{mod_var}somo30"][f"{obs_var}somo30"] = somo30
+                    if calc_somo30 and (obs_var in SOMO30_INPUT_VARS):
+                        try:
+                            somo30 = somo30_colocated_data(
+                                coldata, obs_var=f"{obs_var}somo30", mod_var=f"{mod_var}somo30"
+                            )
+                        except Exception as e:
+                            logger.error(
+                                f"Exception during colocation of somo30: {e} {traceback.format_exc()} ❌"
+                            )
+                        else:
+                            self._save_coldata(somo30)
+                            logger.info(
+                                "Successfully calculated somo30 for [%s, %s]. 🟢",
+                                obs_var,
+                                mod_var,
+                            )
+                            data_out[f"{mod_var}somo30"][f"{obs_var}somo30"] = somo30
 
                 self._processing_status.append((mod_var, obs_var, 1))
             except Exception:

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -468,6 +468,10 @@ class Colocator:
                                 mod_var,
                             )
                             data_out[f"{mod_var}somo30"][f"{obs_var}somo30"] = somo30
+                else:
+                    logger.info(
+                        f"Skipping mda8 and somo30 calculation for [{obs_var}, {mod_var}] because ts_type is {coldata.ts_type}, hourly needed 🟡"
+                    )
 
                 self._processing_status.append((mod_var, obs_var, 1))
             except Exception:

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -469,9 +469,12 @@ class Colocator:
                             )
                             data_out[f"{mod_var}somo30"][f"{obs_var}somo30"] = somo30
                 else:
-                    logger.info(
-                        f"Skipping mda8 and somo30 calculation for [{obs_var}, {mod_var}] because ts_type is {coldata.ts_type}, hourly needed 🟡"
-                    )
+                    if (calc_mda8 and (obs_var in MDA8_INPUT_VARS)) or (
+                        calc_somo30 and (obs_var in SOMO30_INPUT_VARS)
+                    ):
+                        logger.info(
+                            f"Skipping somo30/mda8 calculation for [{obs_var}, {mod_var}] because ts_type is {coldata.ts_type}, hourly needed ⚠️"
+                        )
 
                 self._processing_status.append((mod_var, obs_var, 1))
             except Exception:
@@ -979,9 +982,8 @@ class Colocator:
 
         else:
             savename = self._coldata_savename(obs_var, mvar, coldata.ts_type)
-        fp = coldata.to_netcdf(
-            self.output_dir, savename=savename, compress=True, compression_level=1
-        )
+
+        fp = coldata.to_netcdf(self.output_dir, savename=savename)
         self.files_written.append(fp)
         msg = f"WRITE: {fp}\n"
         logger.info(msg)

--- a/pyaerocom/colocation/colocator.py
+++ b/pyaerocom/colocation/colocator.py
@@ -979,7 +979,9 @@ class Colocator:
 
         else:
             savename = self._coldata_savename(obs_var, mvar, coldata.ts_type)
-        fp = coldata.to_netcdf(self.output_dir, savename=savename)
+        fp = coldata.to_netcdf(
+            self.output_dir, savename=savename, compress=True, compression_level=1
+        )
         self.files_written.append(fp)
         msg = f"WRITE: {fp}\n"
         logger.info(msg)


### PR DESCRIPTION
## Change Summary

When no hourly data is given, but O3 data available, SOMO and MDA8 results cannot be calculated. This raises currently an exception, but just is expected and should be ignored.

In addition, colocated objects are now saved using netcdf-compress-level 1.


## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [ ] At least 1 reviewer is selected
* [x] Make PR ready to review
