### PR TITLE
fix unspecified error description when projection-information was wrong

### DIFF
--- a/pyaerocom/io/mscw_ctm/reader.py
+++ b/pyaerocom/io/mscw_ctm/reader.py
@@ -852,9 +852,9 @@ class ReadMscwCtm(GriddedReader):
             filedata = self._filedata
             data = filedata[emep_var]
             proj_info = ProjectionInformation.from_xarray(filedata, emep_var)
-        except KeyError:
+        except KeyError as ke:
             raise VarNotAvailableError(
-                f"{var_name_aerocom} ({emep_var}) not available in {self._filename}"
+                f"{var_name_aerocom} ({emep_var}) not available in {self._filename}: {ke}"
             )
         data.attrs["long_name"] = var_name_aerocom
         data.time.attrs["long_name"] = "time"

--- a/tests/io/mscw_ctm/test_reader.py
+++ b/tests/io/mscw_ctm/test_reader.py
@@ -364,7 +364,7 @@ def test_read_emep_dummy_data_error(tmp_path: Path):
     reader = ReadMscwCtm(data_dir=str(data_path / "2017"))
     with pytest.raises(exc.VarNotAvailableError) as e:
         reader.read_var("concno3", ts_type="daily")
-    assert str(e.value) == "concno3f (SURF_ug_NO3_F) not available in Base_day.nc"
+    assert str(e.value).startswith("concno3f (SURF_ug_NO3_F) not available in Base_day.nc")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Summary

KeyErrors where reraised without information about the wrong key, which made the logs not understandable.

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [ ] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
