### PR TITLE
Fix 1819

### DIFF
--- a/pyaerocom/colocation/colocation_setup.py
+++ b/pyaerocom/colocation/colocation_setup.py
@@ -337,6 +337,8 @@ class ColocationSetup(BaseModel):
             return v
         if isinstance(v, str):
             return pd.Timestamp(v)
+        if isinstance(v, pd.Timestamp):
+            return v
 
     pyaro_config: PyaroConfig | None = None
 

--- a/pyaerocom/io/aux_components_fun.py
+++ b/pyaerocom/io/aux_components_fun.py
@@ -123,7 +123,7 @@ def calc_concno3pm25(concno3f, concno3c, fine_from_coarse_fraction: float = 0.13
     # mult_fun = CUBE_MATHS["multiply"]
     # concno3pm25 = add_cubes(concno3f, mult_fun(concno3c, fine_from_coarse_fraction))
 
-    return concno3f
+    return concno3f.cube
 
 
 def calc_concno3pm10(concno3f, concno3c):

--- a/pyaerocom/io/aux_components_fun.py
+++ b/pyaerocom/io/aux_components_fun.py
@@ -123,7 +123,7 @@ def calc_concno3pm25(concno3f, concno3c, fine_from_coarse_fraction: float = 0.13
     # mult_fun = CUBE_MATHS["multiply"]
     # concno3pm25 = add_cubes(concno3f, mult_fun(concno3c, fine_from_coarse_fraction))
 
-    return concno3f.cube
+    return concno3f
 
 
 def calc_concno3pm10(concno3f, concno3c):

--- a/tests/colocation/test_colocation_setup.py
+++ b/tests/colocation/test_colocation_setup.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
+import pandas as pd
+
 from pyaerocom import const
 from pyaerocom.colocation.colocation_setup import ColocationSetup
 from pyaerocom.config_reader import ALL_REGION_NAME
@@ -74,3 +76,26 @@ def test_ColocationSetup_model_kwargs_validationerror() -> None:
 
     with pytest.raises(ValidationError, match="Key ts_type not allowed in model_kwargs "):
         ColocationSetup(**default_setup, model_kwargs={"emep_vars": {}, "ts_type": "daily"})
+
+
+def test_ColocationSetup_model_kwargs_start_stop_validationerror():
+    stp_none = ColocationSetup(**default_setup)
+
+    default_setup["start"] = 2000
+    default_setup["stop"] = 2010
+    stp_int = ColocationSetup(**default_setup)
+    assert stp_int.start == 2000
+    assert stp_int.stop == 2010
+
+    default_setup["start"] = pd.Timestamp("2000-01-01")
+    default_setup["stop"] = pd.Timestamp("2010-12-31")
+    stp_pd = ColocationSetup(**default_setup)
+
+    assert stp_pd.start == pd.Timestamp("2000-01-01")
+    assert stp_pd.stop == pd.Timestamp("2010-12-31")
+
+    with pytest.raises(ValidationError, match="6 validation errors for ColocationSetup"):
+        default_setup["start"] = ["2000-01-01"]
+        default_setup["stop"] = ["2010-12-31"]
+        breakpoint()
+        ColocationSetup(**default_setup)

--- a/tests/colocation/test_colocation_setup.py
+++ b/tests/colocation/test_colocation_setup.py
@@ -81,6 +81,9 @@ def test_ColocationSetup_model_kwargs_validationerror() -> None:
 def test_ColocationSetup_model_kwargs_start_stop_validationerror():
     stp_none = ColocationSetup(**default_setup)
 
+    assert stp_none.start is None
+    assert stp_none.stop is None
+
     default_setup["start"] = 2000
     default_setup["stop"] = 2010
     stp_int = ColocationSetup(**default_setup)

--- a/tests/colocation/test_colocation_setup.py
+++ b/tests/colocation/test_colocation_setup.py
@@ -100,5 +100,4 @@ def test_ColocationSetup_model_kwargs_start_stop_validationerror():
     with pytest.raises(ValidationError, match="6 validation errors for ColocationSetup"):
         default_setup["start"] = ["2000-01-01"]
         default_setup["stop"] = ["2010-12-31"]
-        breakpoint()
         ColocationSetup(**default_setup)


### PR DESCRIPTION
## Change Summary

Fixes a bug where start and stop passed in as pd.Timestamps into ColocationSetup are set as None by the validator.

Fixes also a bug in calc_concno3pm25 which did not return the correct datatype.

## Related issue number

Fixes #1819 

## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [x] PR is set to AeroTools and a tentative milestone
* [x] Documentation reflects the changes where applicable
* [x] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
