### PR TITLE
cams282 tweaks to accomodate for hourly data 

### DIFF
--- a/pyaerocom/io/cams2_82/reader.py
+++ b/pyaerocom/io/cams2_82/reader.py
@@ -287,7 +287,7 @@ def read_dataset(paths: list[Path]) -> xr.Dataset:
         return ds.pipe(only_first_day).pipe(drop_vars).pipe(interpolate_hourly)
 
     ds = xr.open_mfdataset(
-        paths, preprocess=preprocess, parallel=False, join="outer", chunks={"level": 10, "time": 1}
+        paths, preprocess=preprocess, parallel=False, join="outer", chunks={"level": 10, "time": 2}
     )
     return ds.pipe(fix_missing_vars).pipe(convert_units).pipe(fix_names)
 

--- a/pyaerocom/io/cams2_82/reader.py
+++ b/pyaerocom/io/cams2_82/reader.py
@@ -282,7 +282,7 @@ def read_dataset(paths: list[Path]) -> xr.Dataset:
         return ds.pipe(only_first_day).pipe(drop_vars)
 
     ds = xr.open_mfdataset(
-        paths, preprocess=preprocess, parallel=False, chunks={"level": 10, "time": 1}
+        paths, preprocess=preprocess, parallel=False, join="outer", chunks={"level": 10, "time": 1}
     )
     return ds.pipe(fix_missing_vars).pipe(convert_units).pipe(fix_names)
 

--- a/pyaerocom/io/cams2_82/reader.py
+++ b/pyaerocom/io/cams2_82/reader.py
@@ -276,7 +276,8 @@ def only_first_day(ds: xr.Dataset) -> xr.Dataset:
 
 
 def interpolate_hourly(ds: xr.Dataset) -> xr.Dataset:
-    ds = ds.resample(time="1h").interpolate()
+    if len(ds.time) != 24:
+        ds = ds.resample(time="1h").interpolate(kind="nearest")
     return ds
 
 

--- a/pyaerocom/io/cams2_82/reader.py
+++ b/pyaerocom/io/cams2_82/reader.py
@@ -275,11 +275,16 @@ def only_first_day(ds: xr.Dataset) -> xr.Dataset:
     return ds.sel(time=ds.time.dt.day == first_day)
 
 
+def interpolate_hourly(ds: xr.Dataset) -> xr.Dataset:
+    ds = ds.resample(time="1h").interpolate()
+    return ds
+
+
 def read_dataset(paths: list[Path]) -> xr.Dataset:
     paths = check_files(paths)
 
     def preprocess(ds: xr.Dataset) -> xr.Dataset:
-        return ds.pipe(only_first_day).pipe(drop_vars)
+        return ds.pipe(only_first_day).pipe(drop_vars).pipe(interpolate_hourly)
 
     ds = xr.open_mfdataset(
         paths, preprocess=preprocess, parallel=False, join="outer", chunks={"level": 10, "time": 1}

--- a/pyaerocom/scripts/cams2_82/config.py
+++ b/pyaerocom/scripts/cams2_82/config.py
@@ -303,7 +303,6 @@ def make_ICOS_entry(
         obs_vert_type="Surface",
         ts_type="hourly",
         obs_filters=BASE_FILTER,
-        min_num_obs=dict(daily=dict(hourly=6),),
     )
 
 

--- a/pyaerocom/scripts/cams2_82/config.py
+++ b/pyaerocom/scripts/cams2_82/config.py
@@ -303,6 +303,7 @@ def make_ICOS_entry(
         obs_vert_type="Surface",
         ts_type="hourly",
         obs_filters=BASE_FILTER,
+        min_num_obs=dict(daily=dict(hourly=6),),
     )
 
 

--- a/pyaerocom/scripts/cams2_82/config.py
+++ b/pyaerocom/scripts/cams2_82/config.py
@@ -78,7 +78,7 @@ GLOBAL_CONFIG = dict(
     min_num_obs=dict(
         # yearly=dict(monthly=9),
         # monthly=dict(daily=21, weekly=3), # not used
-        daily=dict(hourly=6), # 3-hourly data
+        daily=dict(hourly=18), # 3-hourly data
     ),
 )
 

--- a/pyaerocom/scripts/cams2_82/config.py
+++ b/pyaerocom/scripts/cams2_82/config.py
@@ -78,7 +78,7 @@ GLOBAL_CONFIG = dict(
     min_num_obs=dict(
         # yearly=dict(monthly=9),
         # monthly=dict(daily=21, weekly=3), # not used
-        daily=dict(hourly=18), # 3-hourly data
+        daily=dict(hourly=18), # hourly data
     ),
 )
 


### PR DESCRIPTION
## Change Summary

Hourly data is requested. We get it for the surface fields only (too costly to get it for ml fields and the evaluation that uses vertical levels is only daily, not hourly). All files are read together by the reader in the same dataset tho, so open_mfdataset needs to do more work.


## Checklist

* [x] Start with a draft-PR
* [x] The PR title is a good summary of the changes
* [ ] PR is set to AeroTools and a tentative milestone
* [ ] Documentation reflects the changes where applicable
* [ ] Tests for the changes exist where applicable
* [x] Tests pass locally
* [x] Tests pass on CI
* [x] At least 1 reviewer is selected
* [x] Make PR ready to review
